### PR TITLE
Add how-to guide for testing alert thresholds

### DIFF
--- a/docs/how-to/test-alert-thresholds.md
+++ b/docs/how-to/test-alert-thresholds.md
@@ -65,7 +65,7 @@ scenarios:
         duration: 500ms +/- 100ms
 ```
 
-Add the scenario block to your topology file, or keep scenarios in a separate file and pass both to `motel run`.
+Add the scenario block to your topology file.
 
 ## Match scenario duration to alerting windows
 


### PR DESCRIPTION
## Summary
- Add `docs/how-to/test-alert-thresholds.md` covering baseline topology setup, scenario-based degradation injection, matching scenario duration to alerting windows, accounting for sampling, and a worked example

## Test plan
- [ ] Review guide for accuracy and completeness
- [ ] Verify scenario timing advice matches motel behaviour

Closes #45