### PR TITLE
Rename emit --duration to --span-duration, add simulation --duration

### DIFF
--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -169,6 +169,9 @@ func emitCmd() *cobra.Command {
 			if operation == "" {
 				return fmt.Errorf("--operation is required")
 			}
+			if count == 0 && duration == 0 {
+				return nil
+			}
 
 			// Parse --attr key=value pairs
 			opAttrs := make(map[string]synth.AttributeValueConfig, len(attrs))
@@ -287,7 +290,7 @@ func emitCmd() *cobra.Command {
 				return err
 			}
 
-			return json.NewEncoder(os.Stderr).Encode(stats)
+			return json.NewEncoder(cmd.ErrOrStderr()).Encode(stats)
 		},
 	}
 

--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -144,16 +144,17 @@ func runCmd() *cobra.Command {
 
 func emitCmd() *cobra.Command {
 	var (
-		service   string
-		operation string
-		duration  time.Duration
-		errorRate string
-		attrs     []string
-		count     int
-		rate      string
-		endpoint  string
-		stdout    bool
-		protocol  string
+		service      string
+		operation    string
+		spanDuration time.Duration
+		duration     time.Duration
+		errorRate    string
+		attrs        []string
+		count        int
+		rate         string
+		endpoint     string
+		stdout       bool
+		protocol     string
 	)
 
 	cmd := &cobra.Command{
@@ -188,7 +189,7 @@ func emitCmd() *cobra.Command {
 						Operations: []synth.OperationConfig{
 							{
 								Name:       operation,
-								Duration:   duration.String(),
+								Duration:   spanDuration.String(),
 								ErrorRate:  errorRate,
 								Attributes: opAttrs,
 							},
@@ -248,6 +249,15 @@ func emitCmd() *cobra.Command {
 			}
 			defer shutdownTraces()
 
+			engineDuration := unlimitedDuration
+			maxTraces := count
+			if duration > 0 {
+				engineDuration = duration
+				if !cmd.Flags().Changed("count") {
+					maxTraces = 0
+				}
+			}
+
 			engine := &synth.Engine{
 				Topology: topo,
 				Traffic:  traffic,
@@ -265,8 +275,8 @@ func emitCmd() *cobra.Command {
 					)
 				},
 				Rng:       rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())), //nolint:gosec // synthetic data, not security-sensitive
-				Duration:  unlimitedDuration,
-				MaxTraces: count,
+				Duration:  engineDuration,
+				MaxTraces: maxTraces,
 			}
 
 			ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
@@ -283,7 +293,8 @@ func emitCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&service, "service", "", "service name (required)")
 	cmd.Flags().StringVar(&operation, "operation", "", "operation name (required)")
-	cmd.Flags().DurationVar(&duration, "duration", 100*time.Millisecond, "span duration")
+	cmd.Flags().DurationVar(&spanDuration, "span-duration", 100*time.Millisecond, "span duration")
+	cmd.Flags().DurationVar(&duration, "duration", 0, "simulation duration, e.g. 10s, 5m, 1h")
 	cmd.Flags().StringVar(&errorRate, "error-rate", "", "error rate (e.g. 5%, 0.05)")
 	cmd.Flags().StringArrayVar(&attrs, "attr", nil, "span attribute in key=value format (repeatable)")
 	cmd.Flags().IntVar(&count, "count", 1, "number of traces to emit")

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -1033,7 +1033,7 @@ func TestEmitCommand(t *testing.T) {
 		root := rootCmd()
 		root.SetArgs([]string{
 			"emit", "--service", "api", "--operation", "request",
-			"--duration", "10s", "--count", "3", "--stdout",
+			"--duration", "2s", "--count", "3", "--stdout",
 		})
 
 		err := root.Execute()

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -1003,13 +1003,37 @@ func TestEmitCommand(t *testing.T) {
 		assert.Contains(t, err.Error(), "key=value")
 	})
 
-	t.Run("with duration and error rate", func(t *testing.T) {
+	t.Run("with span-duration and error rate", func(t *testing.T) {
 		t.Parallel()
 		root := rootCmd()
 		root.SetArgs([]string{
 			"emit", "--service", "api", "--operation", "GET /users",
-			"--duration", "50ms", "--error-rate", "5%",
+			"--span-duration", "50ms", "--error-rate", "5%",
 			"--count", "10", "--stdout",
+		})
+
+		err := root.Execute()
+		require.NoError(t, err)
+	})
+
+	t.Run("duration controls simulation time", func(t *testing.T) {
+		t.Parallel()
+		root := rootCmd()
+		root.SetArgs([]string{
+			"emit", "--service", "api", "--operation", "request",
+			"--duration", "200ms", "--rate", "100/s", "--stdout",
+		})
+
+		err := root.Execute()
+		require.NoError(t, err)
+	})
+
+	t.Run("duration with count stops at count", func(t *testing.T) {
+		t.Parallel()
+		root := rootCmd()
+		root.SetArgs([]string{
+			"emit", "--service", "api", "--operation", "request",
+			"--duration", "10s", "--count", "3", "--stdout",
 		})
 
 		err := root.Execute()

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -4,6 +4,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -1023,9 +1024,17 @@ func TestEmitCommand(t *testing.T) {
 			"emit", "--service", "api", "--operation", "request",
 			"--duration", "200ms", "--rate", "100/s", "--stdout",
 		})
+		var stderr bytes.Buffer
+		root.SetErr(&stderr)
 
 		err := root.Execute()
 		require.NoError(t, err)
+
+		var stats struct {
+			Traces int64 `json:"traces"`
+		}
+		require.NoError(t, json.Unmarshal(stderr.Bytes(), &stats))
+		assert.Greater(t, stats.Traces, int64(1), "duration-based emit should produce multiple traces")
 	})
 
 	t.Run("duration with count stops at count", func(t *testing.T) {
@@ -1034,6 +1043,26 @@ func TestEmitCommand(t *testing.T) {
 		root.SetArgs([]string{
 			"emit", "--service", "api", "--operation", "request",
 			"--duration", "2s", "--count", "3", "--stdout",
+		})
+		var stderr bytes.Buffer
+		root.SetErr(&stderr)
+
+		err := root.Execute()
+		require.NoError(t, err)
+
+		var stats struct {
+			Traces int64 `json:"traces"`
+		}
+		require.NoError(t, json.Unmarshal(stderr.Bytes(), &stats))
+		assert.Equal(t, int64(3), stats.Traces, "should stop at --count")
+	})
+
+	t.Run("count zero exits immediately", func(t *testing.T) {
+		t.Parallel()
+		root := rootCmd()
+		root.SetArgs([]string{
+			"emit", "--service", "api", "--operation", "request",
+			"--count", "0", "--stdout",
 		})
 
 		err := root.Execute()

--- a/docs/demos/demo-emit.md
+++ b/docs/demos/demo-emit.md
@@ -21,10 +21,10 @@ kind (2=SERVER): 2
 
 ## Custom span duration
 
-The default span duration is 100ms. Use `--duration` to set a specific value.
+The default span duration is 100ms. Use `--span-duration` to set a specific value.
 
 ```bash
-motel emit --service api --operation "GET /health" --duration 250ms --stdout 2>/dev/null | jq -r '"operation: \(.Name)", "has timestamps: \((.StartTime | length) > 0)"'
+motel emit --service api --operation "GET /health" --span-duration 250ms --stdout 2>/dev/null | jq -r '"operation: \(.Name)", "has timestamps: \((.StartTime | length) > 0)"'
 
 ```
 


### PR DESCRIPTION
## Summary

Fixes #132.

- Renames `--duration` on `emit` to `--span-duration` (controls how long each generated span appears to last, default 100ms)
- Adds `--duration` to `emit` for simulation duration, matching `run`'s semantics (how long motel keeps generating traces)
- When `--duration` is set without `--count`, emit runs for the specified duration instead of producing a single trace
- When both `--duration` and `--count` are set, whichever fires first stops the engine

## Test plan

- [x] `make test` passes (new tests for `--duration` alone and `--duration` + `--count`)
- [x] `make lint` passes
- [x] Manual: `motel emit --service test --operation health --span-duration 250ms --stdout` emits 1 trace with ~250ms span duration
- [x] Manual: `motel emit --service test --operation health --rate 100/s --duration 500ms --stdout` emits ~46 traces over 500ms
- [x] Manual: `motel emit --service test --operation health --duration 10s --count 3 --stdout` stops after exactly 3 traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)