### PR TITLE
perf: pre-compute Operation.Ref to avoid hot-path string concat

### DIFF
--- a/pkg/synth/engine_test.go
+++ b/pkg/synth/engine_test.go
@@ -1672,9 +1672,9 @@ func TestEffectiveCalls(t *testing.T) {
 	svcB := &Service{Name: "b", Operations: make(map[string]*Operation)}
 	svcC := &Service{Name: "c", Operations: make(map[string]*Operation)}
 
-	opA := &Operation{Service: svcA, Name: "op", Duration: Distribution{Mean: 10 * time.Millisecond}}
-	opB := &Operation{Service: svcB, Name: "op", Duration: Distribution{Mean: 10 * time.Millisecond}}
-	opC := &Operation{Service: svcC, Name: "op", Duration: Distribution{Mean: 10 * time.Millisecond}}
+	opA := &Operation{Service: svcA, Name: "op", Ref: "a.op", Duration: Distribution{Mean: 10 * time.Millisecond}}
+	opB := &Operation{Service: svcB, Name: "op", Ref: "b.op", Duration: Distribution{Mean: 10 * time.Millisecond}}
+	opC := &Operation{Service: svcC, Name: "op", Ref: "c.op", Duration: Distribution{Mean: 10 * time.Millisecond}}
 
 	svcA.Operations["op"] = opA
 	svcB.Operations["op"] = opB

--- a/pkg/synth/scenario.go
+++ b/pkg/synth/scenario.go
@@ -157,10 +157,8 @@ func validateScenarioCycles(sc Scenario, topo *Topology) error {
 	// Start with base topology edges
 	for _, svc := range topo.Services {
 		for _, op := range svc.Operations {
-			ref := svc.Name + "." + op.Name
 			for _, call := range op.Calls {
-				targetRef := call.Operation.Service.Name + "." + call.Operation.Name
-				adj[ref] = append(adj[ref], targetRef)
+				adj[op.Ref] = append(adj[op.Ref], call.Operation.Ref)
 			}
 		}
 	}
@@ -185,8 +183,7 @@ func validateScenarioCycles(sc Scenario, topo *Topology) error {
 
 		// Add calls
 		for _, call := range ov.AddCalls {
-			targetRef := call.Operation.Service.Name + "." + call.Operation.Name
-			adj[ref] = append(adj[ref], targetRef)
+			adj[ref] = append(adj[ref], call.Operation.Ref)
 		}
 	}
 

--- a/pkg/synth/scenario_test.go
+++ b/pkg/synth/scenario_test.go
@@ -533,9 +533,9 @@ func callTopoForTests() *Topology {
 	svcB := &Service{Name: "b", Operations: make(map[string]*Operation)}
 	svcC := &Service{Name: "c", Operations: make(map[string]*Operation)}
 
-	opA := &Operation{Service: svcA, Name: "op", Duration: Distribution{Mean: 10 * time.Millisecond}}
-	opB := &Operation{Service: svcB, Name: "op", Duration: Distribution{Mean: 10 * time.Millisecond}}
-	opC := &Operation{Service: svcC, Name: "op", Duration: Distribution{Mean: 10 * time.Millisecond}}
+	opA := &Operation{Service: svcA, Name: "op", Ref: "a.op", Duration: Distribution{Mean: 10 * time.Millisecond}}
+	opB := &Operation{Service: svcB, Name: "op", Ref: "b.op", Duration: Distribution{Mean: 10 * time.Millisecond}}
+	opC := &Operation{Service: svcC, Name: "op", Ref: "c.op", Duration: Distribution{Mean: 10 * time.Millisecond}}
 
 	opA.Calls = []Call{{Operation: opB}}
 	svcA.Operations["op"] = opA

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -41,6 +41,7 @@ type ResolvedCircuitBreaker struct {
 type Operation struct {
 	Service        *Service
 	Name           string
+	Ref            string
 	Duration       Distribution
 	ErrorRate      float64
 	Calls          []Call
@@ -125,6 +126,7 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 			op := &Operation{
 				Service:    svc,
 				Name:       opCfg.Name,
+				Ref:        svcCfg.Name + "." + opCfg.Name,
 				Duration:   dist,
 				ErrorRate:  errorRate,
 				CallStyle:  opCfg.CallStyle,
@@ -262,7 +264,7 @@ func detectCycles(topo *Topology) error {
 	visit = func(op *Operation) error {
 		switch state[op] {
 		case visiting:
-			return fmt.Errorf("cycle detected involving %s.%s", op.Service.Name, op.Name)
+			return fmt.Errorf("cycle detected involving %s", op.Ref)
 		case visited:
 			return nil
 		}


### PR DESCRIPTION
## Summary

- Add `Ref` field to `Operation`, set once during `BuildTopology` as `"service.operation"`
- Replace all per-span `op.Service.Name + "." + op.Name` concatenation in `engine.go` with `op.Ref`
- Replace same pattern in `scenario.go` (`validateScenarioCycles`, `effectiveCalls`)
- Update hand-built test operations to include `Ref`

Net result: -19 lines, +15 lines. Eliminates 3 string allocations per span in the hot path and 2 per call target in scenario validation.

Closes #6

## Test plan

- [x] `make test` passes
- [x] `make lint` passes