### PR TITLE
Support time offset for metric timestamps

### DIFF
--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -136,7 +136,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().StringVar(&semconvDir, "semconv", "", "directory of additional semantic convention YAML files")
 	cmd.Flags().BoolVar(&labelScenarios, "label-scenarios", false, "add synth.scenarios attribute to spans with active scenario names")
 	cmd.Flags().StringVar(&pprofAddr, "pprof", "", "start pprof HTTP server on this address (e.g. :6060)")
-	cmd.Flags().DurationVar(&timeOffset, "time-offset", 0, "shift span timestamps by this duration (e.g. -1h for past, 1h for future)")
+	cmd.Flags().DurationVar(&timeOffset, "time-offset", 0, "shift span, metric, and log timestamps by this duration (e.g. -1h for past, 1h for future)")
 	cmd.Flags().BoolVar(&realtime, "realtime", false, "emit spans at wall-clock times matching simulated timestamps")
 
 	return cmd
@@ -753,7 +753,7 @@ func createMetricProviders(ctx context.Context, opts runOptions, resources map[s
 		return nil, func() {}, err
 	}
 
-	wrapper := &noopShutdownMetricExporter{exporter}
+	wrapper := &noopShutdownMetricExporter{synth.NewTimeOffsetMetricExporter(exporter, opts.timeOffset)}
 	providers := make([]*sdkmetric.MeterProvider, 0, len(resources))
 	meters := make(map[string]metric.Meter, len(resources))
 

--- a/docs/demos/demo-time-offset.md
+++ b/docs/demos/demo-time-offset.md
@@ -4,7 +4,7 @@ _2026-02-25T08:34:44Z by Showboat 0.6.1_
 
 <!-- showboat-id: 74c2e19b-e96e-4f18-84df-aa7b7ecfd5fb -->
 
-The `--time-offset` flag shifts all trace span and log record timestamps by a fixed duration. Negative values move timestamps into the past; positive values move them into the future. This is useful for testing late-arrival handling in collectors, retention policy enforcement in backends, backfill pipelines, and out-of-order ingestion.
+The `--time-offset` flag shifts all trace span, metric data point, and log record timestamps by a fixed duration. Negative values move timestamps into the past; positive values move them into the future. This is useful for testing late-arrival handling in collectors, retention policy enforcement in backends, backfill pipelines, and out-of-order ingestion.
 
 ## The topology
 
@@ -78,9 +78,9 @@ YESTERDAY=$(date -u -v-1d +%Y-%m-%dT%H); build/motel run --stdout --duration 1s 
 log timestamp starts with yesterday: true
 ```
 
-## Metric timestamps are not shifted
+## Metric timestamps follow the offset
 
-The OpenTelemetry Metrics API does not support caller-supplied timestamps. Metric data points are timestamped at collection time by the SDK's PeriodicReader. This is a limitation of the [Metrics API spec](https://opentelemetry.io/docs/specs/otel/metrics/api/), and will be addressed for motel in [issue 99](https://github.com/andrewh/motel/issues/99).
+The OpenTelemetry [Metrics API spec](https://opentelemetry.io/docs/specs/otel/metrics/api/) does not support caller-supplied timestamps — data points are timestamped at collection time by the SDK's PeriodicReader. motel works around this with an exporter wrapper that rewrites `StartTime` and `Time` on every exported data point, so metric timestamps are shifted by the same offset as spans and logs.
 
 ## Scenario timing is unaffected
 

--- a/pkg/synth/metricoffset.go
+++ b/pkg/synth/metricoffset.go
@@ -1,0 +1,107 @@
+// Metric timestamp offsetting. The OTel Metrics API does not accept
+// caller-supplied timestamps — data points are timestamped at collection time
+// by the SDK reader. Rewriting timestamps at export time is the only way to
+// backdate metric data points without forking the SDK.
+package synth
+
+import (
+	"context"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// timeOffsetMetricExporter wraps a metric exporter and shifts StartTime, Time,
+// and exemplar timestamps on every exported data point by a fixed offset.
+type timeOffsetMetricExporter struct {
+	sdkmetric.Exporter
+	offset time.Duration
+}
+
+// NewTimeOffsetMetricExporter wraps exporter so that all exported metric data
+// point timestamps are shifted by offset. A zero offset returns the exporter
+// unchanged.
+func NewTimeOffsetMetricExporter(exporter sdkmetric.Exporter, offset time.Duration) sdkmetric.Exporter {
+	if offset == 0 {
+		return exporter
+	}
+	return &timeOffsetMetricExporter{Exporter: exporter, offset: offset}
+}
+
+func (e *timeOffsetMetricExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
+	shiftResourceMetrics(rm, e.offset)
+	return e.Exporter.Export(ctx, rm)
+}
+
+func shiftResourceMetrics(rm *metricdata.ResourceMetrics, offset time.Duration) {
+	for i := range rm.ScopeMetrics {
+		metrics := rm.ScopeMetrics[i].Metrics
+		for j := range metrics {
+			shiftAggregation(metrics[j].Data, offset)
+		}
+	}
+}
+
+// shiftAggregation mutates the data points of agg in place. The metricdata
+// aggregation types hold slices, so mutating elements through a copy of the
+// interface value updates the shared backing arrays.
+func shiftAggregation(agg metricdata.Aggregation, offset time.Duration) {
+	switch a := agg.(type) {
+	case metricdata.Gauge[int64]:
+		shiftDataPoints(a.DataPoints, offset)
+	case metricdata.Gauge[float64]:
+		shiftDataPoints(a.DataPoints, offset)
+	case metricdata.Sum[int64]:
+		shiftDataPoints(a.DataPoints, offset)
+	case metricdata.Sum[float64]:
+		shiftDataPoints(a.DataPoints, offset)
+	case metricdata.Histogram[int64]:
+		shiftHistogramDataPoints(a.DataPoints, offset)
+	case metricdata.Histogram[float64]:
+		shiftHistogramDataPoints(a.DataPoints, offset)
+	case metricdata.ExponentialHistogram[int64]:
+		shiftExponentialHistogramDataPoints(a.DataPoints, offset)
+	case metricdata.ExponentialHistogram[float64]:
+		shiftExponentialHistogramDataPoints(a.DataPoints, offset)
+	case metricdata.Summary:
+		shiftSummaryDataPoints(a.DataPoints, offset)
+	}
+}
+
+func shiftDataPoints[N int64 | float64](dps []metricdata.DataPoint[N], offset time.Duration) {
+	for i := range dps {
+		dps[i].StartTime = dps[i].StartTime.Add(offset)
+		dps[i].Time = dps[i].Time.Add(offset)
+		shiftExemplars(dps[i].Exemplars, offset)
+	}
+}
+
+func shiftHistogramDataPoints[N int64 | float64](dps []metricdata.HistogramDataPoint[N], offset time.Duration) {
+	for i := range dps {
+		dps[i].StartTime = dps[i].StartTime.Add(offset)
+		dps[i].Time = dps[i].Time.Add(offset)
+		shiftExemplars(dps[i].Exemplars, offset)
+	}
+}
+
+func shiftExponentialHistogramDataPoints[N int64 | float64](dps []metricdata.ExponentialHistogramDataPoint[N], offset time.Duration) {
+	for i := range dps {
+		dps[i].StartTime = dps[i].StartTime.Add(offset)
+		dps[i].Time = dps[i].Time.Add(offset)
+		shiftExemplars(dps[i].Exemplars, offset)
+	}
+}
+
+func shiftSummaryDataPoints(dps []metricdata.SummaryDataPoint, offset time.Duration) {
+	for i := range dps {
+		dps[i].StartTime = dps[i].StartTime.Add(offset)
+		dps[i].Time = dps[i].Time.Add(offset)
+	}
+}
+
+func shiftExemplars[N int64 | float64](es []metricdata.Exemplar[N], offset time.Duration) {
+	for i := range es {
+		es[i].Time = es[i].Time.Add(offset)
+	}
+}

--- a/pkg/synth/metricoffset_test.go
+++ b/pkg/synth/metricoffset_test.go
@@ -1,0 +1,175 @@
+// Tests for the time-offset metric exporter wrapper that shifts data point
+// timestamps at export time.
+package synth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// captureMetricExporter records the last exported ResourceMetrics.
+type captureMetricExporter struct {
+	exported *metricdata.ResourceMetrics
+}
+
+func (e *captureMetricExporter) Temporality(k sdkmetric.InstrumentKind) metricdata.Temporality {
+	return sdkmetric.DefaultTemporalitySelector(k)
+}
+
+func (e *captureMetricExporter) Aggregation(k sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.DefaultAggregationSelector(k)
+}
+
+func (e *captureMetricExporter) Export(_ context.Context, rm *metricdata.ResourceMetrics) error {
+	e.exported = rm
+	return nil
+}
+
+func (e *captureMetricExporter) ForceFlush(context.Context) error { return nil }
+
+func (e *captureMetricExporter) Shutdown(context.Context) error { return nil }
+
+func TestNewTimeOffsetMetricExporterZeroOffset(t *testing.T) {
+	t.Parallel()
+
+	capture := &captureMetricExporter{}
+	exporter := NewTimeOffsetMetricExporter(capture, 0)
+	assert.Same(t, capture, exporter, "zero offset should return the exporter unchanged")
+}
+
+func TestTimeOffsetMetricExporterShiftsAllDataPointTypes(t *testing.T) {
+	t.Parallel()
+
+	offset := -2 * time.Hour
+	start := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	end := start.Add(time.Minute)
+	exemplarTime := start.Add(30 * time.Second)
+
+	rm := &metricdata.ResourceMetrics{
+		ScopeMetrics: []metricdata.ScopeMetrics{{
+			Metrics: []metricdata.Metrics{
+				{Name: "gauge.int", Data: metricdata.Gauge[int64]{
+					DataPoints: []metricdata.DataPoint[int64]{{StartTime: start, Time: end}},
+				}},
+				{Name: "gauge.float", Data: metricdata.Gauge[float64]{
+					DataPoints: []metricdata.DataPoint[float64]{{StartTime: start, Time: end}},
+				}},
+				{Name: "sum.int", Data: metricdata.Sum[int64]{
+					DataPoints: []metricdata.DataPoint[int64]{{
+						StartTime: start,
+						Time:      end,
+						Exemplars: []metricdata.Exemplar[int64]{{Time: exemplarTime}},
+					}},
+				}},
+				{Name: "sum.float", Data: metricdata.Sum[float64]{
+					DataPoints: []metricdata.DataPoint[float64]{{StartTime: start, Time: end}},
+				}},
+				{Name: "hist.int", Data: metricdata.Histogram[int64]{
+					DataPoints: []metricdata.HistogramDataPoint[int64]{{
+						StartTime: start,
+						Time:      end,
+						Exemplars: []metricdata.Exemplar[int64]{{Time: exemplarTime}},
+					}},
+				}},
+				{Name: "hist.float", Data: metricdata.Histogram[float64]{
+					DataPoints: []metricdata.HistogramDataPoint[float64]{{StartTime: start, Time: end}},
+				}},
+				{Name: "exphist.int", Data: metricdata.ExponentialHistogram[int64]{
+					DataPoints: []metricdata.ExponentialHistogramDataPoint[int64]{{StartTime: start, Time: end}},
+				}},
+				{Name: "exphist.float", Data: metricdata.ExponentialHistogram[float64]{
+					DataPoints: []metricdata.ExponentialHistogramDataPoint[float64]{{
+						StartTime: start,
+						Time:      end,
+						Exemplars: []metricdata.Exemplar[float64]{{Time: exemplarTime}},
+					}},
+				}},
+				{Name: "summary", Data: metricdata.Summary{
+					DataPoints: []metricdata.SummaryDataPoint{{StartTime: start, Time: end}},
+				}},
+			},
+		}},
+	}
+
+	capture := &captureMetricExporter{}
+	exporter := NewTimeOffsetMetricExporter(capture, offset)
+	require.NoError(t, exporter.Export(context.Background(), rm))
+	require.NotNil(t, capture.exported)
+
+	wantStart := start.Add(offset)
+	wantEnd := end.Add(offset)
+	wantExemplar := exemplarTime.Add(offset)
+
+	for _, m := range capture.exported.ScopeMetrics[0].Metrics {
+		switch data := m.Data.(type) {
+		case metricdata.Gauge[int64]:
+			assert.Equal(t, wantStart, data.DataPoints[0].StartTime, m.Name)
+			assert.Equal(t, wantEnd, data.DataPoints[0].Time, m.Name)
+		case metricdata.Gauge[float64]:
+			assert.Equal(t, wantStart, data.DataPoints[0].StartTime, m.Name)
+			assert.Equal(t, wantEnd, data.DataPoints[0].Time, m.Name)
+		case metricdata.Sum[int64]:
+			assert.Equal(t, wantStart, data.DataPoints[0].StartTime, m.Name)
+			assert.Equal(t, wantEnd, data.DataPoints[0].Time, m.Name)
+			assert.Equal(t, wantExemplar, data.DataPoints[0].Exemplars[0].Time, m.Name)
+		case metricdata.Sum[float64]:
+			assert.Equal(t, wantStart, data.DataPoints[0].StartTime, m.Name)
+			assert.Equal(t, wantEnd, data.DataPoints[0].Time, m.Name)
+		case metricdata.Histogram[int64]:
+			assert.Equal(t, wantStart, data.DataPoints[0].StartTime, m.Name)
+			assert.Equal(t, wantEnd, data.DataPoints[0].Time, m.Name)
+			assert.Equal(t, wantExemplar, data.DataPoints[0].Exemplars[0].Time, m.Name)
+		case metricdata.Histogram[float64]:
+			assert.Equal(t, wantStart, data.DataPoints[0].StartTime, m.Name)
+			assert.Equal(t, wantEnd, data.DataPoints[0].Time, m.Name)
+		case metricdata.ExponentialHistogram[int64]:
+			assert.Equal(t, wantStart, data.DataPoints[0].StartTime, m.Name)
+			assert.Equal(t, wantEnd, data.DataPoints[0].Time, m.Name)
+		case metricdata.ExponentialHistogram[float64]:
+			assert.Equal(t, wantStart, data.DataPoints[0].StartTime, m.Name)
+			assert.Equal(t, wantEnd, data.DataPoints[0].Time, m.Name)
+			assert.Equal(t, wantExemplar, data.DataPoints[0].Exemplars[0].Time, m.Name)
+		case metricdata.Summary:
+			assert.Equal(t, wantStart, data.DataPoints[0].StartTime, m.Name)
+			assert.Equal(t, wantEnd, data.DataPoints[0].Time, m.Name)
+		default:
+			t.Fatalf("unhandled aggregation type %T for metric %s", data, m.Name)
+		}
+	}
+}
+
+func TestTimeOffsetMetricExporterEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	offset := -24 * time.Hour
+	capture := &captureMetricExporter{}
+	reader := sdkmetric.NewPeriodicReader(NewTimeOffsetMetricExporter(capture, offset))
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	defer func() { require.NoError(t, mp.Shutdown(context.Background())) }()
+
+	counter, err := mp.Meter("motel").Int64Counter("requests.count")
+	require.NoError(t, err)
+
+	before := time.Now()
+	counter.Add(context.Background(), 1)
+	require.NoError(t, reader.ForceFlush(context.Background()))
+	after := time.Now()
+
+	require.NotNil(t, capture.exported)
+	m := findMetric(*capture.exported, "requests.count")
+	require.NotNil(t, m)
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+
+	dp := sum.DataPoints[0]
+	assert.False(t, dp.Time.Before(before.Add(offset)), "data point time should be shifted by offset")
+	assert.False(t, dp.Time.After(after.Add(offset)), "data point time should be shifted by offset")
+	assert.False(t, dp.StartTime.After(dp.Time), "start time should not be after time")
+}

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -200,8 +200,8 @@ func buildMetricAttrs(attrGens map[string]AttributeGenerator, operation string, 
 
 // Observe records metrics derived from the completed span.
 // Note: metric data points are timestamped at collection time by the OTel SDK's
-// PeriodicReader. The Metrics API does not support caller-supplied timestamps,
-// so Engine.TimeOffset has no effect on metric timestamps. See issue 99.
+// PeriodicReader. The Metrics API does not support caller-supplied timestamps;
+// time offsets are applied at export time by NewTimeOffsetMetricExporter.
 func (m *MetricObserver) Observe(info SpanInfo) {
 	instruments := m.services[info.Service]
 	if len(instruments) == 0 {


### PR DESCRIPTION
Closes #99

## Problem

The `--time-offset` flag shifts trace span and log record timestamps, but metric data points were unaffected: the OTel Metrics API does not accept caller-supplied timestamps, so data points are stamped at collection time by the SDK's `PeriodicReader`.

## Approach

As designed in the issue, this adds a custom exporter wrapper (`synth.NewTimeOffsetMetricExporter`) that rewrites timestamps on `metricdata.ResourceMetrics` before forwarding to the underlying exporter:

- Shifts `StartTime` and `Time` on every data point across all aggregation types: `Gauge`, `Sum`, `Histogram`, `ExponentialHistogram` (both `int64` and `float64` variants), and `Summary`
- Also shifts exemplar timestamps for consistency
- A zero offset returns the wrapped exporter unchanged, so the wrapper is wired unconditionally into `createMetricProviders`

## Tests

- Unit test covering all nine aggregation type variants plus exemplars
- End-to-end test through a `PeriodicReader` verifying a recorded counter's data point lands within the shifted wall-clock window
- Verified manually: `motel run --stdout --signals metrics --time-offset=-24h` produces data points stamped 24 hours in the past

Also updates the stale "Metric timestamps are not shifted" section in the time-offset demo doc and the `--time-offset` flag help text.

https://claude.ai/code/session_01TzfXWApbD3TJcKRrChdgai

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzfXWApbD3TJcKRrChdgai)_