### PR TITLE
Add motel.version resource attribute

### DIFF
--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -252,9 +252,12 @@ func runGenerate(ctx context.Context, configPath string, opts runOptions) error 
 		return err
 	}
 
-	res := resource.NewSchemaless(
+	res, err := resource.Merge(resource.Default(), resource.NewSchemaless(
 		attribute.String("motel.version", version),
-	)
+	))
+	if err != nil {
+		return fmt.Errorf("creating resource: %w", err)
+	}
 
 	// Create tracer provider (no-op if traces not requested)
 	var tp *sdktrace.TracerProvider


### PR DESCRIPTION
## Summary

- Adds a `motel.version` resource attribute to all OTel SDK providers (traces, metrics, logs)
- The version value comes from the existing build-time `version` variable (set by goreleaser, defaults to `dev`)
- Resource is created once in `runGenerate` and threaded through all provider creation paths

## Test plan

- [x] `make test` passes
- [x] Smoke-tested with `--stdout`: confirmed `motel.version` appears in span resource attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)