### PR TITLE
docs: update tagline to Synthetic OpenTelemetry generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/andrewh/motel)](https://goreportcard.com/report/github.com/andrewh/motel)
 [![Go Reference](https://pkg.go.dev/badge/github.com/andrewh/motel.svg)](https://pkg.go.dev/github.com/andrewh/motel)
 
-Topology-driven synthetic telemetry generator for [OpenTelemetry](https://opentelemetry.io/).
+Synthetic [OpenTelemetry](https://opentelemetry.io/) generator.
 
 Describe your distributed system in YAML and motel generates realistic traces,
 metrics, and logs — no live services required.

--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -1,4 +1,4 @@
-// Topology-driven synthetic OTLP signal generator
+// Synthetic OpenTelemetry generator
 // Reads a YAML topology definition and emits traces, metrics, and logs via OTel SDK
 package main
 
@@ -49,7 +49,7 @@ func main() {
 func rootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "motel",
-		Short: "Topology-driven synthetic OTLP trace generator",
+		Short: "Synthetic OpenTelemetry generator",
 	}
 
 	root.AddCommand(runCmd())


### PR DESCRIPTION
## Summary

Replace "Topology-driven synthetic telemetry generator for OpenTelemetry" with "Synthetic OpenTelemetry generator" in README, package comment, and cobra Short description. The old wording could be misread as referring to mathematical topology.