### PR TITLE
Add etymology to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # motel
 
-> **motel** /mōˈtel/ _noun_
-> mock opentelemetry. A synthetic signal generator for testing
-> and developing observability pipelines.
-
 [![CI](https://github.com/andrewh/motel/actions/workflows/ci.yml/badge.svg)](https://github.com/andrewh/motel/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/andrewh/motel)](https://goreportcard.com/report/github.com/andrewh/motel)
 [![Go Reference](https://pkg.go.dev/badge/github.com/andrewh/motel.svg)](https://pkg.go.dev/github.com/andrewh/motel)
+
+> **motel** /mōˈtel/ _noun_
+> mock opentelemetry. A synthetic signal generator for testing
+> and developing observability pipelines.
 
 `motel` is a synthetic [OpenTelemetry](https://opentelemetry.io/) generator.
 


### PR DESCRIPTION
## Summary

- Adds a dictionary-style pull-quote explaining the name: mock opentelemetry