### PR TITLE
Finish the metrics story: scenario overrides, random-walk gauges, interval metrics, semconv validation

### DIFF
--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -323,6 +323,10 @@ running; if no metrics are defined the signal is silently empty.
 | `min`, `max` | float  | Gauge only: clamp observed values to these bounds |
 | `attributes` | map    | Per-measurement attribute generators — same syntax as span attributes |
 
+Metric names that match a known OTel semantic convention metric are checked
+by `motel validate`: a `type` or `unit` that disagrees with the convention
+produces a warning (not an error). Custom metric names are never warned about.
+
 **Span-derived behaviour (no `value`):** the instrument records a value derived
 from the span being observed.
 
@@ -385,13 +389,14 @@ observable callback fires on the collection cycle) and do not accept
 services:
   gateway:
     metrics:
-      # Span-derived histogram: records span duration in milliseconds
+      # Span-derived histogram: records span duration in seconds
       - name: http.server.request.duration
         type: histogram
-        unit: ms
+        unit: s
       # Span-derived updowncounter: tracks currently active requests
       - name: http.server.active_requests
         type: updowncounter
+        unit: "{request}"
       # Topology-defined gauge: independent of spans, sampled on collection
       - name: gateway.cpu.utilisation
         type: gauge

--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -318,6 +318,8 @@ running; if no metrics are defined the signal is silently empty.
 | `type`       | string | `counter`, `updowncounter`, `histogram`, or `gauge` (required) |
 | `unit`       | string | OTel unit string, e.g. `ms`, `s`, `{request}` (optional) |
 | `value`      | string | Distribution to sample, e.g. `0.65` or `0.65 +/- 0.1`. Omit for span-derived behaviour (see below) |
+| `walk`       | string | Gauge only: mean-reversion timescale for a random walk, e.g. `30s` (see below) |
+| `min`, `max` | float  | Gauge only: clamp observed values to these bounds |
 | `attributes` | map    | Per-measurement attribute generators — same syntax as span attributes |
 
 **Span-derived behaviour (no `value`):** the instrument records a value derived
@@ -339,6 +341,27 @@ normal distribution on each observation.
 | `updowncounter` | sampled float added per completed span |
 | `histogram` | sampled float recorded per completed span |
 | `gauge` | sampled float reported on each collection cycle |
+
+**Random-walk gauges (`walk`):** by default each gauge collection samples
+independently, producing white noise. Setting `walk` turns the gauge into a
+mean-reverting random walk (an Ornstein-Uhlenbeck process): consecutive
+samples are correlated and drift smoothly, while the long-run mean and
+standard deviation still match `value`. The timescale controls how quickly
+the value reverts to the mean — short timescales (a few seconds) look jittery,
+long ones (minutes) drift slowly. Combine with `min`/`max` to keep bounded
+metrics like utilisation in range:
+
+```yaml
+- name: gateway.cpu.utilisation
+  type: gauge
+  value: 0.65 +/- 0.1
+  walk: 30s
+  min: 0
+  max: 1
+```
+
+Walk timescales relate to wall-clock time between collection cycles,
+regardless of simulated time compression.
 
 ```yaml
 services:

--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -265,12 +265,12 @@ Time-windowed overrides to operation behaviour and traffic.
 | `at`       | string | Start offset from simulation start, e.g. `+5s`, `30s` |
 | `duration` | string | How long the scenario is active |
 | `priority` | int    | Higher priority wins when scenarios overlap (default: 0) |
-| `override` | map    | Per-operation overrides keyed by `service.operation` |
+| `override` | map    | Per-operation overrides keyed by `service.operation`, or per-service overrides keyed by service name |
 | `traffic`  | object | Traffic pattern override for this window |
 
-Each override can set `duration`, `error_rate`, and `attributes`. Overlapping
-scenarios merge overrides by priority — higher-priority values win per field,
-attributes merge per key.
+Each operation override can set `duration`, `error_rate`, `attributes`, and
+`metrics`. Overlapping scenarios merge overrides by priority — higher-priority
+values win per field, attributes and metrics merge per key.
 
 ```yaml
 scenarios:
@@ -283,6 +283,26 @@ scenarios:
         error_rate: 15%
     traffic:
       rate: 200/s
+```
+
+A `metrics` override replaces the `value` distribution of a topology-defined
+metric for the scenario window. The metric must be defined with a `value` at
+the same scope — a service name key overrides service-level metrics, a
+`service.operation` key overrides operation-level metrics. Span-derived
+metrics (no `value`) cannot be overridden, and `name`, `type`, and `unit` are
+fixed at instrument creation time. An override keyed by a bare service name
+may only contain `metrics`.
+
+```yaml
+scenarios:
+  - name: cpu spike
+    at: +2m
+    duration: 5m
+    override:
+      gateway:
+        metrics:
+          gateway.cpu.utilisation:
+            value: 0.95 +/- 0.02
 ```
 
 ### metrics

--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -318,6 +318,7 @@ running; if no metrics are defined the signal is silently empty.
 | `type`       | string | `counter`, `updowncounter`, `histogram`, or `gauge` (required) |
 | `unit`       | string | OTel unit string, e.g. `ms`, `s`, `{request}` (optional) |
 | `value`      | string | Distribution to sample, e.g. `0.65` or `0.65 +/- 0.1`. Omit for span-derived behaviour (see below) |
+| `interval`   | string | Emit on a timer instead of per span, e.g. `10s`. Requires `value`; not valid for gauges (see below) |
 | `walk`       | string | Gauge only: mean-reversion timescale for a random walk, e.g. `30s` (see below) |
 | `min`, `max` | float  | Gauge only: clamp observed values to these bounds |
 | `attributes` | map    | Per-measurement attribute generators — same syntax as span attributes |
@@ -362,6 +363,23 @@ metrics like utilisation in range:
 
 Walk timescales relate to wall-clock time between collection cycles,
 regardless of simulated time compression.
+
+**Interval-driven metrics (`interval`):** by default, topology-defined
+counters, updowncounters, and histograms record when a span fires, coupling
+their emission rate to the trace rate. Setting `interval` decouples them: the
+instrument records a sampled value on its own timer, so a service with no
+traffic still emits metric data. Intervals are wall-clock durations,
+regardless of simulated time compression. Gauges already behave this way (the
+observable callback fires on the collection cycle) and do not accept
+`interval`; span-derived metrics (no `value`) remain span-coupled.
+
+```yaml
+- name: gateway.gc.pause.duration
+  type: histogram
+  unit: ms
+  value: 2.5 +/- 0.8
+  interval: 10s   # emit every 10 seconds, regardless of trace rate
+```
 
 ```yaml
 services:

--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -614,6 +614,8 @@ func runGenerate(ctx context.Context, configPath string, opts runOptions) error 
 		if mErr != nil {
 			return fmt.Errorf("creating metric observer: %w", mErr)
 		}
+		stopIntervals := obs.Start()
+		defer stopIntervals()
 		observers = append(observers, obs)
 	}
 

--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -932,8 +932,13 @@ func semconvMetricWarnings(cfg *synth.Config, reg *semconv.Registry) []string {
 				scope, mc.Name, mc.Type, g.Instrument))
 		}
 		if g.Unit != "" && mc.Unit != g.Unit {
-			warnings = append(warnings, fmt.Sprintf("%s: metric %q: unit %q does not match semantic convention unit %q",
-				scope, mc.Name, mc.Unit, g.Unit))
+			if mc.Unit == "" {
+				warnings = append(warnings, fmt.Sprintf("%s: metric %q: unit is not set; semantic convention specifies %q",
+					scope, mc.Name, g.Unit))
+			} else {
+				warnings = append(warnings, fmt.Sprintf("%s: metric %q: unit %q does not match semantic convention unit %q",
+					scope, mc.Name, mc.Unit, g.Unit))
+			}
 		}
 	}
 	for _, svc := range cfg.Services {

--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -344,9 +344,16 @@ func validateCmd() *cobra.Command {
 			if err := synth.ValidateConfig(cfg); err != nil {
 				return err
 			}
-			topo, err := buildTopology(cfg, semconvDir)
+			reg, err := loadRegistry(semconvDir)
 			if err != nil {
 				return err
+			}
+			topo, err := synth.BuildTopology(cfg, domainResolver(reg))
+			if err != nil {
+				return err
+			}
+			for _, w := range semconvMetricWarnings(cfg, reg) {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", w)
 			}
 			svcLabel := "services"
 			if len(topo.Services) == 1 {
@@ -878,6 +885,16 @@ func shutdownAll[S shutdownable](ctx context.Context, items []S, label string) {
 }
 
 func buildTopology(cfg *synth.Config, semconvDir string) (*synth.Topology, error) {
+	reg, err := loadRegistry(semconvDir)
+	if err != nil {
+		return nil, err
+	}
+	return synth.BuildTopology(cfg, domainResolver(reg))
+}
+
+// loadRegistry loads the embedded semantic convention registry, merged with
+// any additional YAML files from semconvDir.
+func loadRegistry(semconvDir string) (*semconv.Registry, error) {
 	reg, err := semconv.LoadEmbedded()
 	if err != nil {
 		return nil, fmt.Errorf("loading semantic conventions: %w", err)
@@ -896,7 +913,40 @@ func buildTopology(cfg *synth.Config, semconvDir string) (*synth.Topology, error
 		}
 		reg = reg.Merge(userReg)
 	}
-	return synth.BuildTopology(cfg, domainResolver(reg))
+	return reg, nil
+}
+
+// semconvMetricWarnings checks topology metric definitions whose names match
+// known semantic convention metrics, returning warnings for instrument type
+// and unit mismatches. Unknown metric names are not warned about — users may
+// define custom metrics freely.
+func semconvMetricWarnings(cfg *synth.Config, reg *semconv.Registry) []string {
+	var warnings []string
+	check := func(scope string, mc synth.MetricConfig) {
+		g := reg.MetricByName(mc.Name)
+		if g == nil {
+			return
+		}
+		if g.Instrument != "" && mc.Type != g.Instrument {
+			warnings = append(warnings, fmt.Sprintf("%s: metric %q: type %q does not match semantic convention instrument %q",
+				scope, mc.Name, mc.Type, g.Instrument))
+		}
+		if g.Unit != "" && mc.Unit != g.Unit {
+			warnings = append(warnings, fmt.Sprintf("%s: metric %q: unit %q does not match semantic convention unit %q",
+				scope, mc.Name, mc.Unit, g.Unit))
+		}
+	}
+	for _, svc := range cfg.Services {
+		for _, mc := range svc.Metrics {
+			check(fmt.Sprintf("service %q", svc.Name), mc)
+		}
+		for _, op := range svc.Operations {
+			for _, mc := range op.Metrics {
+				check(fmt.Sprintf("service %q operation %q", svc.Name, op.Name), mc)
+			}
+		}
+	}
+	return warnings
 }
 
 // topoHasMetrics reports whether any service or operation in the topology defines at least one metric.

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -1210,3 +1210,30 @@ traffic:
 		assert.NotContains(t, errOut.String(), "warning:")
 	})
 }
+
+func TestValidateCommandSemconvUnsetUnitWarning(t *testing.T) {
+	t.Parallel()
+	cfg := `
+version: 1
+services:
+  gateway:
+    metrics:
+      - name: http.server.request.duration
+        type: histogram
+    operations:
+      handle:
+        duration: 50ms
+traffic:
+  rate: 10/s
+`
+	path := writeTestConfig(t, cfg)
+	root := rootCmd()
+	root.SetArgs([]string{"validate", path})
+	var out, errOut bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+
+	require.NoError(t, root.Execute())
+	assert.Contains(t, errOut.String(), `unit is not set; semantic convention specifies "s"`)
+	assert.NotContains(t, errOut.String(), `unit ""`)
+}

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -1119,3 +1119,94 @@ func TestMetricShutdownExporterOrder(t *testing.T) {
 			"provider %d shut down after exporter", i)
 	}
 }
+
+func TestValidateCommandSemconvMetricWarnings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("warns on type and unit mismatch", func(t *testing.T) {
+		t.Parallel()
+		cfg := `
+version: 1
+services:
+  gateway:
+    metrics:
+      - name: http.server.request.duration
+        type: counter
+        unit: ms
+    operations:
+      handle:
+        duration: 50ms
+traffic:
+  rate: 10/s
+`
+		path := writeTestConfig(t, cfg)
+		root := rootCmd()
+		root.SetArgs([]string{"validate", path})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+
+		require.NoError(t, root.Execute())
+		assert.Contains(t, out.String(), "Configuration valid", "warnings must not fail validation")
+		assert.Contains(t, errOut.String(), `type "counter" does not match semantic convention instrument "histogram"`)
+		assert.Contains(t, errOut.String(), `unit "ms" does not match semantic convention unit "s"`)
+	})
+
+	t.Run("warns on operation-level metric mismatch", func(t *testing.T) {
+		t.Parallel()
+		cfg := `
+version: 1
+services:
+  gateway:
+    operations:
+      handle:
+        duration: 50ms
+        metrics:
+          - name: http.server.active_requests
+            type: updowncounter
+            unit: ms
+traffic:
+  rate: 10/s
+`
+		path := writeTestConfig(t, cfg)
+		root := rootCmd()
+		root.SetArgs([]string{"validate", path})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+
+		require.NoError(t, root.Execute())
+		assert.Contains(t, errOut.String(), `service "gateway" operation "handle"`)
+		assert.Contains(t, errOut.String(), `unit "ms" does not match semantic convention unit "{request}"`)
+	})
+
+	t.Run("no warnings for compliant or custom metrics", func(t *testing.T) {
+		t.Parallel()
+		cfg := `
+version: 1
+services:
+  gateway:
+    metrics:
+      - name: http.server.request.duration
+        type: histogram
+        unit: s
+      - name: my.custom.metric
+        type: counter
+        unit: ms
+    operations:
+      handle:
+        duration: 50ms
+traffic:
+  rate: 10/s
+`
+		path := writeTestConfig(t, cfg)
+		root := rootCmd()
+		root.SetArgs([]string{"validate", path})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+
+		require.NoError(t, root.Execute())
+		assert.NotContains(t, errOut.String(), "warning:")
+	})
+}

--- a/docs/examples/topology-driven-metrics.yaml
+++ b/docs/examples/topology-driven-metrics.yaml
@@ -8,13 +8,14 @@ version: 1
 services:
   gateway:
     metrics:
-      # Span-derived histogram: records each request's duration in milliseconds
+      # Span-derived histogram: records each request's duration in seconds
       - name: http.server.request.duration
         type: histogram
-        unit: ms
+        unit: s
       # Span-derived updowncounter: tracks in-flight requests (requires --realtime for meaningful values)
       - name: http.server.active_requests
         type: updowncounter
+        unit: "{request}"
       # Topology-defined gauge: sampled on each collection cycle, independent of spans
       - name: gateway.cpu.utilisation
         type: gauge

--- a/docs/how-to/test-alert-thresholds.md
+++ b/docs/how-to/test-alert-thresholds.md
@@ -103,9 +103,10 @@ services:
     metrics:
       - name: http.server.request.duration
         type: histogram
-        unit: ms
+        unit: s
       - name: http.server.active_requests
         type: updowncounter
+        unit: "{request}"
     operations:
       GET /api:
         duration: 45ms +/- 12ms

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -25,6 +25,12 @@ motel validate <topology.yaml | URL>
 
 Prints a summary on success (e.g. `Configuration valid: 5 services, 2 root operations`) or a precise error on failure including the service name, operation name, and field.
 
+When a metric name matches a known OpenTelemetry semantic convention metric, validate also checks the instrument type and unit against the convention. Mismatches are reported as warnings on stderr, not errors — users may intentionally deviate, and custom metric names are never warned about:
+
+```
+warning: service "gateway": metric "http.server.request.duration": unit "ms" does not match semantic convention unit "s"
+```
+
 ### run
 
 Generate synthetic signals from a topology definition.

--- a/pkg/semconv/registry.go
+++ b/pkg/semconv/registry.go
@@ -20,10 +20,11 @@ type groupsFile struct {
 
 // Registry holds indexed semantic convention groups and attributes.
 type Registry struct {
-	groups    []Group
-	byGroupID map[string]*Group
-	byAttrID  map[string]*Attribute
-	byDomain  map[string][]*Group
+	groups       []Group
+	byGroupID    map[string]*Group
+	byAttrID     map[string]*Attribute
+	byDomain     map[string][]*Group
+	byMetricName map[string]*Group
 }
 
 // Load parses all YAML files from the given filesystem into a Registry.
@@ -95,6 +96,12 @@ func (r *Registry) Attribute(id string) *Attribute {
 	return r.byAttrID[id]
 }
 
+// MetricByName returns the metric group with the given metric name
+// (e.g. "http.server.request.duration"), or nil if not found.
+func (r *Registry) MetricByName(name string) *Group {
+	return r.byMetricName[name]
+}
+
 // Domain returns all groups belonging to the given domain.
 func (r *Registry) Domain(name string) []*Group {
 	return r.byDomain[name]
@@ -134,10 +141,11 @@ func (r *Registry) Merge(other *Registry) *Registry {
 // buildRegistry indexes groups and resolves attribute references.
 func buildRegistry(groups []Group) *Registry {
 	r := &Registry{
-		groups:    groups,
-		byGroupID: make(map[string]*Group, len(groups)),
-		byAttrID:  make(map[string]*Attribute, len(groups)*4),
-		byDomain:  make(map[string][]*Group),
+		groups:       groups,
+		byGroupID:    make(map[string]*Group, len(groups)),
+		byAttrID:     make(map[string]*Attribute, len(groups)*4),
+		byDomain:     make(map[string][]*Group),
+		byMetricName: make(map[string]*Group),
 	}
 
 	// First pass: index all inline attributes (those with an ID, not a ref).
@@ -146,6 +154,9 @@ func buildRegistry(groups []Group) *Registry {
 		r.byGroupID[g.ID] = g
 		if g.domain != "" {
 			r.byDomain[g.domain] = append(r.byDomain[g.domain], g)
+		}
+		if g.Type == "metric" && g.MetricName != "" {
+			r.byMetricName[g.MetricName] = g
 		}
 		for j := range g.Attributes {
 			attr := &g.Attributes[j]

--- a/pkg/semconv/registry_test.go
+++ b/pkg/semconv/registry_test.go
@@ -669,3 +669,18 @@ groups:
 	require.NoError(t, err)
 	assert.Len(t, reg.Groups(), 1)
 }
+
+func TestMetricByName(t *testing.T) {
+	t.Parallel()
+	reg, err := LoadEmbedded()
+	require.NoError(t, err)
+
+	g := reg.MetricByName("http.server.request.duration")
+	require.NotNil(t, g, "known semconv metric should be indexed")
+	assert.Equal(t, "metric", g.Type)
+	assert.Equal(t, "histogram", g.Instrument)
+	assert.Equal(t, "s", g.Unit)
+
+	assert.Nil(t, reg.MetricByName("my.custom.metric"), "unknown metric names return nil")
+	assert.Nil(t, reg.MetricByName(""), "empty name returns nil")
+}

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -126,6 +126,7 @@ type MetricConfig struct {
 	Type       string                          `yaml:"type"`
 	Unit       string                          `yaml:"unit,omitempty"`
 	Value      string                          `yaml:"value,omitempty"`
+	Interval   string                          `yaml:"interval,omitempty"`
 	Walk       string                          `yaml:"walk,omitempty"`
 	Min        *float64                        `yaml:"min,omitempty"`
 	Max        *float64                        `yaml:"max,omitempty"`
@@ -787,6 +788,24 @@ func validateMetricConfig(mc MetricConfig, prefix string) error {
 	}
 	if mc.Type == metricTypeGauge && mc.Value == "" {
 		return fmt.Errorf("%s %q: gauge metrics require a value (gauges are point-in-time, not span-derived)", prefix, mc.Name)
+	}
+	if mc.Interval != "" {
+		if mc.Type == metricTypeGauge {
+			return fmt.Errorf("%s %q: interval is not valid for gauge metrics (gauges already emit on the collection cycle)", prefix, mc.Name)
+		}
+		if mc.Value == "" {
+			return fmt.Errorf("%s %q: interval requires a value (span-derived metrics are emitted per span)", prefix, mc.Name)
+		}
+		if mc.ErrorsOnly {
+			return fmt.Errorf("%s %q: interval cannot be combined with errors_only", prefix, mc.Name)
+		}
+		d, err := time.ParseDuration(mc.Interval)
+		if err != nil {
+			return fmt.Errorf("%s %q: invalid interval: %w", prefix, mc.Name, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("%s %q: interval must be positive", prefix, mc.Name)
+		}
 	}
 	if mc.Walk != "" {
 		if mc.Type != metricTypeGauge {

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -202,13 +202,23 @@ type ScenarioConfig struct {
 	Traffic  *TrafficConfig            `yaml:"traffic,omitempty"`
 }
 
-// OverrideConfig holds per-operation overrides within a scenario.
+// OverrideConfig holds per-operation or per-service overrides within a scenario.
+// Override keys are usually "service.operation" references; a bare service name
+// is also accepted, in which case only Metrics may be set.
 type OverrideConfig struct {
 	Duration    string                          `yaml:"duration,omitempty"`
 	ErrorRate   string                          `yaml:"error_rate,omitempty"`
 	Attributes  map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
 	AddCalls    []CallConfig                    `yaml:"add_calls,omitempty"`
 	RemoveCalls []RemoveCallConfig              `yaml:"remove_calls,omitempty"`
+	Metrics     map[string]MetricOverrideConfig `yaml:"metrics,omitempty"`
+}
+
+// MetricOverrideConfig overrides the value distribution of a named metric
+// during a scenario window. Name, type, and unit are fixed at instrument
+// creation time and cannot be overridden.
+type MetricOverrideConfig struct {
+	Value string `yaml:"value"`
 }
 
 // RemoveCallConfig identifies a downstream call to remove by target reference.
@@ -367,9 +377,13 @@ func ValidateConfig(cfg *Config) error {
 
 	// Build lookups for reference validation:
 	// knownOps: all defined operations
+	// knownServices: all defined services (for service-scope metric overrides)
 	// opCalls: which targets each operation calls (for remove_calls validation)
+	// metricsByScope: metric definitions keyed by scope ref (service name or "service.operation")
 	knownOps := make(map[string]bool)
+	knownServices := make(map[string]bool)
 	opCalls := make(map[string]map[string]bool)
+	metricsByScope := make(map[string]map[string]MetricConfig)
 	for _, svc := range cfg.Services {
 		if len(svc.Operations) == 0 {
 			return fmt.Errorf("service %q must have at least one operation, e.g.\n  operations:\n    GET /users:\n      duration: 50ms", svc.Name)
@@ -382,6 +396,7 @@ func ValidateConfig(cfg *Config) error {
 				return fmt.Errorf("service %q: resource_attributes must not contain reserved key %q (set automatically)", svc.Name, k)
 			}
 		}
+		knownServices[svc.Name] = true
 		metricNames := make(map[string]bool)
 		for i, mc := range svc.Metrics {
 			if err := validateMetricConfig(mc, fmt.Sprintf("service %q: metric[%d]", svc.Name, i)); err != nil {
@@ -391,8 +406,13 @@ func ValidateConfig(cfg *Config) error {
 				return fmt.Errorf("service %q: duplicate metric name %q", svc.Name, mc.Name)
 			}
 			metricNames[mc.Name] = true
+			if metricsByScope[svc.Name] == nil {
+				metricsByScope[svc.Name] = make(map[string]MetricConfig)
+			}
+			metricsByScope[svc.Name][mc.Name] = mc
 		}
 		for _, op := range svc.Operations {
+			opRef := svc.Name + "." + op.Name
 			for i, mc := range op.Metrics {
 				if err := validateMetricConfig(mc, fmt.Sprintf("service %q operation %q: metric[%d]", svc.Name, op.Name, i)); err != nil {
 					return err
@@ -401,8 +421,12 @@ func ValidateConfig(cfg *Config) error {
 					return fmt.Errorf("service %q operation %q: duplicate metric name %q (already defined at service or operation level)", svc.Name, op.Name, mc.Name)
 				}
 				metricNames[mc.Name] = true
+				if metricsByScope[opRef] == nil {
+					metricsByScope[opRef] = make(map[string]MetricConfig)
+				}
+				metricsByScope[opRef][mc.Name] = mc
 			}
-			ref := svc.Name + "." + op.Name
+			ref := opRef
 			knownOps[ref] = true
 			targets := make(map[string]bool, len(op.Calls))
 			for _, call := range op.Calls {
@@ -576,7 +600,16 @@ func ValidateConfig(cfg *Config) error {
 		}
 		for ref, override := range sc.Override {
 			if !knownOps[ref] {
-				return fmt.Errorf("scenario %q: override %q references unknown operation", sc.Name, ref)
+				if !knownServices[ref] {
+					return fmt.Errorf("scenario %q: override %q references unknown operation or service", sc.Name, ref)
+				}
+				if override.Duration != "" || override.ErrorRate != "" || len(override.Attributes) > 0 ||
+					len(override.AddCalls) > 0 || len(override.RemoveCalls) > 0 {
+					return fmt.Errorf("scenario %q: override %q: service-level overrides support only metrics (use %s.<operation> for operation overrides)", sc.Name, ref, ref)
+				}
+			}
+			if err := validateMetricOverrides(sc.Name, ref, override.Metrics, metricsByScope[ref]); err != nil {
+				return err
 			}
 			if override.Duration != "" {
 				if _, err := ParseDistribution(override.Duration); err != nil {
@@ -711,6 +744,27 @@ func validateCallConfig(call CallConfig, knownOps map[string]bool) error {
 	}
 	if call.Async && call.Timeout != "" {
 		return fmt.Errorf("target %q: async calls cannot have a timeout", call.Target)
+	}
+	return nil
+}
+
+// validateMetricOverrides checks scenario metric overrides against the metrics
+// defined at the override's scope (a service or operation).
+func validateMetricOverrides(scenarioName, ref string, overrides map[string]MetricOverrideConfig, defined map[string]MetricConfig) error {
+	for name, mo := range overrides {
+		base, ok := defined[name]
+		if !ok {
+			return fmt.Errorf("scenario %q: override %q: metric %q is not defined at this scope", scenarioName, ref, name)
+		}
+		if base.Value == "" {
+			return fmt.Errorf("scenario %q: override %q: metric %q is span-derived and has no value distribution to override", scenarioName, ref, name)
+		}
+		if mo.Value == "" {
+			return fmt.Errorf("scenario %q: override %q: metric %q: value is required", scenarioName, ref, name)
+		}
+		if _, err := ParseFloatDistribution(mo.Value); err != nil {
+			return fmt.Errorf("scenario %q: override %q: metric %q: invalid value: %w", scenarioName, ref, name, err)
+		}
 	}
 	return nil
 }

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -126,6 +126,9 @@ type MetricConfig struct {
 	Type       string                          `yaml:"type"`
 	Unit       string                          `yaml:"unit,omitempty"`
 	Value      string                          `yaml:"value,omitempty"`
+	Walk       string                          `yaml:"walk,omitempty"`
+	Min        *float64                        `yaml:"min,omitempty"`
+	Max        *float64                        `yaml:"max,omitempty"`
 	ErrorsOnly bool                            `yaml:"errors_only,omitempty"`
 	Attributes map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
 }
@@ -784,6 +787,24 @@ func validateMetricConfig(mc MetricConfig, prefix string) error {
 	}
 	if mc.Type == metricTypeGauge && mc.Value == "" {
 		return fmt.Errorf("%s %q: gauge metrics require a value (gauges are point-in-time, not span-derived)", prefix, mc.Name)
+	}
+	if mc.Walk != "" {
+		if mc.Type != metricTypeGauge {
+			return fmt.Errorf("%s %q: walk is only valid for gauge metrics", prefix, mc.Name)
+		}
+		d, err := time.ParseDuration(mc.Walk)
+		if err != nil {
+			return fmt.Errorf("%s %q: invalid walk: %w", prefix, mc.Name, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("%s %q: walk must be positive", prefix, mc.Name)
+		}
+	}
+	if (mc.Min != nil || mc.Max != nil) && mc.Type != metricTypeGauge {
+		return fmt.Errorf("%s %q: min and max bounds are only valid for gauge metrics", prefix, mc.Name)
+	}
+	if mc.Min != nil && mc.Max != nil && *mc.Min >= *mc.Max {
+		return fmt.Errorf("%s %q: min must be less than max", prefix, mc.Name)
 	}
 	if mc.ErrorsOnly && mc.Type != metricTypeCounter {
 		return fmt.Errorf("%s %q: errors_only is only valid for counter metrics", prefix, mc.Name)

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -2231,3 +2231,137 @@ func TestValidateConfigMetrics(t *testing.T) {
 		require.NoError(t, ValidateConfig(cfg))
 	})
 }
+
+func TestValidateConfigMetricOverrides(t *testing.T) {
+	t.Parallel()
+
+	configWithScenario := func(override map[string]OverrideConfig) *Config {
+		return &Config{
+			Version: 1,
+			Services: []ServiceConfig{{
+				Name: "gateway",
+				Metrics: []MetricConfig{
+					{Name: "gateway.cpu.utilisation", Type: "gauge", Value: "0.65 +/- 0.1"},
+					{Name: "request.count", Type: "counter"},
+				},
+				Operations: []OperationConfig{{
+					Name:     "handle",
+					Duration: "50ms",
+					Metrics: []MetricConfig{
+						{Name: "gateway.cache.hit_ratio", Type: "gauge", Value: "0.85 +/- 0.05"},
+					},
+				}},
+			}},
+			Traffic: TrafficConfig{Rate: "10/s"},
+			Scenarios: []ScenarioConfig{{
+				Name:     "test",
+				At:       "+1m",
+				Duration: "5m",
+				Override: override,
+			}},
+		}
+	}
+
+	t.Run("service-scope metric override is valid", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway": {Metrics: map[string]MetricOverrideConfig{
+				"gateway.cpu.utilisation": {Value: "0.95 +/- 0.02"},
+			}},
+		})
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("operation-scope metric override is valid", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway.handle": {Metrics: map[string]MetricOverrideConfig{
+				"gateway.cache.hit_ratio": {Value: "0.10 +/- 0.05"},
+			}},
+		})
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("unknown override key rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"nosuch": {Metrics: map[string]MetricOverrideConfig{
+				"gateway.cpu.utilisation": {Value: "0.95"},
+			}},
+		})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown operation or service")
+	})
+
+	t.Run("service-scope override with non-metric field rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway": {ErrorRate: "10%"},
+		})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "service-level overrides support only metrics")
+	})
+
+	t.Run("metric not defined at scope rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway": {Metrics: map[string]MetricOverrideConfig{
+				"gateway.cache.hit_ratio": {Value: "0.10"},
+			}},
+		})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not defined at this scope")
+	})
+
+	t.Run("span-derived metric override rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway": {Metrics: map[string]MetricOverrideConfig{
+				"request.count": {Value: "100"},
+			}},
+		})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "span-derived")
+	})
+
+	t.Run("missing value rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway": {Metrics: map[string]MetricOverrideConfig{
+				"gateway.cpu.utilisation": {},
+			}},
+		})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "value is required")
+	})
+
+	t.Run("invalid value distribution rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway": {Metrics: map[string]MetricOverrideConfig{
+				"gateway.cpu.utilisation": {Value: "not-a-number"},
+			}},
+		})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid value")
+	})
+
+	t.Run("operation override may combine metrics with other fields", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway.handle": {
+				Duration: "200ms",
+				Metrics: map[string]MetricOverrideConfig{
+					"gateway.cache.hit_ratio": {Value: "0.10"},
+				},
+			},
+		})
+		require.NoError(t, ValidateConfig(cfg))
+	})
+}

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -2365,3 +2365,82 @@ func TestValidateConfigMetricOverrides(t *testing.T) {
 		require.NoError(t, ValidateConfig(cfg))
 	})
 }
+
+func TestValidateConfigMetricWalkAndBounds(t *testing.T) {
+	t.Parallel()
+
+	baseConfig := func(metrics []MetricConfig) *Config {
+		return &Config{
+			Version: 1,
+			Services: []ServiceConfig{{
+				Name:    "svc",
+				Metrics: metrics,
+				Operations: []OperationConfig{{
+					Name:     "op",
+					Duration: "50ms",
+				}},
+			}},
+			Traffic: TrafficConfig{Rate: "10/s"},
+		}
+	}
+	fl := func(v float64) *float64 { return &v }
+
+	t.Run("gauge with walk and bounds is valid", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "cpu", Type: "gauge", Value: "0.65 +/- 0.1",
+			Walk: "30s", Min: fl(0), Max: fl(1),
+		}})
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("walk on counter rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "bytes", Type: "counter", Value: "1024", Walk: "30s",
+		}})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "walk is only valid for gauge")
+	})
+
+	t.Run("invalid walk duration rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "cpu", Type: "gauge", Value: "0.5", Walk: "fast",
+		}})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid walk")
+	})
+
+	t.Run("non-positive walk rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "cpu", Type: "gauge", Value: "0.5", Walk: "-10s",
+		}})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "walk must be positive")
+	})
+
+	t.Run("bounds on histogram rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "dur", Type: "histogram", Min: fl(0),
+		}})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only valid for gauge")
+	})
+
+	t.Run("min >= max rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "cpu", Type: "gauge", Value: "0.5", Min: fl(1), Max: fl(0),
+		}})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "min must be less than max")
+	})
+}

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -2444,3 +2444,88 @@ func TestValidateConfigMetricWalkAndBounds(t *testing.T) {
 		assert.Contains(t, err.Error(), "min must be less than max")
 	})
 }
+
+func TestValidateConfigMetricInterval(t *testing.T) {
+	t.Parallel()
+
+	baseConfig := func(metrics []MetricConfig) *Config {
+		return &Config{
+			Version: 1,
+			Services: []ServiceConfig{{
+				Name:    "svc",
+				Metrics: metrics,
+				Operations: []OperationConfig{{
+					Name:     "op",
+					Duration: "50ms",
+				}},
+			}},
+			Traffic: TrafficConfig{Rate: "10/s"},
+		}
+	}
+
+	t.Run("interval counter with value is valid", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "gc.count", Type: "counter", Value: "1", Interval: "10s",
+		}})
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("interval histogram with value is valid", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "gc.pause", Type: "histogram", Unit: "ms", Value: "2.5 +/- 0.8", Interval: "10s",
+		}})
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("interval on gauge rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "cpu", Type: "gauge", Value: "0.5", Interval: "10s",
+		}})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "interval is not valid for gauge")
+	})
+
+	t.Run("interval without value rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "req.count", Type: "counter", Interval: "10s",
+		}})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "interval requires a value")
+	})
+
+	t.Run("interval with errors_only rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "err.count", Type: "counter", Value: "1", ErrorsOnly: true, Interval: "10s",
+		}})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "errors_only")
+	})
+
+	t.Run("invalid interval rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "gc.count", Type: "counter", Value: "1", Interval: "soon",
+		}})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid interval")
+	})
+
+	t.Run("non-positive interval rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{
+			Name: "gc.count", Type: "counter", Value: "1", Interval: "0s",
+		}})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "interval must be positive")
+	})
+}

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -126,6 +126,7 @@ func (e *Engine) Run(ctx context.Context) (*Stats, error) {
 	var stats Stats
 	startTime := time.Now()
 	deadline := startTime.Add(e.Duration)
+	var lastActive []Scenario
 
 	for {
 		select {
@@ -161,7 +162,13 @@ func (e *Engine) Run(ctx context.Context) (*Stats, error) {
 					}
 				}
 			}
-			notifyOverrides(e.Observers, overrides)
+			// Scenario contents are static, so the merged overrides only
+			// change when the active set does — notify observers on
+			// transitions rather than every iteration.
+			if !activeScenariosEqual(active, lastActive) {
+				notifyOverrides(e.Observers, overrides)
+				lastActive = active
+			}
 		}
 
 		rate := trafficPattern.Rate(elapsed)
@@ -242,6 +249,7 @@ func (e *Engine) runRealtime(ctx context.Context) (*Stats, error) {
 	sem := make(chan struct{}, e.maxInFlightTraces())
 
 	var rstats realtimeStats
+	var lastActive []Scenario
 
 	intervalTimer := time.NewTimer(0)
 	defer intervalTimer.Stop()
@@ -284,7 +292,13 @@ func (e *Engine) runRealtime(ctx context.Context) (*Stats, error) {
 					}
 				}
 			}
-			notifyOverrides(e.Observers, overrides)
+			// Scenario contents are static, so the merged overrides only
+			// change when the active set does — notify observers on
+			// transitions rather than every iteration.
+			if !activeScenariosEqual(active, lastActive) {
+				notifyOverrides(e.Observers, overrides)
+				lastActive = active
+			}
 		}
 
 		rate := trafficPattern.Rate(elapsed)
@@ -662,6 +676,14 @@ func (e *Engine) executeCall(ctx context.Context, call Call, callStart time.Time
 	}
 
 	return callStart, true // unreachable: loop always returns on final iteration
+}
+
+// activeScenariosEqual reports whether two active scenario sets are the same.
+// Used to skip redundant observer notifications between activation transitions.
+func activeScenariosEqual(a, b []Scenario) bool {
+	return slices.EqualFunc(a, b, func(x, y Scenario) bool {
+		return x.Name == y.Name && x.Start == y.Start && x.End == y.End && x.Priority == y.Priority
+	})
 }
 
 // isRoot checks whether an operation is a root (entry point) in the topology.

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -161,6 +161,7 @@ func (e *Engine) Run(ctx context.Context) (*Stats, error) {
 					}
 				}
 			}
+			notifyOverrides(e.Observers, overrides)
 		}
 
 		rate := trafficPattern.Rate(elapsed)
@@ -283,6 +284,7 @@ func (e *Engine) runRealtime(ctx context.Context) (*Stats, error) {
 					}
 				}
 			}
+			notifyOverrides(e.Observers, overrides)
 		}
 
 		rate := trafficPattern.Rate(elapsed)

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -28,15 +28,17 @@ type metricInstrument struct {
 	value      *FloatDistribution // nil = span-derived
 	unit       string
 	attrGens   map[string]AttributeGenerator
-	operation  string // non-empty if operation-level (fires only for this op)
-	errorsOnly bool   // if true, counter only increments for error spans
+	operation  string        // non-empty if operation-level (fires only for this op)
+	errorsOnly bool          // if true, counter only increments for error spans
+	interval   time.Duration // non-zero = emit on a wall-clock timer instead of per span
 }
 
 // MetricObserver records derived metrics for each observed span.
 type MetricObserver struct {
-	services map[string][]metricInstrument
-	rng      *rand.Rand
-	mu       sync.Mutex
+	services  map[string][]metricInstrument
+	intervals []metricInstrument // emitted on their own timers, not per span
+	rng       *rand.Rand
+	mu        sync.Mutex
 
 	overrideMu sync.RWMutex
 	overrides  map[string]Override // active scenario overrides, set by the engine
@@ -64,7 +66,10 @@ func NewMetricObserver(meters map[string]metric.Meter, topo *Topology, rng *rand
 			if err != nil {
 				return nil, err
 			}
-			if keep {
+			switch {
+			case keep && inst.interval > 0:
+				m.intervals = append(m.intervals, inst)
+			case keep:
 				instruments = append(instruments, inst)
 			}
 		}
@@ -76,7 +81,10 @@ func NewMetricObserver(meters map[string]metric.Meter, topo *Topology, rng *rand
 				if err != nil {
 					return nil, err
 				}
-				if keep {
+				switch {
+				case keep && inst.interval > 0:
+					m.intervals = append(m.intervals, inst)
+				case keep:
 					instruments = append(instruments, inst)
 				}
 			}
@@ -130,6 +138,7 @@ func (m *MetricObserver) createInstrument(meter metric.Meter, md MetricDefinitio
 		attrGens:   md.Attributes,
 		operation:  operation,
 		errorsOnly: md.ErrorsOnly,
+		interval:   md.Interval,
 	}
 
 	switch md.Type {
@@ -213,6 +222,58 @@ func (m *MetricObserver) createInstrument(meter metric.Meter, md MetricDefinitio
 	}
 
 	return inst, true, nil
+}
+
+// Start launches background emitters for interval-driven metrics: one
+// goroutine per instrument with an interval field, each recording a sampled
+// value on its own wall-clock ticker, independent of trace rate. The returned
+// stop function halts the emitters and waits for them to exit. Call it before
+// shutting down the meter providers. Returns a no-op when no interval metrics
+// are defined.
+func (m *MetricObserver) Start() (stop func()) {
+	if len(m.intervals) == 0 {
+		return func() {}
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range m.intervals {
+		inst := &m.intervals[i]
+		wg.Go(func() {
+			ticker := time.NewTicker(inst.interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-done:
+					return
+				case <-ticker.C:
+					m.recordInterval(inst)
+				}
+			}
+		})
+	}
+
+	return func() {
+		close(done)
+		wg.Wait()
+	}
+}
+
+// recordInterval records one sampled measurement for an interval-driven instrument.
+func (m *MetricObserver) recordInterval(inst *metricInstrument) {
+	m.mu.Lock()
+	attrs := buildMetricAttrs(inst.attrGens, inst.operation, m.rng)
+	sampledValue := m.effectiveValue(inst.scopeRef, inst.name, inst.value).Sample(m.rng)
+	m.mu.Unlock()
+
+	switch {
+	case inst.float64Counter != nil:
+		inst.float64Counter.Add(context.Background(), max(0, sampledValue), attrs)
+	case inst.float64UpDownCounter != nil:
+		inst.float64UpDownCounter.Add(context.Background(), sampledValue, attrs)
+	case inst.float64Histogram != nil:
+		inst.float64Histogram.Record(context.Background(), sampledValue, attrs)
+	}
 }
 
 // gaugeCallback returns the observation callback for a topology-defined gauge.

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -107,19 +107,21 @@ func (m *MetricObserver) SetOverrides(overrides map[string]Override) {
 }
 
 // effectiveValue returns the value distribution for a metric, applying any
-// active scenario override for its scope. Returns nil for span-derived metrics.
-func (m *MetricObserver) effectiveValue(scopeRef, name string, base *FloatDistribution) *FloatDistribution {
+// active scenario override for its scope. Returns false for span-derived
+// metrics, which have no value distribution. Returned by value to avoid a
+// heap allocation on the per-span hot path.
+func (m *MetricObserver) effectiveValue(scopeRef, name string, base *FloatDistribution) (FloatDistribution, bool) {
 	if base == nil {
-		return nil
+		return FloatDistribution{}, false
 	}
 	m.overrideMu.RLock()
 	defer m.overrideMu.RUnlock()
 	if ov, ok := m.overrides[scopeRef]; ok {
 		if dist, ok := ov.Metrics[name]; ok {
-			return &dist
+			return dist, true
 		}
 	}
-	return base
+	return *base, true
 }
 
 // createInstrument builds a metricInstrument from a MetricDefinition.
@@ -263,7 +265,8 @@ func (m *MetricObserver) Start() (stop func()) {
 func (m *MetricObserver) recordInterval(inst *metricInstrument) {
 	m.mu.Lock()
 	attrs := buildMetricAttrs(inst.attrGens, inst.operation, m.rng)
-	sampledValue := m.effectiveValue(inst.scopeRef, inst.name, inst.value).Sample(m.rng)
+	dist, _ := m.effectiveValue(inst.scopeRef, inst.name, inst.value)
+	sampledValue := dist.Sample(m.rng)
 	m.mu.Unlock()
 
 	switch {
@@ -294,7 +297,7 @@ func (m *MetricObserver) gaugeCallback(md MetricDefinition, scopeRef, operation 
 		// during collection and cannot share the observer's rng.
 		rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // synthetic data
 		attrs := buildMetricAttrs(md.Attributes, operation, rng)
-		dist := m.effectiveValue(scopeRef, md.Name, base)
+		dist, _ := m.effectiveValue(scopeRef, md.Name, base)
 
 		if md.Walk <= 0 {
 			obs.Observe(clampValue(dist.Sample(rng), md.Min, md.Max), attrs)
@@ -369,7 +372,7 @@ func (m *MetricObserver) Observe(info SpanInfo) {
 		m.mu.Lock()
 		attrs := buildMetricAttrs(inst.attrGens, info.Operation, m.rng)
 		var sampledValue float64
-		if dist := m.effectiveValue(inst.scopeRef, inst.name, inst.value); dist != nil {
+		if dist, ok := m.effectiveValue(inst.scopeRef, inst.name, inst.value); ok {
 			sampledValue = dist.Sample(m.rng)
 		}
 		m.mu.Unlock()

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -22,6 +22,8 @@ type metricInstrument struct {
 	float64Histogram     metric.Float64Histogram
 	float64UpDownCounter metric.Float64UpDownCounter
 
+	name       string
+	scopeRef   string             // service name or "service.operation" — key into scenario overrides
 	value      *FloatDistribution // nil = span-derived
 	unit       string
 	attrGens   map[string]AttributeGenerator
@@ -34,12 +36,18 @@ type MetricObserver struct {
 	services map[string][]metricInstrument
 	rng      *rand.Rand
 	mu       sync.Mutex
+
+	overrideMu sync.RWMutex
+	overrides  map[string]Override // active scenario overrides, set by the engine
 }
 
 // NewMetricObserver creates a MetricObserver from topology metric definitions.
 // Each meter should carry a resource with the correct service.name for its service.
 func NewMetricObserver(meters map[string]metric.Meter, topo *Topology, rng *rand.Rand) (*MetricObserver, error) {
-	services := make(map[string][]metricInstrument)
+	m := &MetricObserver{
+		services: make(map[string][]metricInstrument),
+		rng:      rng,
+	}
 
 	for svcName, svc := range topo.Services {
 		meter := meters[svcName]
@@ -51,7 +59,7 @@ func NewMetricObserver(meters map[string]metric.Meter, topo *Topology, rng *rand
 
 		// Service-level metrics (fire for every span in this service)
 		for _, md := range svc.Metrics {
-			inst, keep, err := createInstrument(meter, md, "")
+			inst, keep, err := m.createInstrument(meter, md, svcName, "")
 			if err != nil {
 				return nil, err
 			}
@@ -63,7 +71,7 @@ func NewMetricObserver(meters map[string]metric.Meter, topo *Topology, rng *rand
 		// Operation-level metrics (fire only for the specific operation)
 		for _, op := range svc.Operations {
 			for _, md := range op.Metrics {
-				inst, keep, err := createInstrument(meter, md, op.Name)
+				inst, keep, err := m.createInstrument(meter, md, svcName, op.Name)
 				if err != nil {
 					return nil, err
 				}
@@ -74,18 +82,48 @@ func NewMetricObserver(meters map[string]metric.Meter, topo *Topology, rng *rand
 		}
 
 		if len(instruments) > 0 {
-			services[svcName] = instruments
+			m.services[svcName] = instruments
 		}
 	}
 
-	return &MetricObserver{services: services, rng: rng}, nil
+	return m, nil
+}
+
+// SetOverrides replaces the active scenario overrides. The engine calls this
+// as scenario windows open and close; a nil map clears all overrides.
+func (m *MetricObserver) SetOverrides(overrides map[string]Override) {
+	m.overrideMu.Lock()
+	m.overrides = overrides
+	m.overrideMu.Unlock()
+}
+
+// effectiveValue returns the value distribution for a metric, applying any
+// active scenario override for its scope. Returns nil for span-derived metrics.
+func (m *MetricObserver) effectiveValue(scopeRef, name string, base *FloatDistribution) *FloatDistribution {
+	if base == nil {
+		return nil
+	}
+	m.overrideMu.RLock()
+	defer m.overrideMu.RUnlock()
+	if ov, ok := m.overrides[scopeRef]; ok {
+		if dist, ok := ov.Metrics[name]; ok {
+			return &dist
+		}
+	}
+	return base
 }
 
 // createInstrument builds a metricInstrument from a MetricDefinition.
 // Returns (inst, true, nil) for instruments that should be appended to the observer's list.
 // Returns (inst, false, nil) for gauge types — the callback handles everything; no instrument entry is needed.
-func createInstrument(meter metric.Meter, md MetricDefinition, operation string) (metricInstrument, bool, error) {
+func (m *MetricObserver) createInstrument(meter metric.Meter, md MetricDefinition, service, operation string) (metricInstrument, bool, error) {
+	scopeRef := service
+	if operation != "" {
+		scopeRef = service + "." + operation
+	}
 	inst := metricInstrument{
+		name:       md.Name,
+		scopeRef:   scopeRef,
 		value:      md.Value,
 		unit:       md.Unit,
 		attrGens:   md.Attributes,
@@ -165,7 +203,9 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 		}
 		// The gauge callback fires on collection, not per span.
 		// No instrument entry is needed.
-		dist := md.Value
+		base := md.Value
+		gaugeName := md.Name
+		gaugeScope := scopeRef
 		gaugeAttrs := md.Attributes
 		gaugeOp := operation
 		gopts = append(gopts, metric.WithFloat64Callback(func(_ context.Context, obs metric.Float64Observer) error {
@@ -173,6 +213,7 @@ func createInstrument(meter metric.Meter, md MetricDefinition, operation string)
 			// during collection and cannot share the observer's rng.
 			rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // synthetic data
 			attrs := buildMetricAttrs(gaugeAttrs, gaugeOp, rng)
+			dist := m.effectiveValue(gaugeScope, gaugeName, base)
 			obs.Observe(dist.Sample(rng), attrs)
 			return nil
 		}))
@@ -222,8 +263,8 @@ func (m *MetricObserver) Observe(info SpanInfo) {
 		m.mu.Lock()
 		attrs := buildMetricAttrs(inst.attrGens, info.Operation, m.rng)
 		var sampledValue float64
-		if inst.value != nil {
-			sampledValue = inst.value.Sample(m.rng)
+		if dist := m.effectiveValue(inst.scopeRef, inst.name, inst.value); dist != nil {
+			sampledValue = dist.Sample(m.rng)
 		}
 		m.mu.Unlock()
 

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -5,6 +5,7 @@ package synth
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand/v2"
 	"sync"
 	"time"
@@ -203,20 +204,7 @@ func (m *MetricObserver) createInstrument(meter metric.Meter, md MetricDefinitio
 		}
 		// The gauge callback fires on collection, not per span.
 		// No instrument entry is needed.
-		base := md.Value
-		gaugeName := md.Name
-		gaugeScope := scopeRef
-		gaugeAttrs := md.Attributes
-		gaugeOp := operation
-		gopts = append(gopts, metric.WithFloat64Callback(func(_ context.Context, obs metric.Float64Observer) error {
-			// Create a fresh rng inside the callback — it runs asynchronously
-			// during collection and cannot share the observer's rng.
-			rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // synthetic data
-			attrs := buildMetricAttrs(gaugeAttrs, gaugeOp, rng)
-			dist := m.effectiveValue(gaugeScope, gaugeName, base)
-			obs.Observe(dist.Sample(rng), attrs)
-			return nil
-		}))
+		gopts = append(gopts, metric.WithFloat64Callback(m.gaugeCallback(md, scopeRef, operation)))
 		_, err := meter.Float64ObservableGauge(md.Name, gopts...)
 		if err != nil {
 			return metricInstrument{}, false, err
@@ -225,6 +213,63 @@ func (m *MetricObserver) createInstrument(meter metric.Meter, md MetricDefinitio
 	}
 
 	return inst, true, nil
+}
+
+// gaugeCallback returns the observation callback for a topology-defined gauge.
+// Without walk, each collection samples independently from the value
+// distribution (white noise). With walk, samples follow an Ornstein-Uhlenbeck
+// process: a mean-reverting random walk whose stationary distribution matches
+// the configured mean and standard deviation, with mean-reversion timescale
+// md.Walk. Walk timescales relate to wall-clock time between collections.
+func (m *MetricObserver) gaugeCallback(md MetricDefinition, scopeRef, operation string) metric.Float64Callback {
+	base := md.Value
+	// Walk state persists across collection cycles in this closure.
+	var walkMu sync.Mutex
+	var current float64
+	var lastSample time.Time
+
+	return func(_ context.Context, obs metric.Float64Observer) error {
+		// Create a fresh rng inside the callback — it runs asynchronously
+		// during collection and cannot share the observer's rng.
+		rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // synthetic data
+		attrs := buildMetricAttrs(md.Attributes, operation, rng)
+		dist := m.effectiveValue(scopeRef, md.Name, base)
+
+		if md.Walk <= 0 {
+			obs.Observe(clampValue(dist.Sample(rng), md.Min, md.Max), attrs)
+			return nil
+		}
+
+		walkMu.Lock()
+		now := time.Now()
+		if lastSample.IsZero() {
+			current = dist.Sample(rng)
+		} else {
+			// Exact OU discretisation: decay toward the mean over the elapsed
+			// interval, plus noise scaled so the stationary std dev is dist.StdDev.
+			decay := math.Exp(-now.Sub(lastSample).Seconds() / md.Walk.Seconds())
+			current = dist.Mean + (current-dist.Mean)*decay +
+				dist.StdDev*math.Sqrt(1-decay*decay)*rng.NormFloat64()
+		}
+		lastSample = now
+		current = clampValue(current, md.Min, md.Max)
+		value := current
+		walkMu.Unlock()
+
+		obs.Observe(value, attrs)
+		return nil
+	}
+}
+
+// clampValue restricts v to the optional [min, max] bounds.
+func clampValue(v float64, minBound, maxBound *float64) float64 {
+	if minBound != nil && v < *minBound {
+		v = *minBound
+	}
+	if maxBound != nil && v > *maxBound {
+		v = *maxBound
+	}
+	return v
 }
 
 // buildMetricAttrs constructs metric attributes from generators and adds operation.name.

--- a/pkg/synth/metrics_test.go
+++ b/pkg/synth/metrics_test.go
@@ -648,3 +648,91 @@ traffic:
 	require.Len(t, cntSum.DataPoints, 1)
 	assert.Greater(t, cntSum.DataPoints[0].Value, 0.0)
 }
+
+func TestMetricObserverGaugeWalkCorrelation(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	// With a very long mean-reversion timescale and back-to-back collections,
+	// the decay factor is ~1 and the noise term ~0, so consecutive samples
+	// must be nearly identical — unlike independent sampling, where draws
+	// from N(0.5, 0.2) differ.
+	dist := FloatDistribution{Mean: 0.5, StdDev: 0.2}
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "cpu", Type: "gauge", Value: &dist, Walk: time.Hour},
+	}, "op", nil)
+
+	_, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	readGauge := func() float64 {
+		rm := collectMetrics(t, reader)
+		m := findMetric(rm, "cpu")
+		require.NotNil(t, m)
+		gauge, ok := m.Data.(metricdata.Gauge[float64])
+		require.True(t, ok)
+		require.Len(t, gauge.DataPoints, 1)
+		return gauge.DataPoints[0].Value
+	}
+
+	first := readGauge()
+	second := readGauge()
+	assert.InDelta(t, first, second, 0.01, "walk samples collected back-to-back should be strongly correlated")
+}
+
+func TestMetricObserverGaugeWalkMeanReversion(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	// Zero stddev: the walk has no noise, so every sample equals the mean.
+	dist := FloatDistribution{Mean: 42, StdDev: 0}
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "depth", Type: "gauge", Value: &dist, Walk: time.Second},
+	}, "op", nil)
+
+	_, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	for range 3 {
+		rm := collectMetrics(t, reader)
+		m := findMetric(rm, "depth")
+		require.NotNil(t, m)
+		gauge := m.Data.(metricdata.Gauge[float64])
+		assert.InDelta(t, 42.0, gauge.DataPoints[0].Value, 0.001)
+	}
+}
+
+func TestMetricObserverGaugeBounds(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	lower, upper := 0.0, 1.0
+	// Mean near the upper bound with huge variance: unclamped samples
+	// frequently land outside [0, 1].
+	dist := FloatDistribution{Mean: 0.9, StdDev: 10}
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "util", Type: "gauge", Value: &dist, Min: &lower, Max: &upper},
+	}, "op", nil)
+
+	_, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	for range 10 {
+		rm := collectMetrics(t, reader)
+		m := findMetric(rm, "util")
+		require.NotNil(t, m)
+		gauge := m.Data.(metricdata.Gauge[float64])
+		v := gauge.DataPoints[0].Value
+		assert.GreaterOrEqual(t, v, lower)
+		assert.LessOrEqual(t, v, upper)
+	}
+}

--- a/pkg/synth/metrics_test.go
+++ b/pkg/synth/metrics_test.go
@@ -466,6 +466,104 @@ func TestMetricObserverErrorsOnly(t *testing.T) {
 	assert.Equal(t, int64(1), sum.DataPoints[0].Value, "only error spans should increment the counter")
 }
 
+func TestMetricObserverScenarioOverrideCounter(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	dist := FloatDistribution{Mean: 10, StdDev: 0}
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "bytes.sent", Type: "counter", Value: &dist},
+	}, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: time.Millisecond})
+
+	// Activate a service-scope override
+	obs.SetOverrides(map[string]Override{
+		"svc": {Metrics: map[string]FloatDistribution{"bytes.sent": {Mean: 100, StdDev: 0}}},
+	})
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: time.Millisecond})
+
+	// Clear overrides — back to the base distribution
+	obs.SetOverrides(nil)
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: time.Millisecond})
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "bytes.sent")
+	require.NotNil(t, m)
+
+	sum, ok := m.Data.(metricdata.Sum[float64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	assert.InDelta(t, 120.0, sum.DataPoints[0].Value, 0.1, "10 base + 100 overridden + 10 base")
+}
+
+func TestMetricObserverScenarioOverrideGauge(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	dist := FloatDistribution{Mean: 0.4, StdDev: 0}
+	topo := testTopology("svc", nil, "op", []MetricDefinition{
+		{Name: "cache.hit_ratio", Type: "gauge", Value: &dist},
+	})
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "cache.hit_ratio")
+	require.NotNil(t, m)
+	gauge := m.Data.(metricdata.Gauge[float64])
+	assert.InDelta(t, 0.4, gauge.DataPoints[0].Value, 0.001)
+
+	// Operation-scope override changes the value observed at the next collection
+	obs.SetOverrides(map[string]Override{
+		"svc.op": {Metrics: map[string]FloatDistribution{"cache.hit_ratio": {Mean: 0.05, StdDev: 0}}},
+	})
+
+	rm = collectMetrics(t, reader)
+	m = findMetric(rm, "cache.hit_ratio")
+	require.NotNil(t, m)
+	gauge = m.Data.(metricdata.Gauge[float64])
+	assert.InDelta(t, 0.05, gauge.DataPoints[0].Value, 0.001)
+}
+
+func TestMetricObserverOverrideOtherScopeIgnored(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	dist := FloatDistribution{Mean: 10, StdDev: 0}
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "bytes.sent", Type: "counter", Value: &dist},
+	}, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	// Override targets a different scope (operation, not service) — no effect
+	obs.SetOverrides(map[string]Override{
+		"svc.op": {Metrics: map[string]FloatDistribution{"bytes.sent": {Mean: 100, StdDev: 0}}},
+	})
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: time.Millisecond})
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "bytes.sent")
+	require.NotNil(t, m)
+	sum := m.Data.(metricdata.Sum[float64])
+	assert.InDelta(t, 10.0, sum.DataPoints[0].Value, 0.1, "service-scope metric ignores operation-scope override")
+}
+
 // TestMetricObserverEndToEnd verifies the full path: YAML → LoadConfig → BuildTopology →
 // NewMetricObserver → Observe → collect. Tests all four instrument types.
 func TestMetricObserverEndToEnd(t *testing.T) {

--- a/pkg/synth/metrics_test.go
+++ b/pkg/synth/metrics_test.go
@@ -736,3 +736,134 @@ func TestMetricObserverGaugeBounds(t *testing.T) {
 		assert.LessOrEqual(t, v, upper)
 	}
 }
+
+func TestMetricObserverIntervalCounter(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	dist := FloatDistribution{Mean: 5, StdDev: 0}
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "gc.count", Type: "counter", Value: &dist, Interval: 10 * time.Millisecond},
+	}, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	stop := obs.Start()
+	t.Cleanup(stop)
+
+	// No spans observed — emission is driven purely by the timer.
+	require.Eventually(t, func() bool {
+		rm := collectMetrics(t, reader)
+		m := findMetric(rm, "gc.count")
+		if m == nil {
+			return false
+		}
+		sum, ok := m.Data.(metricdata.Sum[float64])
+		return ok && len(sum.DataPoints) == 1 && sum.DataPoints[0].Value >= 10
+	}, 2*time.Second, 10*time.Millisecond, "interval counter should accumulate without any spans")
+
+	// Span observation must not double-record interval instruments.
+	before := func() float64 {
+		rm := collectMetrics(t, reader)
+		m := findMetric(rm, "gc.count")
+		require.NotNil(t, m)
+		return m.Data.(metricdata.Sum[float64]).DataPoints[0].Value
+	}()
+	obs.Observe(SpanInfo{Service: "svc", Operation: "op", Duration: time.Millisecond})
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "gc.count")
+	require.NotNil(t, m)
+	after := m.Data.(metricdata.Sum[float64]).DataPoints[0].Value
+	assert.Less(t, after-before, 5.0, "Observe must not record interval-driven instruments")
+}
+
+func TestMetricObserverIntervalHistogram(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	dist := FloatDistribution{Mean: 2.5, StdDev: 0}
+	topo := testTopology("svc", nil, "op", []MetricDefinition{
+		{Name: "gc.pause", Type: "histogram", Unit: "ms", Value: &dist, Interval: 10 * time.Millisecond},
+	})
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	stop := obs.Start()
+	t.Cleanup(stop)
+
+	require.Eventually(t, func() bool {
+		rm := collectMetrics(t, reader)
+		m := findMetric(rm, "gc.pause")
+		if m == nil {
+			return false
+		}
+		hist, ok := m.Data.(metricdata.Histogram[float64])
+		return ok && len(hist.DataPoints) == 1 && hist.DataPoints[0].Count >= 2
+	}, 2*time.Second, 10*time.Millisecond)
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "gc.pause")
+	hist := m.Data.(metricdata.Histogram[float64])
+	dp := hist.DataPoints[0]
+	assert.InDelta(t, 2.5, dp.Sum/float64(dp.Count), 0.001, "each tick records the sampled value")
+
+	// Operation-level interval metrics carry the operation.name attribute.
+	expected := attribute.NewSet(attribute.String("operation.name", "op"))
+	assert.True(t, dp.Attributes.Equals(&expected), "got %v", dp.Attributes)
+}
+
+func TestMetricObserverIntervalStop(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	dist := FloatDistribution{Mean: 1, StdDev: 0}
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "tick.count", Type: "counter", Value: &dist, Interval: 5 * time.Millisecond},
+	}, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	stop := obs.Start()
+	require.Eventually(t, func() bool {
+		rm := collectMetrics(t, reader)
+		return findMetric(rm, "tick.count") != nil
+	}, 2*time.Second, 5*time.Millisecond)
+	stop()
+
+	rm := collectMetrics(t, reader)
+	before := findMetric(rm, "tick.count").Data.(metricdata.Sum[float64]).DataPoints[0].Value
+	time.Sleep(30 * time.Millisecond)
+	rm = collectMetrics(t, reader)
+	after := findMetric(rm, "tick.count").Data.(metricdata.Sum[float64]).DataPoints[0].Value
+	assert.Equal(t, before, after, "no emission after stop")
+}
+
+func TestMetricObserverStartNoIntervals(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	topo := testTopology("svc", []MetricDefinition{
+		{Name: "req.count", Type: "counter"},
+	}, "op", nil)
+
+	obs, err := NewMetricObserver(testMeters(mp, "svc"), topo, testRng())
+	require.NoError(t, err)
+
+	stop := obs.Start()
+	stop() // must not panic or block
+}

--- a/pkg/synth/observer.go
+++ b/pkg/synth/observer.go
@@ -41,6 +41,24 @@ func notifySpanStart(observers []SpanObserver, service, operation string) {
 	}
 }
 
+// OverrideObserver receives the currently active scenario overrides.
+// Observers whose output depends on scenario state (e.g. metric value
+// overrides) implement this. The engine calls SetOverrides with the merged
+// overrides for the current simulation time; a nil map means no scenario
+// is active.
+type OverrideObserver interface {
+	SetOverrides(overrides map[string]Override)
+}
+
+// notifyOverrides dispatches SetOverrides to all observers that implement OverrideObserver.
+func notifyOverrides(observers []SpanObserver, overrides map[string]Override) {
+	for _, obs := range observers {
+		if oo, ok := obs.(OverrideObserver); ok {
+			oo.SetOverrides(overrides)
+		}
+	}
+}
+
 // newSpanInfo constructs a SpanInfo from its component fields.
 func newSpanInfo(service, operation string, timestamp time.Time, duration time.Duration, isError bool, kind trace.SpanKind, attrs []attribute.KeyValue, scenarios []string) SpanInfo {
 	return SpanInfo{

--- a/pkg/synth/scenario.go
+++ b/pkg/synth/scenario.go
@@ -21,7 +21,7 @@ type Scenario struct {
 	Traffic   TrafficPattern
 }
 
-// Override holds resolved per-operation overrides within a scenario.
+// Override holds resolved per-operation or per-service overrides within a scenario.
 type Override struct {
 	Duration     Distribution
 	ErrorRate    float64
@@ -29,6 +29,7 @@ type Override struct {
 	Attributes   map[string]AttributeGenerator
 	AddCalls     []Call
 	RemoveCalls  map[string]bool
+	Metrics      map[string]FloatDistribution
 }
 
 // ParseOffset parses a time offset string like "+5m" or "30s" into a duration.
@@ -116,6 +117,16 @@ func BuildScenarios(cfgs []ScenarioConfig, topo *Topology) ([]Scenario, error) {
 				o.RemoveCalls = make(map[string]bool, len(ov.RemoveCalls))
 				for _, rc := range ov.RemoveCalls {
 					o.RemoveCalls[rc.Target] = true
+				}
+			}
+			if len(ov.Metrics) > 0 {
+				o.Metrics = make(map[string]FloatDistribution, len(ov.Metrics))
+				for name, mo := range ov.Metrics {
+					dist, distErr := ParseFloatDistribution(mo.Value)
+					if distErr != nil {
+						return nil, fmt.Errorf("scenario %q override %q: metric %q: %w", cfg.Name, ref, name, distErr)
+					}
+					o.Metrics[name] = dist
 				}
 			}
 			overrides[ref] = o
@@ -280,6 +291,12 @@ func ResolveOverrides(active []Scenario) map[string]Override {
 					existing.RemoveCalls = make(map[string]bool, len(ov.RemoveCalls))
 				}
 				maps.Copy(existing.RemoveCalls, ov.RemoveCalls)
+			}
+			if len(ov.Metrics) > 0 {
+				newMetrics := make(map[string]FloatDistribution, len(existing.Metrics)+len(ov.Metrics))
+				maps.Copy(newMetrics, existing.Metrics)
+				maps.Copy(newMetrics, ov.Metrics)
+				existing.Metrics = newMetrics
 			}
 			merged[ref] = existing
 		}

--- a/pkg/synth/scenario_test.go
+++ b/pkg/synth/scenario_test.go
@@ -790,3 +790,61 @@ func TestResolveOverridesMergesCallChanges(t *testing.T) {
 			"original scenario should not be mutated")
 	})
 }
+
+func TestResolveOverridesMergesMetrics(t *testing.T) {
+	t.Parallel()
+
+	scenarios := []Scenario{
+		{
+			Name: "low", Start: 0, End: time.Hour, Priority: 1,
+			Overrides: map[string]Override{
+				"svc": {Metrics: map[string]FloatDistribution{
+					"cpu": {Mean: 0.5},
+					"mem": {Mean: 0.3},
+				}},
+			},
+		},
+		{
+			Name: "high", Start: 0, End: time.Hour, Priority: 2,
+			Overrides: map[string]Override{
+				"svc": {Metrics: map[string]FloatDistribution{
+					"cpu": {Mean: 0.9},
+				}},
+			},
+		},
+	}
+
+	merged := ResolveOverrides(ActiveScenarios(scenarios, time.Minute))
+	require.Contains(t, merged, "svc")
+	assert.InDelta(t, 0.9, merged["svc"].Metrics["cpu"].Mean, 0.001, "higher priority wins per metric")
+	assert.InDelta(t, 0.3, merged["svc"].Metrics["mem"].Mean, 0.001, "unrelated metric preserved")
+
+	assert.InDelta(t, 0.5, scenarios[0].Overrides["svc"].Metrics["cpu"].Mean, 0.001,
+		"original scenario should not be mutated")
+}
+
+func TestBuildScenariosParsesMetricOverrides(t *testing.T) {
+	t.Parallel()
+
+	topo := &Topology{Services: map[string]*Service{
+		"svc": {Name: "svc", Operations: map[string]*Operation{}},
+	}}
+
+	scenarios, err := BuildScenarios([]ScenarioConfig{{
+		Name:     "cpu spike",
+		At:       "+1m",
+		Duration: "5m",
+		Override: map[string]OverrideConfig{
+			"svc": {Metrics: map[string]MetricOverrideConfig{
+				"cpu": {Value: "0.95 +/- 0.02"},
+			}},
+		},
+	}}, topo)
+	require.NoError(t, err)
+	require.Len(t, scenarios, 1)
+
+	dist, ok := scenarios[0].Overrides["svc"].Metrics["cpu"]
+	require.True(t, ok)
+	assert.InDelta(t, 0.95, dist.Mean, 0.001)
+	assert.InDelta(t, 0.02, dist.StdDev, 0.001)
+}

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -22,6 +22,7 @@ type MetricDefinition struct {
 	Type       string
 	Unit       string
 	Value      *FloatDistribution
+	Interval   time.Duration // emit on a timer instead of per span; zero = span-coupled
 	Walk       time.Duration // mean-reversion timescale for gauge random walk; zero = independent samples
 	Min        *float64      // optional lower bound for gauge values
 	Max        *float64      // optional upper bound for gauge values
@@ -299,6 +300,17 @@ func resolveMetrics(configs []MetricConfig, svcName, opName string) ([]MetricDef
 				return nil, fmt.Errorf("%s: metric %q: invalid walk: %w", ctx, mc.Name, err)
 			}
 			def.Walk = walk
+		}
+		if mc.Interval != "" {
+			interval, err := time.ParseDuration(mc.Interval)
+			if err != nil {
+				ctx := fmt.Sprintf("service %q", svcName)
+				if opName != "" {
+					ctx = fmt.Sprintf("service %q operation %q", svcName, opName)
+				}
+				return nil, fmt.Errorf("%s: metric %q: invalid interval: %w", ctx, mc.Name, err)
+			}
+			def.Interval = interval
 		}
 		if mc.Value != "" {
 			dist, err := ParseFloatDistribution(mc.Value)

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -22,6 +22,9 @@ type MetricDefinition struct {
 	Type       string
 	Unit       string
 	Value      *FloatDistribution
+	Walk       time.Duration // mean-reversion timescale for gauge random walk; zero = independent samples
+	Min        *float64      // optional lower bound for gauge values
+	Max        *float64      // optional upper bound for gauge values
 	ErrorsOnly bool
 	Attributes map[string]AttributeGenerator
 }
@@ -282,7 +285,20 @@ func resolveMetrics(configs []MetricConfig, svcName, opName string) ([]MetricDef
 			Name:       mc.Name,
 			Type:       mc.Type,
 			Unit:       mc.Unit,
+			Min:        mc.Min,
+			Max:        mc.Max,
 			ErrorsOnly: mc.ErrorsOnly,
+		}
+		if mc.Walk != "" {
+			walk, err := time.ParseDuration(mc.Walk)
+			if err != nil {
+				ctx := fmt.Sprintf("service %q", svcName)
+				if opName != "" {
+					ctx = fmt.Sprintf("service %q operation %q", svcName, opName)
+				}
+				return nil, fmt.Errorf("%s: metric %q: invalid walk: %w", ctx, mc.Name, err)
+			}
+			def.Walk = walk
 		}
 		if mc.Value != "" {
 			dist, err := ParseFloatDistribution(mc.Value)


### PR DESCRIPTION
Completes the topology-driven metrics feature from PR 135 by implementing the four follow-up issues, one commit each.

## Scenario overrides for metric values (closes #136)

Scenarios can override a metric's `value` distribution during their window, at operation scope (`gateway.handle`) or service scope (bare `gateway`, metrics only):

```yaml
scenarios:
  - name: cpu spike
    at: +2m
    duration: 5m
    override:
      gateway:
        metrics:
          gateway.cpu.utilisation:
            value: 0.95 +/- 0.02
```

The engine pushes resolved overrides to observers each cycle via a new `OverrideObserver` interface; `MetricObserver` applies them when sampling values for counters, updowncounters, histograms, and gauge callbacks. Overlapping scenarios merge per metric name with the existing priority semantics. Validation rejects overrides of span-derived metrics, metrics not defined at the scope, and non-metric fields on service-scope keys.

## Random-walk gauge values (closes #139)

Gauges gain an optional `walk:` mean-reversion timescale that replaces independent per-collection samples with an Ornstein-Uhlenbeck process — consecutive samples are temporally correlated while the stationary distribution still matches the configured mean and standard deviation. Optional `min`/`max` bounds clamp gauge values:

```yaml
- name: gateway.cpu.utilisation
  type: gauge
  value: 0.65 +/- 0.1
  walk: 30s
  min: 0
  max: 1
```

White noise remains the default; walk timescales relate to wall-clock time between collections.

## Rate-driven independent metrics (closes #137)

Topology-defined counters, updowncounters, and histograms accept an `interval:` field that emits sampled values on a wall-clock ticker instead of per span, so a service with no traffic still produces metric data:

```yaml
- name: gateway.gc.pause.duration
  type: histogram
  unit: ms
  value: 2.5 +/- 0.8
  interval: 10s
```

`MetricObserver.Start()` runs one emitter goroutine per interval instrument and stops cleanly before meter provider shutdown. Interval emitters honour scenario value overrides. Gauges (already collection-driven) and span-derived metrics reject `interval` at validation.

## Semconv-aware metric validation (closes #138)

`motel validate` now checks metric names against the vendored semantic convention registry. Where a name matches a known semconv metric, mismatched instrument types and units are reported as warnings on stderr — never errors, since users may intentionally deviate:

```
warning: service "gateway": metric "http.server.request.duration": unit "ms" does not match semantic convention unit "s"
```

Adds `Registry.MetricByName` to `pkg/semconv`. This caught non-compliant units in our own docs examples, which are updated to `unit: s` / `unit: "{request}"`. The semconv attribute shorthand extension mentioned in the issue is left for a separate change.

## Testing

- 28 new test cases across config validation, scenario merging, observer behaviour (override application, walk correlation and mean reversion, bounds clamping, interval emission and stop), the semconv registry, and the validate command
- Verified end to end: a topology combining a walking bounded gauge, an interval histogram, and a scenario override produces the expected values via `motel run --signals metrics --stdout`
- `make test` and `make lint` pass

https://claude.ai/code/session_01TgWavXRfzQiTWDZccuS2pf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgWavXRfzQiTWDZccuS2pf)_