### PR TITLE
Note motel.version resource attribute in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ motel run --endpoint localhost:4318 --duration 30s my-topology.yaml
 motel reads a YAML topology file describing services, operations, call
 patterns, latency distributions, and error rates. It walks the topology tree
 once per trace, producing spans that look like they came from real instrumented
-services.
+services. All signals include a `motel.version` resource attribute so you can
+distinguish synthetic traffic from real data.
 
 Use cases:
 


### PR DESCRIPTION
## Summary

- Mention the `motel.version` resource attribute in the "What it does" section so users know how to distinguish synthetic traffic from real data

## Test plan

- [ ] README reads correctly