### PR TITLE
Add topology-driven metrics generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /motel
+/issue-analysis.md

--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -50,6 +50,7 @@ and optional resource attributes.
 |------------------------|------|-------------|
 | `resource_attributes`  | map  | Static string key-value pairs attached to the OTel resource (not spans). Use for `deployment.environment`, `service.version`, `service.namespace`, etc. `service.name` and `motel.version` are set automatically and cannot be overridden |
 | `attributes`           | map  | Static string key-value pairs added to every span from this service |
+| `metrics`              | list | Metric instruments emitted by this service (see [metrics](#metrics)) |
 | `operations`           | map  | Operation definitions (required) |
 
 ```yaml
@@ -74,6 +75,7 @@ Each operation defines the span it produces.
 | `call_style` | string | `parallel` or `sequential` (default: parallel) |
 | `domain`     | string | Semconv shorthand (e.g. `http`) — auto-generates standard attributes |
 | `attributes` | map    | Per-span attribute generators (see below) |
+| `metrics`    | list   | Metric instruments scoped to this operation (see [metrics](#metrics)) |
 | `events`     | list   | Span events emitted during the operation (see below) |
 | `links`      | list   | Cross-trace span links to other operations (see below) |
 | `calls`      | list   | Downstream calls to other operations |
@@ -281,6 +283,83 @@ scenarios:
         error_rate: 15%
     traffic:
       rate: 200/s
+```
+
+### metrics
+
+Topology-driven metric instruments. Define them at the service level (fire for
+every span in the service) or at the operation level (fire only for that
+operation). Requires `--signals metrics` or `--signals traces,metrics` when
+running; if no metrics are defined the signal is silently empty.
+
+| Field        | Type   | Description |
+|-------------|--------|-------------|
+| `name`       | string | OTel instrument name (required) |
+| `type`       | string | `counter`, `updowncounter`, `histogram`, or `gauge` (required) |
+| `unit`       | string | OTel unit string, e.g. `ms`, `s`, `{request}` (optional) |
+| `value`      | string | Distribution to sample, e.g. `0.65` or `0.65 +/- 0.1`. Omit for span-derived behaviour (see below) |
+| `attributes` | map    | Per-measurement attribute generators — same syntax as span attributes |
+
+**Span-derived behaviour (no `value`):** the instrument records a value derived
+from the span being observed.
+
+| Type | Span-derived recording |
+|------|----------------------|
+| `counter` | `+1` per completed span |
+| `updowncounter` | `+1` on span start, `−1` on span end — tracks active-span count |
+| `histogram` | span duration, converted to the configured `unit` |
+| `gauge` | not valid — gauge requires `value` |
+
+**Topology-defined behaviour (`value` present):** the value is sampled from a
+normal distribution on each observation.
+
+| Type | Topology-defined recording |
+|------|---------------------------|
+| `counter` | sampled float added per completed span (clamped ≥ 0) |
+| `updowncounter` | sampled float added per completed span |
+| `histogram` | sampled float recorded per completed span |
+| `gauge` | sampled float reported on each collection cycle |
+
+```yaml
+services:
+  gateway:
+    metrics:
+      # Span-derived histogram: records span duration in milliseconds
+      - name: http.server.request.duration
+        type: histogram
+        unit: ms
+      # Span-derived updowncounter: tracks currently active requests
+      - name: http.server.active_requests
+        type: updowncounter
+      # Topology-defined gauge: independent of spans, sampled on collection
+      - name: gateway.cpu.utilisation
+        type: gauge
+        value: 0.65 +/- 0.1
+    operations:
+      handle:
+        duration: 50ms +/- 10ms
+        metrics:
+          # Operation-level metric: only fires for this operation
+          - name: gateway.cache.hit_ratio
+            type: gauge
+            value: 0.85 +/- 0.05
+```
+
+**Migrating from the built-in instruments:** earlier versions of motel emitted
+three hard-coded instruments automatically (`motel.span.duration`,
+`motel.span.count`, `motel.span.errors`). These have been replaced by
+topology-driven metrics. To restore equivalent behaviour, add the following to
+each service that previously produced those instruments:
+
+```yaml
+metrics:
+  - name: motel.span.duration
+    type: histogram
+    unit: ms
+  - name: motel.span.count
+    type: counter
+  - name: motel.span.errors
+    type: counter
 ```
 
 ## Derived Signals

--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -606,7 +606,8 @@ func runGenerate(ctx context.Context, configPath string, opts runOptions) error 
 			return fmt.Errorf("creating metric providers: %w", mErr)
 		}
 		defer shutdownMetrics()
-		obs, mErr := synth.NewMetricObserver(meters)
+		rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // synthetic data, not security-sensitive
+		obs, mErr := synth.NewMetricObserver(meters, topo, rng)
 		if mErr != nil {
 			return fmt.Errorf("creating metric observer: %w", mErr)
 		}

--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -601,6 +601,9 @@ func runGenerate(ctx context.Context, configPath string, opts runOptions) error 
 	var observers []synth.SpanObserver
 
 	if enabledSignals["metrics"] {
+		if !topoHasMetrics(topo) {
+			fmt.Fprintln(os.Stderr, "warning: --signals includes metrics but the topology defines no metric instruments; no metric data will be emitted. Add a metrics: section to at least one service or operation.")
+		}
 		meters, shutdownMetrics, mErr := createMetricProviders(ctx, opts, serviceResources)
 		if mErr != nil {
 			return fmt.Errorf("creating metric providers: %w", mErr)
@@ -892,6 +895,21 @@ func buildTopology(cfg *synth.Config, semconvDir string) (*synth.Topology, error
 		reg = reg.Merge(userReg)
 	}
 	return synth.BuildTopology(cfg, domainResolver(reg))
+}
+
+// topoHasMetrics reports whether any service or operation in the topology defines at least one metric.
+func topoHasMetrics(topo *synth.Topology) bool {
+	for _, svc := range topo.Services {
+		if len(svc.Metrics) > 0 {
+			return true
+		}
+		for _, op := range svc.Operations {
+			if len(op.Metrics) > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func domainResolver(reg *semconv.Registry) synth.DomainResolver {

--- a/docs/examples/topology-driven-metrics.yaml
+++ b/docs/examples/topology-driven-metrics.yaml
@@ -1,0 +1,50 @@
+# Topology-driven metrics example
+# Demonstrates all four OTel instrument types at both service and operation level.
+# Run with:
+#   motel run --signals traces,metrics --duration 30s docs/examples/topology-driven-metrics.yaml
+
+version: 1
+
+services:
+  gateway:
+    metrics:
+      # Span-derived histogram: records each request's duration in milliseconds
+      - name: http.server.request.duration
+        type: histogram
+        unit: ms
+      # Span-derived updowncounter: tracks in-flight requests (requires --realtime for meaningful values)
+      - name: http.server.active_requests
+        type: updowncounter
+      # Topology-defined gauge: sampled on each collection cycle, independent of spans
+      - name: gateway.cpu.utilisation
+        type: gauge
+        value: 0.40 +/- 0.08
+    operations:
+      GET /api:
+        duration: 40ms +/- 10ms
+        error_rate: 0.5%
+        metrics:
+          # Operation-level metric: only fires for this operation
+          - name: gateway.cache.hit_ratio
+            type: gauge
+            value: 0.75 +/- 0.05
+        calls:
+          - backend.process
+
+  backend:
+    metrics:
+      # Span-derived counter: +1 per completed span
+      - name: backend.requests.total
+        type: counter
+      # Topology-defined counter: sampled bytes-per-request added on each span
+      - name: backend.response.bytes
+        type: counter
+        unit: "By"
+        value: 4096 +/- 512
+    operations:
+      process:
+        duration: 20ms +/- 5ms
+        error_rate: 0.2%
+
+traffic:
+  rate: 50/s

--- a/docs/how-to/test-alert-thresholds.md
+++ b/docs/how-to/test-alert-thresholds.md
@@ -94,13 +94,29 @@ If you use the OpenTelemetry Collector's span metrics connector before the sampl
 
 ### Application-level metrics
 
-Motel can generate metrics directly, bypassing trace sampling entirely:
+Motel can generate metrics directly, bypassing trace sampling entirely. Define
+the instruments you want in the topology, then run with `--signals metrics`:
+
+```yaml
+services:
+  web-gateway:
+    metrics:
+      - name: http.server.request.duration
+        type: histogram
+        unit: ms
+      - name: http.server.active_requests
+        type: updowncounter
+    operations:
+      GET /api:
+        duration: 45ms +/- 12ms
+        error_rate: 0.1%
+```
 
 ```sh
 motel run --signals metrics --duration 15m --endpoint http://localhost:4318 alert-test.yaml
 ```
 
-This is the most predictable path for alert testing. The configured error rate is exactly what your alerting backend sees, with no sampling distortion.
+This is the most predictable path for alert testing. The configured error rate is exactly what your alerting backend sees, with no sampling distortion. See the [metrics DSL reference](../../cmd/motel/README.md#metrics) for the full list of instrument types and value options.
 
 **Recommendation:** understand where in your pipeline metrics are derived. If metrics come from sampled traces, calibrate motel's error rates to account for the sampler. If metrics come from a pre-sampling connector or directly from motel, use the target error rate directly.
 

--- a/docs/how-to/validate-collector-pipeline.md
+++ b/docs/how-to/validate-collector-pipeline.md
@@ -114,12 +114,28 @@ If spans do not appear:
 If your pipeline carries metrics or logs as well as traces, verify those separately:
 
 ```sh
-# Metrics only
+# Metrics only (requires metrics: definitions in topology — see below)
 motel run --endpoint localhost:4318 --signals metrics --duration 10s topology.yaml
 
 # All signals
 motel run --endpoint localhost:4318 --signals traces,metrics,logs --duration 10s topology.yaml
 ```
+
+For metrics to flow, the topology must define at least one `metrics:` entry on a
+service or operation. A minimal example:
+
+```yaml
+services:
+  pipeline-test:
+    metrics:
+      - name: pipeline.test.requests
+        type: counter
+    operations:
+      validate:
+        duration: 10ms
+```
+
+See the [metrics DSL reference](../../cmd/motel/README.md#metrics) for all instrument types.
 
 ## Common failure modes
 

--- a/pkg/synth/attributes.go
+++ b/pkg/synth/attributes.go
@@ -105,6 +105,19 @@ func (n *NormalValue) Generate(rng *rand.Rand) any {
 	return n.Mean + rng.NormFloat64()*n.StdDev
 }
 
+// IsStaticAttributeConfig reports whether cfg produces a deterministic value
+// that is the same on every Generate call (i.e. only the value: field is set).
+// Used to validate that span-derived updowncounter attributes are consistent
+// across start and end observations.
+func IsStaticAttributeConfig(cfg AttributeValueConfig) bool {
+	return cfg.Value != nil &&
+		len(cfg.Values) == 0 &&
+		cfg.Sequence == "" &&
+		cfg.Probability == nil &&
+		len(cfg.Range) == 0 &&
+		cfg.Distribution == nil
+}
+
 // NewAttributeGenerator creates an AttributeGenerator from a config entry.
 // Exactly one of the config fields must be set.
 func NewAttributeGenerator(cfg AttributeValueConfig) (AttributeGenerator, error) {

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -29,6 +29,14 @@ var reservedResourceAttribute = map[string]bool{
 	"motel.version": true,
 }
 
+// validMetricType lists supported OTel instrument types.
+var validMetricType = map[string]bool{
+	"counter":       true,
+	"updowncounter": true,
+	"histogram":     true,
+	"gauge":         true,
+}
+
 // Config is the top-level YAML configuration for a synthetic topology.
 type Config struct {
 	Version   int              `yaml:"version"`
@@ -49,6 +57,7 @@ type rawConfig struct {
 type rawServiceConfig struct {
 	ResourceAttributes map[string]string             `yaml:"resource_attributes,omitempty"`
 	Attributes         map[string]string             `yaml:"attributes,omitempty"`
+	Metrics            []MetricConfig                `yaml:"metrics,omitempty"`
 	Operations         map[string]rawOperationConfig `yaml:"operations"`
 }
 
@@ -103,6 +112,15 @@ type EventConfig struct {
 	Attributes map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
 }
 
+// MetricConfig describes a metric instrument defined in the topology YAML.
+type MetricConfig struct {
+	Name       string                          `yaml:"name"`
+	Type       string                          `yaml:"type"`
+	Unit       string                          `yaml:"unit,omitempty"`
+	Value      string                          `yaml:"value,omitempty"`
+	Attributes map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
+}
+
 // rawOperationConfig is the YAML representation of an operation before normalisation.
 type rawOperationConfig struct {
 	Domain         string                          `yaml:"domain,omitempty"`
@@ -113,6 +131,7 @@ type rawOperationConfig struct {
 	Attributes     map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
 	Events         []EventConfig                   `yaml:"events,omitempty"`
 	Links          []string                        `yaml:"links,omitempty"`
+	Metrics        []MetricConfig                  `yaml:"metrics,omitempty"`
 	QueueDepth     int                             `yaml:"queue_depth,omitempty"`
 	Backpressure   *BackpressureConfig             `yaml:"backpressure,omitempty"`
 	CircuitBreaker *CircuitBreakerConfig           `yaml:"circuit_breaker,omitempty"`
@@ -123,6 +142,7 @@ type ServiceConfig struct {
 	Name               string
 	ResourceAttributes map[string]string
 	Attributes         map[string]string
+	Metrics            []MetricConfig
 	Operations         []OperationConfig
 }
 
@@ -137,6 +157,7 @@ type OperationConfig struct {
 	Attributes     map[string]AttributeValueConfig
 	Events         []EventConfig
 	Links          []string
+	Metrics        []MetricConfig
 	QueueDepth     int
 	Backpressure   *BackpressureConfig
 	CircuitBreaker *CircuitBreakerConfig
@@ -293,6 +314,7 @@ func LoadConfig(source string) (*Config, error) {
 			Name:               name,
 			ResourceAttributes: rawSvc.ResourceAttributes,
 			Attributes:         rawSvc.Attributes,
+			Metrics:            rawSvc.Metrics,
 		}
 
 		opNames := make([]string, 0, len(rawSvc.Operations))
@@ -313,6 +335,7 @@ func LoadConfig(source string) (*Config, error) {
 				Attributes:     rawOp.Attributes,
 				Events:         rawOp.Events,
 				Links:          rawOp.Links,
+				Metrics:        rawOp.Metrics,
 				QueueDepth:     rawOp.QueueDepth,
 				Backpressure:   rawOp.Backpressure,
 				CircuitBreaker: rawOp.CircuitBreaker,
@@ -348,6 +371,27 @@ func ValidateConfig(cfg *Config) error {
 			}
 			if reservedResourceAttribute[k] {
 				return fmt.Errorf("service %q: resource_attributes must not contain reserved key %q (set automatically)", svc.Name, k)
+			}
+		}
+		metricNames := make(map[string]bool)
+		for i, mc := range svc.Metrics {
+			if err := validateMetricConfig(mc, fmt.Sprintf("service %q: metric[%d]", svc.Name, i)); err != nil {
+				return err
+			}
+			if metricNames[mc.Name] {
+				return fmt.Errorf("service %q: duplicate metric name %q", svc.Name, mc.Name)
+			}
+			metricNames[mc.Name] = true
+		}
+		for _, op := range svc.Operations {
+			for i, mc := range op.Metrics {
+				if err := validateMetricConfig(mc, fmt.Sprintf("service %q operation %q: metric[%d]", svc.Name, op.Name, i)); err != nil {
+					return err
+				}
+				if metricNames[mc.Name] {
+					return fmt.Errorf("service %q operation %q: duplicate metric name %q (already defined at service or operation level)", svc.Name, op.Name, mc.Name)
+				}
+				metricNames[mc.Name] = true
 			}
 		}
 		for _, op := range svc.Operations {
@@ -660,6 +704,30 @@ func validateCallConfig(call CallConfig, knownOps map[string]bool) error {
 	}
 	if call.Async && call.Timeout != "" {
 		return fmt.Errorf("target %q: async calls cannot have a timeout", call.Target)
+	}
+	return nil
+}
+
+// validateMetricConfig checks a single MetricConfig for structural correctness.
+func validateMetricConfig(mc MetricConfig, prefix string) error {
+	if mc.Name == "" {
+		return fmt.Errorf("%s: name is required", prefix)
+	}
+	if !validMetricType[mc.Type] {
+		return fmt.Errorf("%s %q: type must be one of counter, updowncounter, histogram, gauge; got %q", prefix, mc.Name, mc.Type)
+	}
+	if mc.Value != "" {
+		if _, err := ParseFloatDistribution(mc.Value); err != nil {
+			return fmt.Errorf("%s %q: invalid value: %w", prefix, mc.Name, err)
+		}
+	}
+	if mc.Type == "gauge" && mc.Value == "" {
+		return fmt.Errorf("%s %q: gauge metrics require a value (gauges are point-in-time, not span-derived)", prefix, mc.Name)
+	}
+	for attrName, attrCfg := range mc.Attributes {
+		if _, err := NewAttributeGenerator(attrCfg); err != nil {
+			return fmt.Errorf("%s %q: attribute %q: %w", prefix, mc.Name, attrName, err)
+		}
 	}
 	return nil
 }

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -393,8 +393,6 @@ func ValidateConfig(cfg *Config) error {
 				}
 				metricNames[mc.Name] = true
 			}
-		}
-		for _, op := range svc.Operations {
 			ref := svc.Name + "." + op.Name
 			knownOps[ref] = true
 			targets := make(map[string]bool, len(op.Calls))

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -29,12 +29,20 @@ var reservedResourceAttribute = map[string]bool{
 	"motel.version": true,
 }
 
+// Metric type constants for OTel instrument types.
+const (
+	metricTypeCounter       = "counter"
+	metricTypeUpDownCounter = "updowncounter"
+	metricTypeHistogram     = "histogram"
+	metricTypeGauge         = "gauge"
+)
+
 // validMetricType lists supported OTel instrument types.
 var validMetricType = map[string]bool{
-	"counter":       true,
-	"updowncounter": true,
-	"histogram":     true,
-	"gauge":         true,
+	metricTypeCounter:       true,
+	metricTypeUpDownCounter: true,
+	metricTypeHistogram:     true,
+	metricTypeGauge:         true,
 }
 
 // Config is the top-level YAML configuration for a synthetic topology.
@@ -118,6 +126,7 @@ type MetricConfig struct {
 	Type       string                          `yaml:"type"`
 	Unit       string                          `yaml:"unit,omitempty"`
 	Value      string                          `yaml:"value,omitempty"`
+	ErrorsOnly bool                            `yaml:"errors_only,omitempty"`
 	Attributes map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
 }
 
@@ -719,8 +728,11 @@ func validateMetricConfig(mc MetricConfig, prefix string) error {
 			return fmt.Errorf("%s %q: invalid value: %w", prefix, mc.Name, err)
 		}
 	}
-	if mc.Type == "gauge" && mc.Value == "" {
+	if mc.Type == metricTypeGauge && mc.Value == "" {
 		return fmt.Errorf("%s %q: gauge metrics require a value (gauges are point-in-time, not span-derived)", prefix, mc.Name)
+	}
+	if mc.ErrorsOnly && mc.Type != metricTypeCounter {
+		return fmt.Errorf("%s %q: errors_only is only valid for counter metrics", prefix, mc.Name)
 	}
 	for attrName, attrCfg := range mc.Attributes {
 		if _, err := NewAttributeGenerator(attrCfg); err != nil {

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -734,6 +734,16 @@ func validateMetricConfig(mc MetricConfig, prefix string) error {
 	if mc.ErrorsOnly && mc.Type != metricTypeCounter {
 		return fmt.Errorf("%s %q: errors_only is only valid for counter metrics", prefix, mc.Name)
 	}
+	if mc.Type == metricTypeUpDownCounter && mc.Value == "" {
+		// Span-derived updowncounters record +1 at span start and -1 at span end.
+		// The two observations use independently generated attribute values, so
+		// non-static generators produce mismatched time series that never balance.
+		for attrName, attrCfg := range mc.Attributes {
+			if !IsStaticAttributeConfig(attrCfg) {
+				return fmt.Errorf("%s %q: span-derived updowncounter attribute %q must be a static value (random attributes cause +1/-1 to land on different time series)", prefix, mc.Name, attrName)
+			}
+		}
+	}
 	for attrName, attrCfg := range mc.Attributes {
 		if _, err := NewAttributeGenerator(attrCfg); err != nil {
 			return fmt.Errorf("%s %q: attribute %q: %w", prefix, mc.Name, attrName, err)

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -2026,3 +2026,168 @@ func TestValidateResourceAttributeErrors(t *testing.T) {
 		assert.Contains(t, err.Error(), "key must not be empty")
 	})
 }
+
+func TestLoadConfigMetrics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("service and operation level metrics", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, `
+version: 1
+services:
+  gateway:
+    metrics:
+      - name: http.server.request.duration
+        type: histogram
+        unit: ms
+      - name: gateway.cpu.utilisation
+        type: gauge
+        value: 0.65 +/- 0.1
+    operations:
+      handle:
+        duration: 50ms
+        metrics:
+          - name: gateway.cache.hit_ratio
+            type: gauge
+            value: 0.85 +/- 0.1
+            attributes:
+              cache.name:
+                value: request-cache
+traffic:
+  rate: 10/s
+`)
+		cfg, err := LoadConfig(path)
+		require.NoError(t, err)
+		require.Len(t, cfg.Services, 1)
+
+		svc := cfg.Services[0]
+		require.Len(t, svc.Metrics, 2)
+		assert.Equal(t, "http.server.request.duration", svc.Metrics[0].Name)
+		assert.Equal(t, "histogram", svc.Metrics[0].Type)
+		assert.Equal(t, "ms", svc.Metrics[0].Unit)
+		assert.Equal(t, "", svc.Metrics[0].Value)
+
+		assert.Equal(t, "gateway.cpu.utilisation", svc.Metrics[1].Name)
+		assert.Equal(t, "gauge", svc.Metrics[1].Type)
+		assert.Equal(t, "0.65 +/- 0.1", svc.Metrics[1].Value)
+
+		require.Len(t, svc.Operations[0].Metrics, 1)
+		opMetric := svc.Operations[0].Metrics[0]
+		assert.Equal(t, "gateway.cache.hit_ratio", opMetric.Name)
+		assert.Equal(t, "gauge", opMetric.Type)
+		assert.Equal(t, "0.85 +/- 0.1", opMetric.Value)
+		require.Contains(t, opMetric.Attributes, "cache.name")
+	})
+}
+
+func TestValidateConfigMetrics(t *testing.T) {
+	t.Parallel()
+
+	baseConfig := func(svcMetrics []MetricConfig, opMetrics []MetricConfig) *Config {
+		return &Config{
+			Version: 1,
+			Services: []ServiceConfig{{
+				Name:    "svc",
+				Metrics: svcMetrics,
+				Operations: []OperationConfig{{
+					Name:     "op",
+					Duration: "50ms",
+					Metrics:  opMetrics,
+				}},
+			}},
+			Traffic: TrafficConfig{Rate: "10/s"},
+		}
+	}
+
+	t.Run("valid span-derived counter", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{Name: "req.count", Type: "counter"}}, nil)
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("valid topology-defined gauge", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{Name: "cpu", Type: "gauge", Value: "0.5 +/- 0.1"}}, nil)
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("valid span-derived histogram with unit", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{Name: "duration", Type: "histogram", Unit: "ms"}}, nil)
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("valid span-derived updowncounter", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{Name: "active", Type: "updowncounter"}}, nil)
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{Type: "counter"}}, nil)
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name is required")
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{Name: "m", Type: "summary"}}, nil)
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "type must be one of")
+	})
+
+	t.Run("invalid value", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{Name: "m", Type: "counter", Value: "not-a-number"}}, nil)
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid value")
+	})
+
+	t.Run("gauge without value", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{Name: "g", Type: "gauge"}}, nil)
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "gauge metrics require a value")
+	})
+
+	t.Run("duplicate metric name across service and operation", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig(
+			[]MetricConfig{{Name: "dup", Type: "counter"}},
+			[]MetricConfig{{Name: "dup", Type: "histogram"}},
+		)
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate metric name")
+	})
+
+	t.Run("duplicate metric name within service", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{
+			{Name: "m", Type: "counter"},
+			{Name: "m", Type: "histogram"},
+		}, nil)
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate metric name")
+	})
+
+	t.Run("invalid metric attribute", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "m",
+			Type: "counter",
+			Attributes: map[string]AttributeValueConfig{
+				"bad": {Range: []int64{1}}, // range needs 2 elements
+			},
+		}}, nil)
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "attribute")
+	})
+}

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -2190,4 +2190,44 @@ func TestValidateConfigMetrics(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "attribute")
 	})
+
+	t.Run("span-derived updowncounter with static attribute is valid", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "active",
+			Type: "updowncounter",
+			Attributes: map[string]AttributeValueConfig{
+				"region": {Value: "us-east"},
+			},
+		}}, nil)
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("span-derived updowncounter with random attribute is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "active",
+			Type: "updowncounter",
+			Attributes: map[string]AttributeValueConfig{
+				"bucket": {Range: []int64{1, 10}},
+			},
+		}}, nil)
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "span-derived updowncounter attribute")
+		assert.Contains(t, err.Error(), "static value")
+	})
+
+	t.Run("topology-defined updowncounter with random attribute is valid", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name:  "bytes",
+			Type:  "updowncounter",
+			Value: "512",
+			Attributes: map[string]AttributeValueConfig{
+				"bucket": {Range: []int64{1, 10}},
+			},
+		}}, nil)
+		require.NoError(t, ValidateConfig(cfg))
+	})
 }

--- a/pkg/synth/distribution.go
+++ b/pkg/synth/distribution.go
@@ -5,6 +5,7 @@ package synth
 import (
 	"fmt"
 	"math/rand/v2"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -75,6 +76,72 @@ func (d Distribution) Sample(rng *rand.Rand) time.Duration {
 		sample = 0
 	}
 	return time.Duration(sample)
+}
+
+// FloatDistribution represents a numeric value with optional variance, sampled as a normal distribution.
+type FloatDistribution struct {
+	Mean   float64
+	StdDev float64
+}
+
+// ParseFloatDistribution parses a float distribution string.
+// Supported formats:
+//   - "0.65 +/- 0.1" (mean with standard deviation)
+//   - "0.65 ± 0.1"   (unicode variant)
+//   - "0.65"          (fixed value, zero variance)
+func ParseFloatDistribution(s string) (FloatDistribution, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return FloatDistribution{}, fmt.Errorf("value is required (e.g. '0.65', '0.65 +/- 0.1')")
+	}
+
+	var meanStr, stddevStr string
+	if parts := strings.SplitN(s, "+/-", 2); len(parts) == 2 {
+		meanStr = strings.TrimSpace(parts[0])
+		stddevStr = strings.TrimSpace(parts[1])
+	} else if parts := strings.SplitN(s, "±", 2); len(parts) == 2 {
+		meanStr = strings.TrimSpace(parts[0])
+		stddevStr = strings.TrimSpace(parts[1])
+	} else {
+		mean, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if err != nil {
+			return FloatDistribution{}, fmt.Errorf("invalid mean value: %w", err)
+		}
+		return FloatDistribution{Mean: mean}, nil
+	}
+
+	mean, err := strconv.ParseFloat(meanStr, 64)
+	if err != nil {
+		return FloatDistribution{}, fmt.Errorf("invalid mean value: %w", err)
+	}
+
+	stddev, err := strconv.ParseFloat(stddevStr, 64)
+	if err != nil {
+		return FloatDistribution{}, fmt.Errorf("invalid stddev value: %w", err)
+	}
+	if stddev < 0 {
+		return FloatDistribution{}, fmt.Errorf("stddev must not be negative")
+	}
+
+	return FloatDistribution{Mean: mean, StdDev: stddev}, nil
+}
+
+// Sample returns a value drawn from a normal distribution.
+func (d FloatDistribution) Sample(rng *rand.Rand) float64 {
+	if d.StdDev == 0 {
+		return d.Mean
+	}
+	return d.Mean + rng.NormFloat64()*d.StdDev
+}
+
+// String returns the distribution in DSL format.
+func (d FloatDistribution) String() string {
+	if d.StdDev == 0 {
+		return strconv.FormatFloat(d.Mean, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%s +/- %s",
+		strconv.FormatFloat(d.Mean, 'f', -1, 64),
+		strconv.FormatFloat(d.StdDev, 'f', -1, 64))
 }
 
 // String returns the distribution in DSL format.

--- a/pkg/synth/distribution_test.go
+++ b/pkg/synth/distribution_test.go
@@ -150,6 +150,131 @@ func TestDistributionSample(t *testing.T) {
 	})
 }
 
+func TestParseFloatDistribution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		mean    float64
+		stddev  float64
+		wantErr string
+	}{
+		{
+			name:   "fixed value",
+			input:  "0.65",
+			mean:   0.65,
+			stddev: 0,
+		},
+		{
+			name:   "with +/-",
+			input:  "0.65 +/- 0.1",
+			mean:   0.65,
+			stddev: 0.1,
+		},
+		{
+			name:   "with unicode ±",
+			input:  "0.65 ± 0.1",
+			mean:   0.65,
+			stddev: 0.1,
+		},
+		{
+			name:   "integer value",
+			input:  "100",
+			mean:   100,
+			stddev: 0,
+		},
+		{
+			name:   "integer with variance",
+			input:  "100 +/- 10",
+			mean:   100,
+			stddev: 10,
+		},
+		{
+			name:   "extra whitespace",
+			input:  "  0.5  +/-  0.2  ",
+			mean:   0.5,
+			stddev: 0.2,
+		},
+		{
+			name:   "negative mean",
+			input:  "-1.5",
+			mean:   -1.5,
+			stddev: 0,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: "value is required",
+		},
+		{
+			name:    "invalid mean",
+			input:   "abc",
+			wantErr: "invalid mean value",
+		},
+		{
+			name:    "invalid stddev",
+			input:   "0.5 +/- xyz",
+			wantErr: "invalid stddev value",
+		},
+		{
+			name:    "negative stddev",
+			input:   "0.5 +/- -0.1",
+			wantErr: "stddev must not be negative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			d, err := ParseFloatDistribution(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.InDelta(t, tt.mean, d.Mean, 1e-9)
+			assert.InDelta(t, tt.stddev, d.StdDev, 1e-9)
+		})
+	}
+}
+
+func TestFloatDistributionSample(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero stddev returns mean", func(t *testing.T) {
+		t.Parallel()
+		d := FloatDistribution{Mean: 0.65, StdDev: 0}
+		rng := rand.New(rand.NewPCG(42, 0)) //nolint:gosec // deterministic seed for testing
+		for range 100 {
+			assert.Equal(t, 0.65, d.Sample(rng))
+		}
+	})
+
+	t.Run("samples cluster around mean", func(t *testing.T) {
+		t.Parallel()
+		d := FloatDistribution{Mean: 0.65, StdDev: 0.1}
+		rng := rand.New(rand.NewPCG(42, 0)) //nolint:gosec // deterministic seed for testing
+
+		var total float64
+		n := 10000
+		for range n {
+			total += d.Sample(rng)
+		}
+		avg := total / float64(n)
+		assert.InDelta(t, 0.65, avg, 0.01, "average should be close to mean")
+	})
+}
+
+func TestFloatDistributionString(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "0.65", FloatDistribution{Mean: 0.65}.String())
+	assert.Equal(t, "0.65 +/- 0.1", FloatDistribution{Mean: 0.65, StdDev: 0.1}.String())
+	assert.Equal(t, "100 +/- 10", FloatDistribution{Mean: 100, StdDev: 10}.String())
+}
+
 func TestDistributionString(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/synth/emit.go
+++ b/pkg/synth/emit.go
@@ -96,6 +96,11 @@ func emitTrace(ctx context.Context, plans []SpanPlan, baseSimTime time.Time, bas
 			if len(plan.Attrs) > 0 {
 				span.SetAttributes(plan.Attrs...)
 			}
+			for _, obs := range observers {
+				if sso, ok := obs.(SpanStartObserver); ok {
+					sso.ObserveStart(plan.Service, plan.Operation)
+				}
+			}
 			live[ev.Index] = liveSpan{Span: span, Ctx: spanCtx}
 		} else {
 			ls := live[ev.Index]

--- a/pkg/synth/emit.go
+++ b/pkg/synth/emit.go
@@ -56,7 +56,7 @@ func emitTrace(ctx context.Context, plans []SpanPlan, baseSimTime time.Time, bas
 
 		select {
 		case <-ctx.Done():
-			endAllOpen(live, rstats)
+			endAllOpen(live, plans, observers, rstats)
 			return
 		case <-timer.C:
 		}
@@ -177,7 +177,8 @@ func finishSpan(span trace.Span, plan *SpanPlan, observers []SpanObserver, rstat
 
 // endAllOpen ends all open spans on context cancellation.
 // Iterates in reverse order so children end before parents.
-func endAllOpen(live []liveSpan, rstats *realtimeStats) {
+// Fires Observe for each cancelled span to balance updowncounter increments from ObserveStart.
+func endAllOpen(live []liveSpan, plans []SpanPlan, observers []SpanObserver, rstats *realtimeStats) {
 	now := time.Now()
 	for i := len(live) - 1; i >= 0; i-- {
 		if live[i].Span == nil {
@@ -187,5 +188,21 @@ func endAllOpen(live []liveSpan, rstats *realtimeStats) {
 		live[i].Span.End(trace.WithTimestamp(now))
 		rstats.Spans.Add(1)
 		rstats.Errors.Add(1)
+		if len(observers) > 0 {
+			plan := &plans[i]
+			info := SpanInfo{
+				Service:   plan.Service,
+				Operation: plan.Operation,
+				Timestamp: plan.StartTime,
+				Duration:  now.Sub(plan.StartTime),
+				IsError:   true,
+				Kind:      plan.Kind,
+				Attrs:     plan.Attrs,
+				Scenarios: plan.Scenarios,
+			}
+			for _, obs := range observers {
+				obs.Observe(info)
+			}
+		}
 	}
 }

--- a/pkg/synth/emit.go
+++ b/pkg/synth/emit.go
@@ -96,11 +96,7 @@ func emitTrace(ctx context.Context, plans []SpanPlan, baseSimTime time.Time, bas
 			if len(plan.Attrs) > 0 {
 				span.SetAttributes(plan.Attrs...)
 			}
-			for _, obs := range observers {
-				if sso, ok := obs.(SpanStartObserver); ok {
-					sso.ObserveStart(plan.Service, plan.Operation)
-				}
-			}
+			notifySpanStart(observers, plan.Service, plan.Operation)
 			live[ev.Index] = liveSpan{Span: span, Ctx: spanCtx}
 		} else {
 			ls := live[ev.Index]
@@ -159,16 +155,12 @@ func finishSpan(span trace.Span, plan *SpanPlan, observers []SpanObserver, rstat
 	span.End(trace.WithTimestamp(plan.EndTime))
 
 	if len(observers) > 0 {
-		info := SpanInfo{
-			Service:   plan.Service,
-			Operation: plan.Operation,
-			Timestamp: plan.StartTime,
-			Duration:  plan.EndTime.Sub(plan.StartTime),
-			IsError:   plan.IsError,
-			Kind:      plan.Kind,
-			Attrs:     plan.Attrs,
-			Scenarios: plan.Scenarios,
-		}
+		info := newSpanInfo(
+			plan.Service, plan.Operation,
+			plan.StartTime, plan.EndTime.Sub(plan.StartTime),
+			plan.IsError, plan.Kind,
+			plan.Attrs, plan.Scenarios,
+		)
 		for _, obs := range observers {
 			obs.Observe(info)
 		}
@@ -190,16 +182,12 @@ func endAllOpen(live []liveSpan, plans []SpanPlan, observers []SpanObserver, rst
 		rstats.Errors.Add(1)
 		if len(observers) > 0 {
 			plan := &plans[i]
-			info := SpanInfo{
-				Service:   plan.Service,
-				Operation: plan.Operation,
-				Timestamp: plan.StartTime,
-				Duration:  now.Sub(plan.StartTime),
-				IsError:   true,
-				Kind:      plan.Kind,
-				Attrs:     plan.Attrs,
-				Scenarios: plan.Scenarios,
-			}
+			info := newSpanInfo(
+				plan.Service, plan.Operation,
+				plan.StartTime, now.Sub(plan.StartTime),
+				true, plan.Kind,
+				plan.Attrs, plan.Scenarios,
+			)
 			for _, obs := range observers {
 				obs.Observe(info)
 			}

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -450,6 +450,12 @@ func (e *Engine) walkTrace(ctx context.Context, op *Operation, startTime time.Ti
 		e.linkRegistry.store(op.Ref, span.SpanContext())
 	}
 
+	for _, obs := range e.Observers {
+		if sso, ok := obs.(SpanStartObserver); ok {
+			sso.ObserveStart(op.Service.Name, op.Name)
+		}
+	}
+
 	// Collect attributes for both the span and observers
 	spanAttrs := make([]attribute.KeyValue, 0, len(op.Service.Attributes)+len(opAttrs))
 	for k, v := range op.Service.Attributes {

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -624,6 +624,11 @@ func (e *Engine) emitRejectionSpan(ctx context.Context, op *Operation, startTime
 	stats.Errors++
 
 	if len(e.Observers) > 0 {
+		for _, obs := range e.Observers {
+			if sso, ok := obs.(SpanStartObserver); ok {
+				sso.ObserveStart(op.Service.Name, op.Name)
+			}
+		}
 		info := SpanInfo{
 			Service:   op.Service.Name,
 			Operation: op.Name,

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -450,11 +450,7 @@ func (e *Engine) walkTrace(ctx context.Context, op *Operation, startTime time.Ti
 		e.linkRegistry.store(op.Ref, span.SpanContext())
 	}
 
-	for _, obs := range e.Observers {
-		if sso, ok := obs.(SpanStartObserver); ok {
-			sso.ObserveStart(op.Service.Name, op.Name)
-		}
-	}
+	notifySpanStart(e.Observers, op.Service.Name, op.Name)
 
 	// Collect attributes for both the span and observers
 	spanAttrs := make([]attribute.KeyValue, 0, len(op.Service.Attributes)+len(opAttrs))
@@ -570,16 +566,12 @@ func (e *Engine) walkTrace(ctx context.Context, op *Operation, startTime time.Ti
 	if len(e.Observers) > 0 {
 		attrsCopy := make([]attribute.KeyValue, len(spanAttrs))
 		copy(attrsCopy, spanAttrs)
-		info := SpanInfo{
-			Service:   op.Service.Name,
-			Operation: op.Name,
-			Timestamp: startTime,
-			Duration:  endTime.Sub(startTime),
-			IsError:   isError,
-			Kind:      kind,
-			Attrs:     attrsCopy,
-			Scenarios: scenarioNames,
-		}
+		info := newSpanInfo(
+			op.Service.Name, op.Name,
+			startTime, endTime.Sub(startTime),
+			isError, kind,
+			attrsCopy, scenarioNames,
+		)
 		for _, obs := range e.Observers {
 			obs.Observe(info)
 		}
@@ -624,24 +616,17 @@ func (e *Engine) emitRejectionSpan(ctx context.Context, op *Operation, startTime
 	stats.Errors++
 
 	if len(e.Observers) > 0 {
-		for _, obs := range e.Observers {
-			if sso, ok := obs.(SpanStartObserver); ok {
-				sso.ObserveStart(op.Service.Name, op.Name)
-			}
-		}
-		info := SpanInfo{
-			Service:   op.Service.Name,
-			Operation: op.Name,
-			Timestamp: startTime,
-			Duration:  rejectionDuration,
-			IsError:   true,
-			Kind:      kind,
-			Attrs: []attribute.KeyValue{
+		notifySpanStart(e.Observers, op.Service.Name, op.Name)
+		info := newSpanInfo(
+			op.Service.Name, op.Name,
+			startTime, rejectionDuration,
+			true, kind,
+			[]attribute.KeyValue{
 				attribute.Bool("synth.rejected", true),
 				attribute.String("synth.rejection_reason", reason),
 			},
-			Scenarios: scenarioNames,
-		}
+			scenarioNames,
+		)
 		for _, obs := range e.Observers {
 			obs.Observe(info)
 		}

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -156,8 +156,11 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 		gaugeAttrs := md.Attributes
 		gaugeOp := operation
 		gopts = append(gopts, metric.WithFloat64Callback(func(_ context.Context, obs metric.Float64Observer) error {
-			attrs := buildMetricAttrs(gaugeAttrs, gaugeOp, nil)
-			obs.Observe(dist.Sample(rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))), attrs) //nolint:gosec // synthetic data
+			// Create a fresh rng inside the callback — it runs asynchronously
+			// during collection and cannot share the observer's rng.
+			rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // synthetic data
+			attrs := buildMetricAttrs(gaugeAttrs, gaugeOp, rng)
+			obs.Observe(dist.Sample(rng), attrs)
 			return nil
 		}))
 		_, err := meter.Float64ObservableGauge(md.Name, gopts...)
@@ -201,12 +204,7 @@ func (m *MetricObserver) Observe(info SpanInfo) {
 			continue
 		}
 
-		opName := info.Operation
-		if inst.operation == "" {
-			opName = info.Operation
-		}
-
-		attrs := buildMetricAttrs(inst.attrGens, opName, m.rng)
+		attrs := buildMetricAttrs(inst.attrGens, info.Operation, m.rng)
 
 		switch {
 		case inst.int64Counter != nil:

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -1,62 +1,186 @@
-// MetricObserver derives request duration, count, and error metrics from spans.
+// MetricObserver records topology-defined and span-derived metrics.
 // Uses the OTel Metrics API to record measurements with service and operation attributes.
 package synth
 
 import (
 	"context"
+	"math/rand/v2"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
-// serviceInstruments holds the metric instruments for a single service.
-type serviceInstruments struct {
-	duration metric.Float64Histogram
-	requests metric.Int64Counter
-	errors   metric.Int64Counter
+// metricInstrument holds one OTel instrument and its recording configuration.
+type metricInstrument struct {
+	// Exactly one of these is non-nil.
+	int64Counter         metric.Int64Counter
+	int64UpDownCounter   metric.Int64UpDownCounter
+	float64Counter       metric.Float64Counter
+	float64Histogram     metric.Float64Histogram
+	float64UpDownCounter metric.Float64UpDownCounter
+
+	value     *FloatDistribution // nil = span-derived
+	unit      string
+	attrGens  map[string]AttributeGenerator
+	operation string // non-empty if operation-level (fires only for this op)
 }
 
 // MetricObserver records derived metrics for each observed span.
 type MetricObserver struct {
-	services map[string]*serviceInstruments
+	services map[string][]metricInstrument
+	rng      *rand.Rand
 }
 
-// NewMetricObserver creates a MetricObserver with per-service instruments.
+// NewMetricObserver creates a MetricObserver from topology metric definitions.
 // Each meter should carry a resource with the correct service.name for its service.
-func NewMetricObserver(meters map[string]metric.Meter) (*MetricObserver, error) {
-	services := make(map[string]*serviceInstruments, len(meters))
-	for name, meter := range meters {
-		duration, err := meter.Float64Histogram("synth.request.duration",
-			metric.WithUnit("ms"),
-			metric.WithDescription("Duration of synthetic requests in milliseconds"),
-		)
-		if err != nil {
-			return nil, err
+func NewMetricObserver(meters map[string]metric.Meter, topo *Topology, rng *rand.Rand) (*MetricObserver, error) {
+	services := make(map[string][]metricInstrument)
+
+	for svcName, svc := range topo.Services {
+		meter := meters[svcName]
+		if meter == nil {
+			continue
 		}
 
-		requests, err := meter.Int64Counter("synth.request.count",
-			metric.WithDescription("Number of synthetic requests"),
-		)
-		if err != nil {
-			return nil, err
+		var instruments []metricInstrument
+
+		// Service-level metrics (fire for every span in this service)
+		for _, md := range svc.Metrics {
+			inst, err := createInstrument(meter, md, "")
+			if err != nil {
+				return nil, err
+			}
+			instruments = append(instruments, inst)
 		}
 
-		errors, err := meter.Int64Counter("synth.error.count",
-			metric.WithDescription("Number of synthetic request errors"),
-		)
-		if err != nil {
-			return nil, err
+		// Operation-level metrics (fire only for the specific operation)
+		for _, op := range svc.Operations {
+			for _, md := range op.Metrics {
+				inst, err := createInstrument(meter, md, op.Name)
+				if err != nil {
+					return nil, err
+				}
+				instruments = append(instruments, inst)
+			}
 		}
 
-		services[name] = &serviceInstruments{
-			duration: duration,
-			requests: requests,
-			errors:   errors,
+		if len(instruments) > 0 {
+			services[svcName] = instruments
 		}
 	}
 
-	return &MetricObserver{services: services}, nil
+	return &MetricObserver{services: services, rng: rng}, nil
+}
+
+// createInstrument builds a metricInstrument from a MetricDefinition.
+func createInstrument(meter metric.Meter, md MetricDefinition, operation string) (metricInstrument, error) {
+	inst := metricInstrument{
+		value:     md.Value,
+		unit:      md.Unit,
+		attrGens:  md.Attributes,
+		operation: operation,
+	}
+
+	switch md.Type {
+	case "counter":
+		if md.Value != nil {
+			// Topology-defined: sampled float value per recording
+			var copts []metric.Float64CounterOption
+			if md.Unit != "" {
+				copts = append(copts, metric.WithUnit(md.Unit))
+			}
+			c, err := meter.Float64Counter(md.Name, copts...)
+			if err != nil {
+				return metricInstrument{}, err
+			}
+			inst.float64Counter = c
+		} else {
+			// Span-derived: +1 per span
+			var copts []metric.Int64CounterOption
+			if md.Unit != "" {
+				copts = append(copts, metric.WithUnit(md.Unit))
+			}
+			c, err := meter.Int64Counter(md.Name, copts...)
+			if err != nil {
+				return metricInstrument{}, err
+			}
+			inst.int64Counter = c
+		}
+
+	case "updowncounter":
+		if md.Value != nil {
+			var copts []metric.Float64UpDownCounterOption
+			if md.Unit != "" {
+				copts = append(copts, metric.WithUnit(md.Unit))
+			}
+			c, err := meter.Float64UpDownCounter(md.Name, copts...)
+			if err != nil {
+				return metricInstrument{}, err
+			}
+			inst.float64UpDownCounter = c
+		} else {
+			// Span-derived: +1 on start, -1 on end
+			var copts []metric.Int64UpDownCounterOption
+			if md.Unit != "" {
+				copts = append(copts, metric.WithUnit(md.Unit))
+			}
+			c, err := meter.Int64UpDownCounter(md.Name, copts...)
+			if err != nil {
+				return metricInstrument{}, err
+			}
+			inst.int64UpDownCounter = c
+		}
+
+	case "histogram":
+		var hopts []metric.Float64HistogramOption
+		if md.Unit != "" {
+			hopts = append(hopts, metric.WithUnit(md.Unit))
+		}
+		h, err := meter.Float64Histogram(md.Name, hopts...)
+		if err != nil {
+			return metricInstrument{}, err
+		}
+		inst.float64Histogram = h
+
+	case "gauge":
+		// Gauges are always topology-defined (validated earlier).
+		// Register an observable gauge with a callback that samples the distribution.
+		var gopts []metric.Float64ObservableGaugeOption
+		if md.Unit != "" {
+			gopts = append(gopts, metric.WithUnit(md.Unit))
+		}
+		// The gauge callback is registered via WithFloat64Callback on the gauge itself.
+		// We don't store it in the instrument — it fires on collection.
+		dist := md.Value
+		gaugeAttrs := md.Attributes
+		gaugeOp := operation
+		gopts = append(gopts, metric.WithFloat64Callback(func(_ context.Context, obs metric.Float64Observer) error {
+			attrs := buildMetricAttrs(gaugeAttrs, gaugeOp, nil)
+			obs.Observe(dist.Sample(rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))), attrs) //nolint:gosec // synthetic data
+			return nil
+		}))
+		_, err := meter.Float64ObservableGauge(md.Name, gopts...)
+		if err != nil {
+			return metricInstrument{}, err
+		}
+		// No instrument stored — the callback handles everything.
+		return inst, nil
+	}
+
+	return inst, nil
+}
+
+// buildMetricAttrs constructs metric attributes from generators and adds operation.name.
+func buildMetricAttrs(attrGens map[string]AttributeGenerator, operation string, rng *rand.Rand) metric.MeasurementOption {
+	attrs := make([]attribute.KeyValue, 0, len(attrGens)+1)
+	if operation != "" {
+		attrs = append(attrs, attribute.String("operation.name", operation))
+	}
+	for k, gen := range attrGens {
+		attrs = append(attrs, typedAttribute(k, gen.Generate(rng)))
+	}
+	return metric.WithAttributes(attrs...)
 }
 
 // Observe records metrics derived from the completed span.
@@ -64,16 +188,84 @@ func NewMetricObserver(meters map[string]metric.Meter) (*MetricObserver, error) 
 // PeriodicReader. The Metrics API does not support caller-supplied timestamps,
 // so Engine.TimeOffset has no effect on metric timestamps. See issue 99.
 func (m *MetricObserver) Observe(info SpanInfo) {
-	svc := m.services[info.Service]
-	if svc == nil {
+	instruments := m.services[info.Service]
+	if len(instruments) == 0 {
 		return
 	}
-	attrs := metric.WithAttributes(
-		attribute.String("operation.name", info.Operation),
-	)
-	svc.requests.Add(context.Background(), 1, attrs)
-	svc.duration.Record(context.Background(), float64(info.Duration)/float64(time.Millisecond), attrs)
-	if info.IsError {
-		svc.errors.Add(context.Background(), 1, attrs)
+
+	for i := range instruments {
+		inst := &instruments[i]
+
+		// Operation-level metrics only fire for their specific operation.
+		if inst.operation != "" && inst.operation != info.Operation {
+			continue
+		}
+
+		opName := info.Operation
+		if inst.operation == "" {
+			opName = info.Operation
+		}
+
+		attrs := buildMetricAttrs(inst.attrGens, opName, m.rng)
+
+		switch {
+		case inst.int64Counter != nil:
+			inst.int64Counter.Add(context.Background(), 1, attrs)
+
+		case inst.float64Counter != nil:
+			inst.float64Counter.Add(context.Background(), inst.value.Sample(m.rng), attrs)
+
+		case inst.int64UpDownCounter != nil:
+			// -1 on span end (the +1 happens in ObserveStart)
+			inst.int64UpDownCounter.Add(context.Background(), -1, attrs)
+
+		case inst.float64UpDownCounter != nil:
+			inst.float64UpDownCounter.Add(context.Background(), inst.value.Sample(m.rng), attrs)
+
+		case inst.float64Histogram != nil:
+			if inst.value != nil {
+				inst.float64Histogram.Record(context.Background(), inst.value.Sample(m.rng), attrs)
+			} else {
+				// Span-derived: record span duration in the configured unit
+				duration := durationInUnit(info.Duration, inst.unit)
+				inst.float64Histogram.Record(context.Background(), duration, attrs)
+			}
+		}
+	}
+}
+
+// ObserveStart records the start of a span for updowncounter tracking.
+func (m *MetricObserver) ObserveStart(service, operation string) {
+	instruments := m.services[service]
+	if len(instruments) == 0 {
+		return
+	}
+
+	for i := range instruments {
+		inst := &instruments[i]
+		if inst.int64UpDownCounter == nil {
+			continue
+		}
+		if inst.operation != "" && inst.operation != operation {
+			continue
+		}
+
+		attrs := buildMetricAttrs(inst.attrGens, operation, m.rng)
+		inst.int64UpDownCounter.Add(context.Background(), 1, attrs)
+	}
+}
+
+// durationInUnit converts a duration to a float64 in the given unit.
+// Defaults to milliseconds if unit is empty or unrecognised.
+func durationInUnit(d time.Duration, unit string) float64 {
+	switch unit {
+	case "s":
+		return d.Seconds()
+	case "us":
+		return float64(d.Microseconds())
+	case "ns":
+		return float64(d.Nanoseconds())
+	default:
+		return float64(d) / float64(time.Millisecond)
 	}
 }

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -4,6 +4,7 @@ package synth
 
 import (
 	"context"
+	"fmt"
 	"math/rand/v2"
 	"sync"
 	"time"
@@ -154,14 +155,16 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 		inst.float64Histogram = h
 
 	case metricTypeGauge:
-		// Gauges are always topology-defined (validated earlier).
+		if md.Value == nil {
+			return metricInstrument{}, false, fmt.Errorf("gauge metric %q has no value; gauges require an explicit value distribution", md.Name)
+		}
 		// Register an observable gauge with a callback that samples the distribution.
 		var gopts []metric.Float64ObservableGaugeOption
 		if md.Unit != "" {
 			gopts = append(gopts, metric.WithUnit(md.Unit))
 		}
-		// The gauge callback is registered via WithFloat64Callback on the gauge itself.
-		// No instrument entry is needed — the callback fires on collection, not per span.
+		// The gauge callback fires on collection, not per span.
+		// No instrument entry is needed.
 		dist := md.Value
 		gaugeAttrs := md.Attributes
 		gaugeOp := operation

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -49,21 +49,25 @@ func NewMetricObserver(meters map[string]metric.Meter, topo *Topology, rng *rand
 
 		// Service-level metrics (fire for every span in this service)
 		for _, md := range svc.Metrics {
-			inst, err := createInstrument(meter, md, "")
+			inst, keep, err := createInstrument(meter, md, "")
 			if err != nil {
 				return nil, err
 			}
-			instruments = append(instruments, inst)
+			if keep {
+				instruments = append(instruments, inst)
+			}
 		}
 
 		// Operation-level metrics (fire only for the specific operation)
 		for _, op := range svc.Operations {
 			for _, md := range op.Metrics {
-				inst, err := createInstrument(meter, md, op.Name)
+				inst, keep, err := createInstrument(meter, md, op.Name)
 				if err != nil {
 					return nil, err
 				}
-				instruments = append(instruments, inst)
+				if keep {
+					instruments = append(instruments, inst)
+				}
 			}
 		}
 
@@ -76,7 +80,9 @@ func NewMetricObserver(meters map[string]metric.Meter, topo *Topology, rng *rand
 }
 
 // createInstrument builds a metricInstrument from a MetricDefinition.
-func createInstrument(meter metric.Meter, md MetricDefinition, operation string) (metricInstrument, error) {
+// Returns (inst, true, nil) for instruments that should be appended to the observer's list.
+// Returns (inst, false, nil) for gauge types — the callback handles everything; no instrument entry is needed.
+func createInstrument(meter metric.Meter, md MetricDefinition, operation string) (metricInstrument, bool, error) {
 	inst := metricInstrument{
 		value:     md.Value,
 		unit:      md.Unit,
@@ -94,7 +100,7 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 			}
 			c, err := meter.Float64Counter(md.Name, copts...)
 			if err != nil {
-				return metricInstrument{}, err
+				return metricInstrument{}, false, err
 			}
 			inst.float64Counter = c
 		} else {
@@ -105,7 +111,7 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 			}
 			c, err := meter.Int64Counter(md.Name, copts...)
 			if err != nil {
-				return metricInstrument{}, err
+				return metricInstrument{}, false, err
 			}
 			inst.int64Counter = c
 		}
@@ -118,7 +124,7 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 			}
 			c, err := meter.Float64UpDownCounter(md.Name, copts...)
 			if err != nil {
-				return metricInstrument{}, err
+				return metricInstrument{}, false, err
 			}
 			inst.float64UpDownCounter = c
 		} else {
@@ -129,7 +135,7 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 			}
 			c, err := meter.Int64UpDownCounter(md.Name, copts...)
 			if err != nil {
-				return metricInstrument{}, err
+				return metricInstrument{}, false, err
 			}
 			inst.int64UpDownCounter = c
 		}
@@ -141,7 +147,7 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 		}
 		h, err := meter.Float64Histogram(md.Name, hopts...)
 		if err != nil {
-			return metricInstrument{}, err
+			return metricInstrument{}, false, err
 		}
 		inst.float64Histogram = h
 
@@ -153,7 +159,7 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 			gopts = append(gopts, metric.WithUnit(md.Unit))
 		}
 		// The gauge callback is registered via WithFloat64Callback on the gauge itself.
-		// We don't store it in the instrument — it fires on collection.
+		// No instrument entry is needed — the callback fires on collection, not per span.
 		dist := md.Value
 		gaugeAttrs := md.Attributes
 		gaugeOp := operation
@@ -167,13 +173,12 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 		}))
 		_, err := meter.Float64ObservableGauge(md.Name, gopts...)
 		if err != nil {
-			return metricInstrument{}, err
+			return metricInstrument{}, false, err
 		}
-		// No instrument stored — the callback handles everything.
-		return inst, nil
+		return inst, false, nil
 	}
 
-	return inst, nil
+	return inst, true, nil
 }
 
 // buildMetricAttrs constructs metric attributes from generators and adds operation.name.
@@ -216,7 +221,7 @@ func (m *MetricObserver) Observe(info SpanInfo) {
 			inst.int64Counter.Add(context.Background(), 1, attrs)
 
 		case inst.float64Counter != nil:
-			inst.float64Counter.Add(context.Background(), inst.value.Sample(m.rng), attrs)
+			inst.float64Counter.Add(context.Background(), max(0, inst.value.Sample(m.rng)), attrs)
 
 		case inst.int64UpDownCounter != nil:
 			// -1 on span end (the +1 happens in ObserveStart)

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -5,6 +5,7 @@ package synth
 import (
 	"context"
 	"math/rand/v2"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -30,6 +31,7 @@ type metricInstrument struct {
 type MetricObserver struct {
 	services map[string][]metricInstrument
 	rng      *rand.Rand
+	mu       sync.Mutex
 }
 
 // NewMetricObserver creates a MetricObserver from topology metric definitions.
@@ -196,6 +198,9 @@ func (m *MetricObserver) Observe(info SpanInfo) {
 		return
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	for i := range instruments {
 		inst := &instruments[i]
 
@@ -238,6 +243,9 @@ func (m *MetricObserver) ObserveStart(service, operation string) {
 	if len(instruments) == 0 {
 		return
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	for i := range instruments {
 		inst := &instruments[i]

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -21,10 +21,11 @@ type metricInstrument struct {
 	float64Histogram     metric.Float64Histogram
 	float64UpDownCounter metric.Float64UpDownCounter
 
-	value     *FloatDistribution // nil = span-derived
-	unit      string
-	attrGens  map[string]AttributeGenerator
-	operation string // non-empty if operation-level (fires only for this op)
+	value      *FloatDistribution // nil = span-derived
+	unit       string
+	attrGens   map[string]AttributeGenerator
+	operation  string // non-empty if operation-level (fires only for this op)
+	errorsOnly bool   // if true, counter only increments for error spans
 }
 
 // MetricObserver records derived metrics for each observed span.
@@ -84,14 +85,15 @@ func NewMetricObserver(meters map[string]metric.Meter, topo *Topology, rng *rand
 // Returns (inst, false, nil) for gauge types — the callback handles everything; no instrument entry is needed.
 func createInstrument(meter metric.Meter, md MetricDefinition, operation string) (metricInstrument, bool, error) {
 	inst := metricInstrument{
-		value:     md.Value,
-		unit:      md.Unit,
-		attrGens:  md.Attributes,
-		operation: operation,
+		value:      md.Value,
+		unit:       md.Unit,
+		attrGens:   md.Attributes,
+		operation:  operation,
+		errorsOnly: md.ErrorsOnly,
 	}
 
 	switch md.Type {
-	case "counter":
+	case metricTypeCounter:
 		if md.Value != nil {
 			// Topology-defined: sampled float value per recording
 			var copts []metric.Float64CounterOption
@@ -116,7 +118,7 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 			inst.int64Counter = c
 		}
 
-	case "updowncounter":
+	case metricTypeUpDownCounter:
 		if md.Value != nil {
 			var copts []metric.Float64UpDownCounterOption
 			if md.Unit != "" {
@@ -140,7 +142,7 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 			inst.int64UpDownCounter = c
 		}
 
-	case "histogram":
+	case metricTypeHistogram:
 		var hopts []metric.Float64HistogramOption
 		if md.Unit != "" {
 			hopts = append(hopts, metric.WithUnit(md.Unit))
@@ -151,7 +153,7 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 		}
 		inst.float64Histogram = h
 
-	case "gauge":
+	case metricTypeGauge:
 		// Gauges are always topology-defined (validated earlier).
 		// Register an observable gauge with a callback that samples the distribution.
 		var gopts []metric.Float64ObservableGaugeOption
@@ -203,38 +205,43 @@ func (m *MetricObserver) Observe(info SpanInfo) {
 		return
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	for i := range instruments {
 		inst := &instruments[i]
 
-		// Operation-level metrics only fire for their specific operation.
 		if inst.operation != "" && inst.operation != info.Operation {
 			continue
 		}
+		if inst.errorsOnly && !info.IsError {
+			continue
+		}
 
+		// Lock only while sampling the RNG and building attributes.
+		m.mu.Lock()
 		attrs := buildMetricAttrs(inst.attrGens, info.Operation, m.rng)
+		var sampledValue float64
+		if inst.value != nil {
+			sampledValue = inst.value.Sample(m.rng)
+		}
+		m.mu.Unlock()
 
 		switch {
 		case inst.int64Counter != nil:
 			inst.int64Counter.Add(context.Background(), 1, attrs)
 
 		case inst.float64Counter != nil:
-			inst.float64Counter.Add(context.Background(), max(0, inst.value.Sample(m.rng)), attrs)
+			inst.float64Counter.Add(context.Background(), max(0, sampledValue), attrs)
 
 		case inst.int64UpDownCounter != nil:
 			// -1 on span end (the +1 happens in ObserveStart)
 			inst.int64UpDownCounter.Add(context.Background(), -1, attrs)
 
 		case inst.float64UpDownCounter != nil:
-			inst.float64UpDownCounter.Add(context.Background(), inst.value.Sample(m.rng), attrs)
+			inst.float64UpDownCounter.Add(context.Background(), sampledValue, attrs)
 
 		case inst.float64Histogram != nil:
 			if inst.value != nil {
-				inst.float64Histogram.Record(context.Background(), inst.value.Sample(m.rng), attrs)
+				inst.float64Histogram.Record(context.Background(), sampledValue, attrs)
 			} else {
-				// Span-derived: record span duration in the configured unit
 				duration := durationInUnit(info.Duration, inst.unit)
 				inst.float64Histogram.Record(context.Background(), duration, attrs)
 			}
@@ -249,9 +256,6 @@ func (m *MetricObserver) ObserveStart(service, operation string) {
 		return
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	for i := range instruments {
 		inst := &instruments[i]
 		if inst.int64UpDownCounter == nil {
@@ -261,7 +265,10 @@ func (m *MetricObserver) ObserveStart(service, operation string) {
 			continue
 		}
 
+		m.mu.Lock()
 		attrs := buildMetricAttrs(inst.attrGens, operation, m.rng)
+		m.mu.Unlock()
+
 		inst.int64UpDownCounter.Add(context.Background(), 1, attrs)
 	}
 }

--- a/pkg/synth/metrics_test.go
+++ b/pkg/synth/metrics_test.go
@@ -1,9 +1,10 @@
-// Tests for MetricObserver that derives request duration, count, and error metrics.
+// Tests for MetricObserver that records topology-defined and span-derived metrics.
 // Uses the OTel SDK ManualReader to verify metric data points.
 package synth
 
 import (
 	"context"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -42,59 +43,77 @@ func testMeters(mp metric.MeterProvider, services ...string) map[string]metric.M
 	return m
 }
 
-func TestMetricObserverRequestCount(t *testing.T) {
+func testRng() *rand.Rand {
+	return rand.New(rand.NewPCG(42, 0)) //nolint:gosec // deterministic seed for testing
+}
+
+func testTopology(svcName string, svcMetrics []MetricDefinition, opName string, opMetrics []MetricDefinition) *Topology {
+	svc := &Service{
+		Name:       svcName,
+		Operations: map[string]*Operation{},
+	}
+	if svcMetrics != nil {
+		svc.Metrics = svcMetrics
+	}
+	op := &Operation{
+		Service: svc,
+		Name:    opName,
+		Ref:     svcName + "." + opName,
+		Metrics: opMetrics,
+	}
+	svc.Operations[opName] = op
+	return &Topology{
+		Services: map[string]*Service{svcName: svc},
+		Roots:    []*Operation{op},
+	}
+}
+
+func TestMetricObserverSpanDerivedCounter(t *testing.T) {
 	t.Parallel()
 
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
 
-	obs, err := NewMetricObserver(testMeters(mp, "gateway"))
+	topo := testTopology("gateway", []MetricDefinition{
+		{Name: "request.count", Type: "counter"},
+	}, "GET /users", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "gateway"), topo, testRng())
 	require.NoError(t, err)
 
-	obs.Observe(SpanInfo{
-		Service:   "gateway",
-		Operation: "GET /users",
-		Duration:  50 * time.Millisecond,
-		Kind:      trace.SpanKindServer,
-	})
-	obs.Observe(SpanInfo{
-		Service:   "gateway",
-		Operation: "GET /users",
-		Duration:  30 * time.Millisecond,
-		Kind:      trace.SpanKindServer,
-	})
+	obs.Observe(SpanInfo{Service: "gateway", Operation: "GET /users", Duration: 50 * time.Millisecond, Kind: trace.SpanKindServer})
+	obs.Observe(SpanInfo{Service: "gateway", Operation: "GET /users", Duration: 30 * time.Millisecond, Kind: trace.SpanKindServer})
 
 	rm := collectMetrics(t, reader)
-	m := findMetric(rm, "synth.request.count")
-	require.NotNil(t, m, "synth.request.count metric should exist")
+	m := findMetric(rm, "request.count")
+	require.NotNil(t, m, "request.count metric should exist")
 
 	sum, ok := m.Data.(metricdata.Sum[int64])
-	require.True(t, ok, "request count should be a Sum[int64]")
+	require.True(t, ok, "span-derived counter should be Sum[int64]")
 	require.Len(t, sum.DataPoints, 1)
 	assert.Equal(t, int64(2), sum.DataPoints[0].Value)
 }
 
-func TestMetricObserverDuration(t *testing.T) {
+func TestMetricObserverSpanDerivedHistogram(t *testing.T) {
 	t.Parallel()
 
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
 
-	obs, err := NewMetricObserver(testMeters(mp, "backend"))
+	topo := testTopology("backend", []MetricDefinition{
+		{Name: "request.duration", Type: "histogram", Unit: "ms"},
+	}, "query", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "backend"), topo, testRng())
 	require.NoError(t, err)
 
-	obs.Observe(SpanInfo{
-		Service:   "backend",
-		Operation: "query",
-		Duration:  100 * time.Millisecond,
-		Kind:      trace.SpanKindClient,
-	})
+	obs.Observe(SpanInfo{Service: "backend", Operation: "query", Duration: 100 * time.Millisecond, Kind: trace.SpanKindClient})
 
 	rm := collectMetrics(t, reader)
-	m := findMetric(rm, "synth.request.duration")
-	require.NotNil(t, m, "synth.request.duration metric should exist")
+	m := findMetric(rm, "request.duration")
+	require.NotNil(t, m, "request.duration metric should exist")
 
 	hist, ok := m.Data.(metricdata.Histogram[float64])
 	require.True(t, ok, "duration should be a Histogram[float64]")
@@ -103,39 +122,126 @@ func TestMetricObserverDuration(t *testing.T) {
 	assert.InDelta(t, 100.0, hist.DataPoints[0].Sum, 0.1)
 }
 
-func TestMetricObserverErrorCount(t *testing.T) {
+func TestMetricObserverTopologyDefinedGauge(t *testing.T) {
 	t.Parallel()
 
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
 
-	obs, err := NewMetricObserver(testMeters(mp, "svc"))
+	dist := FloatDistribution{Mean: 0.65, StdDev: 0}
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "cpu.utilisation", Type: "gauge", Value: &dist},
+	}, "op", nil)
+
+	_, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
 	require.NoError(t, err)
 
-	obs.Observe(SpanInfo{
-		Service:   "svc",
-		Operation: "op",
-		Duration:  10 * time.Millisecond,
-		IsError:   true,
-		Kind:      trace.SpanKindServer,
-	})
-	obs.Observe(SpanInfo{
-		Service:   "svc",
-		Operation: "op",
-		Duration:  10 * time.Millisecond,
-		IsError:   false,
-		Kind:      trace.SpanKindServer,
-	})
+	// Gauge fires on collection, not on Observe
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "cpu.utilisation")
+	require.NotNil(t, m, "gauge should exist after collection")
+
+	gauge, ok := m.Data.(metricdata.Gauge[float64])
+	require.True(t, ok, "should be a Gauge[float64]")
+	require.Len(t, gauge.DataPoints, 1)
+	assert.InDelta(t, 0.65, gauge.DataPoints[0].Value, 0.01)
+}
+
+func TestMetricObserverUpDownCounter(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "active_requests", Type: "updowncounter"},
+	}, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	// Start 3 spans
+	obs.ObserveStart("svc", "op")
+	obs.ObserveStart("svc", "op")
+	obs.ObserveStart("svc", "op")
+
+	// End 1 span
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: 10 * time.Millisecond})
 
 	rm := collectMetrics(t, reader)
-	m := findMetric(rm, "synth.error.count")
-	require.NotNil(t, m, "synth.error.count metric should exist")
+	m := findMetric(rm, "active_requests")
+	require.NotNil(t, m)
 
 	sum, ok := m.Data.(metricdata.Sum[int64])
-	require.True(t, ok, "error count should be a Sum[int64]")
+	require.True(t, ok)
 	require.Len(t, sum.DataPoints, 1)
-	assert.Equal(t, int64(1), sum.DataPoints[0].Value)
+	assert.Equal(t, int64(2), sum.DataPoints[0].Value, "3 starts - 1 end = 2 active")
+}
+
+func TestMetricObserverOperationScoping(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	// Service-level metric fires for all ops, operation-level only for its op
+	svc := &Service{
+		Name:       "svc",
+		Operations: map[string]*Operation{},
+		Metrics: []MetricDefinition{
+			{Name: "svc.count", Type: "counter"},
+		},
+	}
+	opA := &Operation{
+		Service: svc,
+		Name:    "a",
+		Ref:     "svc.a",
+		Metrics: []MetricDefinition{
+			{Name: "a.count", Type: "counter"},
+		},
+	}
+	opB := &Operation{
+		Service: svc,
+		Name:    "b",
+		Ref:     "svc.b",
+	}
+	svc.Operations["a"] = opA
+	svc.Operations["b"] = opB
+
+	topo := &Topology{
+		Services: map[string]*Service{"svc": svc},
+		Roots:    []*Operation{opA, opB},
+	}
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "a", Duration: 10 * time.Millisecond})
+	obs.Observe(SpanInfo{Service: "svc", Operation: "b", Duration: 10 * time.Millisecond})
+
+	rm := collectMetrics(t, reader)
+
+	// svc.count should have 2 data points (one per operation)
+	svcCount := findMetric(rm, "svc.count")
+	require.NotNil(t, svcCount)
+	sum, ok := svcCount.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	var total int64
+	for _, dp := range sum.DataPoints {
+		total += dp.Value
+	}
+	assert.Equal(t, int64(2), total, "service-level counter fires for both operations")
+
+	// a.count should only have 1 data point for operation "a"
+	aCount := findMetric(rm, "a.count")
+	require.NotNil(t, aCount)
+	aSum, ok := aCount.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, aSum.DataPoints, 1)
+	assert.Equal(t, int64(1), aSum.DataPoints[0].Value)
 }
 
 func TestMetricObserverAttributes(t *testing.T) {
@@ -145,18 +251,23 @@ func TestMetricObserverAttributes(t *testing.T) {
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
 
-	obs, err := NewMetricObserver(testMeters(mp, "api"))
-	require.NoError(t, err)
-
-	obs.Observe(SpanInfo{
-		Service:   "api",
-		Operation: "POST /orders",
-		Duration:  25 * time.Millisecond,
-		Kind:      trace.SpanKindServer,
+	topo := testTopology("api", nil, "POST /orders", []MetricDefinition{
+		{
+			Name: "order.count",
+			Type: "counter",
+			Attributes: map[string]AttributeGenerator{
+				"region": &StaticValue{Value: "us-east"},
+			},
+		},
 	})
 
+	obs, err := NewMetricObserver(testMeters(mp, "api"), topo, testRng())
+	require.NoError(t, err)
+
+	obs.Observe(SpanInfo{Service: "api", Operation: "POST /orders", Duration: 25 * time.Millisecond})
+
 	rm := collectMetrics(t, reader)
-	m := findMetric(rm, "synth.request.count")
+	m := findMetric(rm, "order.count")
 	require.NotNil(t, m)
 
 	sum, ok := m.Data.(metricdata.Sum[int64])
@@ -166,9 +277,10 @@ func TestMetricObserverAttributes(t *testing.T) {
 	dp := sum.DataPoints[0]
 	expected := attribute.NewSet(
 		attribute.String("operation.name", "POST /orders"),
+		attribute.String("region", "us-east"),
 	)
 	assert.True(t, dp.Attributes.Equals(&expected),
-		"metric attributes should contain operation.name, got %v", dp.Attributes)
+		"metric attributes should contain operation.name and region, got %v", dp.Attributes)
 }
 
 func TestMetricObserverSubMillisecondDuration(t *testing.T) {
@@ -178,51 +290,112 @@ func TestMetricObserverSubMillisecondDuration(t *testing.T) {
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
 
-	obs, err := NewMetricObserver(testMeters(mp, "svc"))
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "dur", Type: "histogram", Unit: "ms"},
+	}, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
 	require.NoError(t, err)
 
-	obs.Observe(SpanInfo{
-		Service:   "svc",
-		Operation: "op",
-		Duration:  500 * time.Microsecond,
-		Kind:      trace.SpanKindServer,
-	})
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: 500 * time.Microsecond})
 
 	rm := collectMetrics(t, reader)
-	m := findMetric(rm, "synth.request.duration")
+	m := findMetric(rm, "dur")
 	require.NotNil(t, m)
 
 	hist, ok := m.Data.(metricdata.Histogram[float64])
 	require.True(t, ok)
 	require.Len(t, hist.DataPoints, 1)
 	assert.InDelta(t, 0.5, hist.DataPoints[0].Sum, 0.01,
-		"500us should record as 0.5ms, not 0")
+		"500us should record as 0.5ms")
 }
 
-func TestMetricObserverNoErrorsWhenNoErrors(t *testing.T) {
+func TestMetricObserverNoMetricsDefined(t *testing.T) {
 	t.Parallel()
 
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
 
-	obs, err := NewMetricObserver(testMeters(mp, "svc"))
+	topo := testTopology("svc", nil, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
 	require.NoError(t, err)
 
-	obs.Observe(SpanInfo{
-		Service:   "svc",
-		Operation: "op",
-		Duration:  10 * time.Millisecond,
-		IsError:   false,
-		Kind:      trace.SpanKindServer,
-	})
+	// Should not panic with no metrics defined
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: 10 * time.Millisecond})
+	obs.ObserveStart("svc", "op")
 
 	rm := collectMetrics(t, reader)
-	m := findMetric(rm, "synth.error.count")
-	if m != nil {
-		sum, ok := m.Data.(metricdata.Sum[int64])
-		if ok && len(sum.DataPoints) > 0 {
-			assert.Equal(t, int64(0), sum.DataPoints[0].Value)
-		}
+	assert.Empty(t, rm.ScopeMetrics)
+}
+
+func TestMetricObserverTopologyDefinedCounter(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	dist := FloatDistribution{Mean: 1024, StdDev: 0}
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "bytes.sent", Type: "counter", Unit: "By", Value: &dist},
+	}, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: 10 * time.Millisecond})
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "bytes.sent")
+	require.NotNil(t, m)
+
+	sum, ok := m.Data.(metricdata.Sum[float64])
+	require.True(t, ok, "topology-defined counter should be Sum[float64]")
+	require.Len(t, sum.DataPoints, 1)
+	assert.InDelta(t, 1024.0, sum.DataPoints[0].Value, 0.1)
+}
+
+func TestMetricObserverHistogramDurationUnits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		unit     string
+		duration time.Duration
+		expected float64
+	}{
+		{"ms", 100 * time.Millisecond, 100.0},
+		{"s", 2 * time.Second, 2.0},
+		{"us", 500 * time.Microsecond, 500.0},
+		{"", 100 * time.Millisecond, 100.0}, // default is ms
+	}
+
+	for _, tt := range tests {
+		t.Run("unit="+tt.unit, func(t *testing.T) {
+			t.Parallel()
+
+			reader := sdkmetric.NewManualReader()
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+			topo := testTopology("svc", []MetricDefinition{
+				{Name: "dur", Type: "histogram", Unit: tt.unit},
+			}, "op", nil)
+
+			obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+			require.NoError(t, err)
+
+			obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: tt.duration})
+
+			rm := collectMetrics(t, reader)
+			m := findMetric(rm, "dur")
+			require.NotNil(t, m)
+
+			hist, ok := m.Data.(metricdata.Histogram[float64])
+			require.True(t, ok)
+			require.Len(t, hist.DataPoints, 1)
+			assert.InDelta(t, tt.expected, hist.DataPoints[0].Sum, 0.1)
+		})
 	}
 }

--- a/pkg/synth/metrics_test.go
+++ b/pkg/synth/metrics_test.go
@@ -5,6 +5,7 @@ package synth
 import (
 	"context"
 	"math/rand/v2"
+	"sync"
 	"testing"
 	"time"
 
@@ -355,6 +356,42 @@ func TestMetricObserverTopologyDefinedCounter(t *testing.T) {
 	require.True(t, ok, "topology-defined counter should be Sum[float64]")
 	require.Len(t, sum.DataPoints, 1)
 	assert.InDelta(t, 1024.0, sum.DataPoints[0].Value, 0.1)
+}
+
+func TestMetricObserverConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "active", Type: "updowncounter"},
+		{Name: "count", Type: "counter"},
+	}, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	const goroutines = 10
+	const iters = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range iters {
+				obs.ObserveStart("svc", "op")
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range iters {
+				obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: time.Millisecond})
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestMetricObserverHistogramDurationUnits(t *testing.T) {

--- a/pkg/synth/metrics_test.go
+++ b/pkg/synth/metrics_test.go
@@ -5,6 +5,7 @@ package synth
 import (
 	"context"
 	"math/rand/v2"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -435,4 +436,117 @@ func TestMetricObserverHistogramDurationUnits(t *testing.T) {
 			assert.InDelta(t, tt.expected, hist.DataPoints[0].Sum, 0.1)
 		})
 	}
+}
+
+func TestMetricObserverErrorsOnly(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "error.count", Type: "counter", ErrorsOnly: true},
+	}, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: 10 * time.Millisecond, IsError: false})
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: 10 * time.Millisecond, IsError: true})
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: 10 * time.Millisecond, IsError: false})
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "error.count")
+	require.NotNil(t, m)
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	assert.Equal(t, int64(1), sum.DataPoints[0].Value, "only error spans should increment the counter")
+}
+
+// TestMetricObserverEndToEnd verifies the full path: YAML → LoadConfig → BuildTopology →
+// NewMetricObserver → Observe → collect. Tests all four instrument types.
+func TestMetricObserverEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	const yamlContent = `
+version: 1
+services:
+  gateway:
+    metrics:
+      - name: http.server.request.duration
+        type: histogram
+        unit: ms
+      - name: http.server.active_requests
+        type: updowncounter
+      - name: gateway.cpu.utilisation
+        type: gauge
+        value: "0.5"
+      - name: backend.response.bytes
+        type: counter
+        unit: By
+        value: "1024"
+    operations:
+      GET /api:
+        duration: 40ms
+        error_rate: 0%
+traffic:
+  rate: 1/s
+`
+
+	f := t.TempDir() + "/topology.yaml"
+	require.NoError(t, os.WriteFile(f, []byte(yamlContent), 0o600))
+
+	cfg, err := LoadConfig(f)
+	require.NoError(t, err)
+	require.NoError(t, ValidateConfig(cfg))
+
+	topo, err := BuildTopology(cfg)
+	require.NoError(t, err)
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	obs, err := NewMetricObserver(testMeters(mp, "gateway"), topo, testRng())
+	require.NoError(t, err)
+
+	obs.ObserveStart("gateway", "GET /api")
+	obs.Observe(SpanInfo{
+		Service:   "gateway",
+		Operation: "GET /api",
+		Duration:  40 * time.Millisecond,
+		IsError:   false,
+		Kind:      trace.SpanKindServer,
+	})
+
+	rm := collectMetrics(t, reader)
+
+	hist := findMetric(rm, "http.server.request.duration")
+	require.NotNil(t, hist, "histogram must be present")
+	hd, ok := hist.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, hd.DataPoints, 1)
+	assert.InDelta(t, 40.0, hd.DataPoints[0].Sum, 1.0)
+
+	udc := findMetric(rm, "http.server.active_requests")
+	require.NotNil(t, udc, "updowncounter must be present")
+	udSum, ok := udc.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, udSum.DataPoints, 1)
+	assert.Equal(t, int64(0), udSum.DataPoints[0].Value, "start +1 and end -1 should cancel")
+
+	gauge := findMetric(rm, "gateway.cpu.utilisation")
+	require.NotNil(t, gauge, "gauge must be present")
+	_, ok = gauge.Data.(metricdata.Gauge[float64])
+	require.True(t, ok)
+
+	cnt := findMetric(rm, "backend.response.bytes")
+	require.NotNil(t, cnt, "float64 counter must be present")
+	cntSum, ok := cnt.Data.(metricdata.Sum[float64])
+	require.True(t, ok)
+	require.Len(t, cntSum.DataPoints, 1)
+	assert.Greater(t, cntSum.DataPoints[0].Value, 0.0)
 }

--- a/pkg/synth/observer.go
+++ b/pkg/synth/observer.go
@@ -25,3 +25,9 @@ type SpanInfo struct {
 type SpanObserver interface {
 	Observe(info SpanInfo)
 }
+
+// SpanStartObserver receives notification when a span starts.
+// Observers that need to track active spans (e.g. updowncounter) implement this.
+type SpanStartObserver interface {
+	ObserveStart(service, operation string)
+}

--- a/pkg/synth/observer.go
+++ b/pkg/synth/observer.go
@@ -31,3 +31,26 @@ type SpanObserver interface {
 type SpanStartObserver interface {
 	ObserveStart(service, operation string)
 }
+
+// notifySpanStart dispatches ObserveStart to all observers that implement SpanStartObserver.
+func notifySpanStart(observers []SpanObserver, service, operation string) {
+	for _, obs := range observers {
+		if sso, ok := obs.(SpanStartObserver); ok {
+			sso.ObserveStart(service, operation)
+		}
+	}
+}
+
+// newSpanInfo constructs a SpanInfo from its component fields.
+func newSpanInfo(service, operation string, timestamp time.Time, duration time.Duration, isError bool, kind trace.SpanKind, attrs []attribute.KeyValue, scenarios []string) SpanInfo {
+	return SpanInfo{
+		Service:   service,
+		Operation: operation,
+		Timestamp: timestamp,
+		Duration:  duration,
+		IsError:   isError,
+		Kind:      kind,
+		Attrs:     attrs,
+		Scenarios: scenarios,
+	}
+}

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -16,12 +16,22 @@ type Topology struct {
 	Roots    []*Operation
 }
 
+// MetricDefinition is a resolved metric instrument definition.
+type MetricDefinition struct {
+	Name       string
+	Type       string
+	Unit       string
+	Value      *FloatDistribution
+	Attributes map[string]AttributeGenerator
+}
+
 // Service represents a resolved service node in the topology graph.
 type Service struct {
 	Name               string
 	Operations         map[string]*Operation
 	ResourceAttributes map[string]string
 	Attributes         map[string]string
+	Metrics            []MetricDefinition
 }
 
 // ResolvedBackpressure holds parsed backpressure settings for an operation.
@@ -57,6 +67,7 @@ type Operation struct {
 	Attributes     map[string]AttributeGenerator
 	Events         []Event
 	Links          []*Operation
+	Metrics        []MetricDefinition
 	QueueDepth     int
 	Backpressure   *ResolvedBackpressure
 	CircuitBreaker *ResolvedCircuitBreaker
@@ -101,6 +112,13 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 			ResourceAttributes: svcCfg.ResourceAttributes,
 			Attributes:         svcCfg.Attributes,
 		}
+		if len(svcCfg.Metrics) > 0 {
+			resolved, err := resolveMetrics(svcCfg.Metrics, svcCfg.Name, "")
+			if err != nil {
+				return nil, err
+			}
+			svc.Metrics = resolved
+		}
 		for _, opCfg := range svcCfg.Operations {
 			dist, err := ParseDistribution(opCfg.Duration)
 			if err != nil {
@@ -144,6 +162,13 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 				CallStyle:  opCfg.CallStyle,
 				Attributes: attrs,
 				QueueDepth: opCfg.QueueDepth,
+			}
+			if len(opCfg.Metrics) > 0 {
+				resolved, mErr := resolveMetrics(opCfg.Metrics, svcCfg.Name, opCfg.Name)
+				if mErr != nil {
+					return nil, mErr
+				}
+				op.Metrics = resolved
 			}
 			if opCfg.Backpressure != nil {
 				lt, _ := time.ParseDuration(opCfg.Backpressure.LatencyThreshold)
@@ -246,6 +271,45 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 	topo.Roots = findRoots(topo)
 
 	return topo, nil
+}
+
+// resolveMetrics converts MetricConfig entries into MetricDefinitions.
+func resolveMetrics(configs []MetricConfig, svcName, opName string) ([]MetricDefinition, error) {
+	defs := make([]MetricDefinition, len(configs))
+	for i, mc := range configs {
+		def := MetricDefinition{
+			Name: mc.Name,
+			Type: mc.Type,
+			Unit: mc.Unit,
+		}
+		if mc.Value != "" {
+			dist, err := ParseFloatDistribution(mc.Value)
+			if err != nil {
+				ctx := fmt.Sprintf("service %q", svcName)
+				if opName != "" {
+					ctx = fmt.Sprintf("service %q operation %q", svcName, opName)
+				}
+				return nil, fmt.Errorf("%s: metric %q: %w", ctx, mc.Name, err)
+			}
+			def.Value = &dist
+		}
+		if len(mc.Attributes) > 0 {
+			def.Attributes = make(map[string]AttributeGenerator, len(mc.Attributes))
+			for name, acfg := range mc.Attributes {
+				gen, err := NewAttributeGenerator(acfg)
+				if err != nil {
+					ctx := fmt.Sprintf("service %q", svcName)
+					if opName != "" {
+						ctx = fmt.Sprintf("service %q operation %q", svcName, opName)
+					}
+					return nil, fmt.Errorf("%s: metric %q attribute %q: %w", ctx, mc.Name, name, err)
+				}
+				def.Attributes[name] = gen
+			}
+		}
+		defs[i] = def
+	}
+	return defs, nil
 }
 
 // resolveRef resolves a "service.operation" reference string to pointers.

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -22,6 +22,7 @@ type MetricDefinition struct {
 	Type       string
 	Unit       string
 	Value      *FloatDistribution
+	ErrorsOnly bool
 	Attributes map[string]AttributeGenerator
 }
 
@@ -278,9 +279,10 @@ func resolveMetrics(configs []MetricConfig, svcName, opName string) ([]MetricDef
 	defs := make([]MetricDefinition, len(configs))
 	for i, mc := range configs {
 		def := MetricDefinition{
-			Name: mc.Name,
-			Type: mc.Type,
-			Unit: mc.Unit,
+			Name:       mc.Name,
+			Type:       mc.Type,
+			Unit:       mc.Unit,
+			ErrorsOnly: mc.ErrorsOnly,
 		}
 		if mc.Value != "" {
 			dist, err := ParseFloatDistribution(mc.Value)
@@ -292,6 +294,13 @@ func resolveMetrics(configs []MetricConfig, svcName, opName string) ([]MetricDef
 				return nil, fmt.Errorf("%s: metric %q: %w", ctx, mc.Name, err)
 			}
 			def.Value = &dist
+		}
+		if mc.Type == metricTypeGauge && def.Value == nil {
+			ctx := fmt.Sprintf("service %q", svcName)
+			if opName != "" {
+				ctx = fmt.Sprintf("service %q operation %q", svcName, opName)
+			}
+			return nil, fmt.Errorf("%s: metric %q: gauge requires a value", ctx, mc.Name)
 		}
 		if len(mc.Attributes) > 0 {
 			def.Attributes = make(map[string]AttributeGenerator, len(mc.Attributes))


### PR DESCRIPTION
## Summary

- Add `metrics:` section to service and operation definitions in topology YAML, supporting all 4 OTel instrument types (counter, updowncounter, histogram, gauge) with both span-derived and topology-defined values
- Remove the 3 hard-coded metric instruments (`synth.request.duration`, `synth.request.count`, `synth.error.count`) — users now define the metrics they want
- Add `SpanStartObserver` interface for span lifecycle tracking, enabling updowncounter active-span tracking

Closes #111

### YAML syntax

```yaml
services:
  gateway:
    metrics:
      - name: http.server.request.duration
        type: histogram
        unit: ms
        # No value → span-derived (records span duration)
      - name: gateway.cpu.utilisation
        type: gauge
        value: 0.65 +/- 0.1
        # Has value → topology-defined (sampled on collection)
    operations:
      handle:
        duration: 50ms
        metrics:
          - name: gateway.cache.hit_ratio
            type: gauge
            value: 0.85 +/- 0.1
```

### Instrument behaviour

| Type | Span-derived (no `value`) | Topology-defined (`value` present) |
|------|--------------------------|-----------------------------------|
| counter | `Int64Counter`, +1 per span | `Float64Counter`, sampled value |
| updowncounter | `Int64UpDownCounter`, +1 start / -1 end | `Float64UpDownCounter`, sampled value |
| histogram | `Float64Histogram`, span duration in unit | `Float64Histogram`, sampled value |
| gauge | N/A (validation rejects) | `Float64ObservableGauge`, callback on collection |

## Test plan

- [x] `FloatDistribution` parsing: happy path, `+/-`/`±` syntax, errors
- [x] YAML parsing: service and operation level metrics round-trip
- [x] Validation: bad type, missing name, invalid value, duplicate names, gauge-without-value
- [x] Span-derived counter, histogram, updowncounter
- [x] Topology-defined counter, gauge (observable callback)
- [x] Operation-level vs service-level metric scoping
- [x] Metric attributes via `AttributeGenerator`
- [x] Duration unit conversion (ms, s, us, ns)
- [x] `make test` — all pass
- [x] `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)