### PR TITLE
Add GitHub Pages documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'cmd/motel/README.md'
+      - 'README.md'
+      - 'LICENSE'
+      - 'mkdocs.yml'
+      - 'Makefile'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: pip install 'mkdocs-material~=9.6'
+      - run: make site
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build/
 /motel
 /issue-analysis.md
+/.site/
+/site/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildTime=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 
-.PHONY: build test lint clean
+.PHONY: build test lint site clean
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o build/motel ./cmd/motel
@@ -13,6 +13,15 @@ test:
 lint:
 	@test -z "$$(gofmt -s -l .)" || (gofmt -s -l . && exit 1)
 	go vet ./...
+
+site:
+	rm -rf .site site
+	mkdir -p .site/cmd/motel
+	cp README.md .site/index.md
+	cp LICENSE .site/LICENSE
+	cp -R docs .site/docs
+	cp cmd/motel/README.md .site/cmd/motel/README.md
+	mkdocs build --strict
 
 clean:
 	rm -r build/

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ All three signal types are driven by the same topology.
 - [Getting started tutorial](docs/tutorials/getting-started.md)
 - [CLI reference](docs/reference/synth.md)
 - [DSL reference](cmd/motel/README.md) — full topology schema
-- [Example topologies](docs/examples/)
+- [Example topologies](docs/examples/README.md)
 - [Modelling your services](docs/how-to/model-your-services.md)
 - [How import infers a topology](docs/explanation/import-pipeline/README.md)
 - [How motel uses OTel semantic conventions](docs/explanation/semantic-conventions.md)

--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -70,7 +70,7 @@ Each operation defines the span it produces.
 
 | Field        | Type   | Description |
 |-------------|--------|-------------|
-| `duration`   | string | Mean with optional stddev: `30ms +/- 10ms` or fixed `50ms` |
+| `duration`   | string | Required. Mean with optional stddev: `30ms +/- 10ms` or fixed `50ms` |
 | `error_rate` | string | Percentage `0.5%` or decimal `0.005` (0.0 to 1.0) |
 | `call_style` | string | `parallel` or `sequential` (default: parallel) |
 | `domain`     | string | Semconv shorthand (e.g. `http`) — auto-generates standard attributes |
@@ -80,8 +80,8 @@ Each operation defines the span it produces.
 | `links`      | list   | Cross-trace span links to other operations (see below) |
 | `calls`      | list   | Downstream calls to other operations |
 | `queue_depth`| int    | Max concurrent requests before rejection (0 = unlimited) |
-| `backpressure`| object | Latency-driven degradation: increases duration and error rate when a downstream call exceeds a threshold |
-| `circuit_breaker`| object | Opens after repeated failures, rejecting requests for a cooldown period |
+| `backpressure`| object | Latency-driven degradation: increases duration and error rate when a downstream call exceeds a threshold (see below) |
+| `circuit_breaker`| object | Opens after repeated failures, rejecting requests for a cooldown period (see below) |
 
 ```yaml
 operations:
@@ -96,6 +96,57 @@ operations:
       - postgres.query
       - redis.get
 ```
+
+### backpressure
+
+Latency-driven degradation. motel tracks an exponentially weighted moving
+average of the operation's recent latency; while it exceeds
+`latency_threshold`, new requests have their duration multiplied and their
+error rate increased. The effect clears when the average latency drops back
+below the threshold.
+
+| Field                 | Type   | Description |
+|-----------------------|--------|-------------|
+| `latency_threshold`   | string | Required. Average latency above which backpressure activates, e.g. `200ms` |
+| `duration_multiplier` | float  | Span duration multiplier while active (capped at 10; values ≤ 0 are treated as 1) |
+| `error_rate_add`      | string | Added to the operation's error rate while active, e.g. `5%` |
+
+```yaml
+operations:
+  query:
+    duration: 20ms +/- 5ms
+    backpressure:
+      latency_threshold: 200ms
+      duration_multiplier: 3
+      error_rate_add: 10%
+```
+
+### circuit_breaker
+
+Opens after repeated failures, rejecting all requests until a cooldown
+expires. After the cooldown, a single probe request is allowed through:
+success closes the circuit, failure reopens it. All fields are required.
+
+| Field               | Type   | Description |
+|---------------------|--------|-------------|
+| `failure_threshold` | int    | Failures within `window` that open the circuit (must be positive) |
+| `window`            | string | Sliding window over which failures are counted, e.g. `10s` |
+| `cooldown`          | string | How long the circuit stays open before probing, e.g. `30s` |
+
+```yaml
+operations:
+  charge:
+    duration: 80ms +/- 20ms
+    error_rate: 2%
+    circuit_breaker:
+      failure_threshold: 5
+      window: 10s
+      cooldown: 30s
+```
+
+Queue, backpressure, and circuit-breaker state persists across scenario
+boundaries: when a scenario ends, an open circuit stays open until its
+cooldown expires and backpressure stays active until latency recovers.
 
 ### calls
 
@@ -268,9 +319,17 @@ Time-windowed overrides to operation behaviour and traffic.
 | `override` | map    | Per-operation overrides keyed by `service.operation` |
 | `traffic`  | object | Traffic pattern override for this window |
 
-Each override can set `duration`, `error_rate`, and `attributes`. Overlapping
-scenarios merge overrides by priority — higher-priority values win per field,
-attributes merge per key.
+Each override can set `duration`, `error_rate`, `attributes`, `add_calls`,
+and `remove_calls`. Overlapping scenarios merge overrides by priority —
+higher-priority values win per field, attributes merge per key.
+
+| Override field | Type | Description |
+|----------------|------|-------------|
+| `duration`     | string | Replaces the operation's duration for the window |
+| `error_rate`   | string | Replaces the operation's error rate for the window |
+| `attributes`   | map    | Attribute generators merged into the operation's attributes |
+| `add_calls`    | list   | Downstream calls added for the window — same syntax as [calls](#calls) |
+| `remove_calls` | list   | Calls to remove for the window, by `service.operation` target. The target must be a call the operation actually makes |
 
 ```yaml
 scenarios:
@@ -281,6 +340,11 @@ scenarios:
       postgres.query:
         duration: 500ms +/- 100ms
         error_rate: 15%
+      api.checkout:
+        add_calls:
+          - audit.log
+        remove_calls:
+          - cache.get
     traffic:
       rate: 200/s
 ```
@@ -290,7 +354,8 @@ scenarios:
 Topology-driven metric instruments. Define them at the service level (fire for
 every span in the service) or at the operation level (fire only for that
 operation). Requires `--signals metrics` or `--signals traces,metrics` when
-running; if no metrics are defined the signal is silently empty.
+running; if no metrics are defined, motel prints a warning and emits no
+metric data.
 
 | Field        | Type   | Description |
 |-------------|--------|-------------|
@@ -298,6 +363,7 @@ running; if no metrics are defined the signal is silently empty.
 | `type`       | string | `counter`, `updowncounter`, `histogram`, or `gauge` (required) |
 | `unit`       | string | OTel unit string, e.g. `ms`, `s`, `{request}` (optional) |
 | `value`      | string | Distribution to sample, e.g. `0.65` or `0.65 +/- 0.1`. Omit for span-derived behaviour (see below) |
+| `errors_only` | bool  | Record only for error spans. Only valid for `counter` instruments |
 | `attributes` | map    | Per-measurement attribute generators — same syntax as span attributes |
 
 **Span-derived behaviour (no `value`):** the instrument records a value derived

--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -398,6 +398,6 @@ quickly.
 
 ## Further Reading
 
-- [`docs/examples/`](../../docs/examples/) — example topology configs
-- [`docs/tutorials/`](../../docs/tutorials/) — getting started tutorial
-- [`pkg/synth/`](../../pkg/synth/) — implementation source
+- [`docs/examples/`](../../docs/examples/README.md) — example topology configs
+- [`docs/tutorials/`](../../docs/tutorials/getting-started.md) — getting started tutorial
+- [`pkg/synth/`](https://github.com/andrewh/motel/tree/main/pkg/synth) — implementation source

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -30,7 +30,7 @@ motel run --stdout --duration 5s docs/examples/basic-topology.yaml
 
 | Directory | Description |
 |-----------|-------------|
-| [`dsb/`](dsb/) | DeathStarBench microservice topologies (Social Network, Hotel Reservation). |
+| [`dsb/`](dsb/README.md) | DeathStarBench microservice topologies (Social Network, Hotel Reservation). |
 
 ## Further reading
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -20,6 +20,12 @@ motel run --stdout --duration 5s docs/examples/basic-topology.yaml
 | `cascading-failure.yaml` | Timeout and retry through a three-tier chain during scenario-driven database degradation. |
 | `circuit-breaker.yaml` | Scenario `add_calls`/`remove_calls` for circuit-breaker fallback patterns. |
 | `conditional-calls.yaml` | Per-call probability, `on-error`/`on-success` conditions, and `count` fan-out. |
+| `async-calls.yaml` | Async fire-and-forget calls with trace propagation for audit logging and notification dispatch. |
+| `span-events.yaml` | Span events emitted at an offset within operations (cache misses, query starts). |
+| `span-links.yaml` | Cross-trace span links between producer and consumer, modelling a message queue. |
+| `attribute-placement.yaml` | Resource attributes vs span attributes on the same service. |
+| `resource-attributes.yaml` | Per-service resource attributes (`deployment.environment`, `service.version`, etc.). |
+| `topology-driven-metrics.yaml` | All four metric instrument types at both service and operation level. |
 | `backpressure-queue.yaml` | Queue depth rejection, circuit breaker trips, and backpressure duration amplification. |
 | `internal-gateway.yaml` | Internal gateway pattern with async trace propagation through a service mesh. |
 | `ottl-transforms.yaml` | Messy, realistic attributes for practising OTTL transformations. |
@@ -34,6 +40,6 @@ motel run --stdout --duration 5s docs/examples/basic-topology.yaml
 
 ## Further reading
 
-- [Getting started tutorial](../../docs/tutorials/getting-started.md)
+- [Getting started tutorial](../tutorials/getting-started.md)
 - [Topology DSL reference](../../cmd/motel/README.md)
 - [Modelling your services](../how-to/model-your-services.md)

--- a/docs/explanation/import-pipeline/README.md
+++ b/docs/explanation/import-pipeline/README.md
@@ -15,7 +15,7 @@ makes is shown against the actual data.
 You can reproduce the import yourself:
 
 ```
-motel import docs/explanation/worked-example/traces.jsonl
+motel import docs/explanation/import-pipeline/traces.jsonl
 ```
 
 ## The source topology
@@ -209,10 +209,10 @@ service-level attributes in the topology.
 | database | *(none)* | — | — |
 | cache | *(none)* | — | — |
 
-Internal attributes (`synth.service`, `synth.trace_id`, etc.) are excluded
-from this analysis.
+Internal attributes (`synth.service`, `synth.operation`, `synth.scenarios`,
+`service.name`, and `telemetry.sdk.*`) are excluded from this analysis.
 
-Result: only `api` gets an `attributes` section in the YAML.
+Result: only `api` gets a `resource_attributes` section in the YAML.
 
 ## Stage 6: Compute traffic rate
 
@@ -280,7 +280,7 @@ If round-trip validation fails, the import returns an error rather than
 emitting a topology that `motel run` would reject.
 
 ```
-$ motel validate docs/explanation/worked-example/inferred-topology.yaml
+$ motel validate docs/explanation/import-pipeline/inferred-topology.yaml
 Configuration valid: 3 services, 1 root operation
 ```
 

--- a/docs/explanation/property-testing.md
+++ b/docs/explanation/property-testing.md
@@ -43,13 +43,13 @@ Reasons for choosing rapid over alternatives (notably `testing/quick` and
 
 ### Synth engine (`pkg/synth/property_test.go`)
 
-**Topology conformance (7 tests).** Every span produced by the engine
+**Topology conformance (8 tests).** Every span produced by the engine
 references a valid operation in the topology. Refs are correctly formatted as
 `service.operation`. Roots are complete, sorted, and not called by other
 operations. Cycle detection rejects invalid configs. Call targets resolve to
 real operations.
 
-**Span structure (4 tests).** Children start after their parent, parents end
+**Span structure (5 tests).** Children start after their parent, parents end
 after their children, durations are positive. Root spans are SERVER kind,
 non-root spans are CLIENT kind. All spans in a trace share the same trace ID.
 
@@ -62,7 +62,7 @@ call edge in the topology.
 **Error cascading (1 test).** If a child span has an error, its parent also
 has an error.
 
-**Scenarios (5 tests).** `ActiveScenarios` returns only scenarios whose window
+**Scenarios (7 tests).** `ActiveScenarios` returns only scenarios whose window
 contains the current time, sorted by priority, with stable ordering.
 `ResolveOverrides` merges correctly (last-defined wins), preserves earlier
 fields when later scenarios only partially override, doesn't mutate input
@@ -74,7 +74,7 @@ from the highest-priority scenario.
 **Engine with overrides (2 tests).** Duration overrides change actual span
 durations. Error rate override of 100% produces error spans.
 
-**Attribute generators (6 tests).** StaticValue is constant, WeightedChoice
+**Attribute generators (8 tests).** StaticValue is constant, WeightedChoice
 outputs are within the choice set, BoolValue returns booleans with correct
 extreme behaviour, RangeValue stays within bounds with single-value identity,
 SequenceValue is monotonic, NormalValue mean converges.
@@ -121,11 +121,11 @@ exist.
 are bounded by total counts. Duration lists match span counts and are positive.
 Call counts match tree children.
 
-**Duration arithmetic (4 tests).** Computed mean is within min/max. Combining
+**Duration arithmetic (5 tests).** Computed mean is within min/max. Combining
 a distribution with itself is idempotent. Uniform distributions (zero stddev)
 are preserved. Standard deviation is non-negative and zero for uniform inputs.
 
-**Marshal round-trip (1 test).** Generated YAML passes `LoadConfig` and
+**Marshal round-trip (2 tests).** Generated YAML passes `LoadConfig` and
 `ValidateConfig`. All services from the input appear in the output.
 
 ## Bugs found
@@ -170,7 +170,9 @@ run the code, check an invariant.
 
 ## Fuzz targets
 
-Five fuzz targets wrap property tests via `rapid.MakeFuzz`:
+Thirteen fuzz targets exercise the parsers, validators, check bounds, and
+import pipeline. Most wrap property tests via `rapid.MakeFuzz`;
+`FuzzParseErrorRate` and `FuzzParseSpans` fuzz raw bytes directly:
 
 | Target | Package | What it exercises |
 |---|---|---|
@@ -178,6 +180,14 @@ Five fuzz targets wrap property tests via `rapid.MakeFuzz`:
 | `FuzzBuildTopology` | `pkg/synth` | Topology building and ref correctness |
 | `FuzzParseDistribution` | `pkg/synth` | Distribution parse/format round-trip |
 | `FuzzParseRate` | `pkg/synth` | Rate parsing with regex-generated strings |
+| `FuzzParseErrorRate` | `pkg/synth` | Error-rate parsing (percentage and bare float, out-of-range rejection) |
+| `FuzzValidateCallConfig` | `pkg/synth` | Call config validation (timeout, retries, count, conditions) |
+| `FuzzCheckMaxDepthBounds` | `pkg/synth` | Static `MaxDepth` always bounds sampled observations |
+| `FuzzCheckMaxSpansBounds` | `pkg/synth` | Static `MaxSpans` always bounds sampled observations |
+| `FuzzCheckMaxFanOutBounds` | `pkg/synth` | Static `MaxFanOut` always bounds sampled observations |
+| `FuzzDistributionOrdering` | `pkg/synth` | Percentile distributions are monotonic (p50 ≤ p95 ≤ p99 ≤ max) |
+| `FuzzRealisticCheck` | `pkg/synth` | Static bounds hold for production-scale generated topologies |
+| `FuzzParseSpans` | `pkg/synth/traceimport` | Span parsing never panics on arbitrary bytes, in all formats |
 | `FuzzMarshalRoundTrip` | `pkg/synth/traceimport` | Full import pipeline round-trip |
 
 ### Running fuzz targets
@@ -193,13 +203,16 @@ import pipeline):
 go test ./pkg/synth/ -fuzz=FuzzParseRate -fuzztime=5m
 
 # Run all synth targets in parallel
-go test ./pkg/synth/ -fuzz=FuzzValidateConfig -fuzztime=5m &
-go test ./pkg/synth/ -fuzz=FuzzBuildTopology -fuzztime=5m &
-go test ./pkg/synth/ -fuzz=FuzzParseDistribution -fuzztime=5m &
-go test ./pkg/synth/ -fuzz=FuzzParseRate -fuzztime=5m &
+for target in FuzzValidateConfig FuzzBuildTopology FuzzParseDistribution \
+    FuzzParseRate FuzzParseErrorRate FuzzValidateCallConfig \
+    FuzzCheckMaxDepthBounds FuzzCheckMaxSpansBounds FuzzCheckMaxFanOutBounds \
+    FuzzDistributionOrdering FuzzRealisticCheck; do
+  go test ./pkg/synth/ -fuzz="^$target\$" -fuzztime=5m &
+done
 wait
 
-# Run the import pipeline target separately (different package)
+# Run the import pipeline targets separately (different package)
+go test ./pkg/synth/traceimport/ -fuzz=FuzzParseSpans -fuzztime=5m
 go test ./pkg/synth/traceimport/ -fuzz=FuzzMarshalRoundTrip -fuzztime=5m
 ```
 
@@ -216,11 +229,16 @@ src=~/Library/Caches/go-build/fuzz/github.com/andrewh/motel
 # src=~/.cache/go-build/fuzz/github.com/andrewh/motel
 
 # Copy new entries (cp -n skips existing files)
-for target in FuzzValidateConfig FuzzBuildTopology FuzzParseDistribution FuzzParseRate; do
+for target in FuzzValidateConfig FuzzBuildTopology FuzzParseDistribution \
+    FuzzParseRate FuzzParseErrorRate FuzzValidateCallConfig \
+    FuzzCheckMaxDepthBounds FuzzCheckMaxSpansBounds FuzzCheckMaxFanOutBounds \
+    FuzzDistributionOrdering FuzzRealisticCheck; do
   cp -n "$src/pkg/synth/$target"/* "pkg/synth/testdata/fuzz/$target/"
 done
-cp -n "$src/pkg/synth/traceimport/FuzzMarshalRoundTrip"/* \
-  "pkg/synth/traceimport/testdata/fuzz/FuzzMarshalRoundTrip/"
+for target in FuzzParseSpans FuzzMarshalRoundTrip; do
+  cp -n "$src/pkg/synth/traceimport/$target"/* \
+    "pkg/synth/traceimport/testdata/fuzz/$target/"
+done
 
 # Verify tests still pass with new corpus
 make test

--- a/docs/how-to/stress-test-collector.md
+++ b/docs/how-to/stress-test-collector.md
@@ -124,7 +124,7 @@ motel run --endpoint http://localhost:4318 --protocol http/protobuf \
 
 Then query your backend for the same time window and count the spans received. The difference is your data loss under that load profile.
 
-For precise counting, send traces to both the collector and stdout simultaneously using two collector receivers, then compare line counts:
+For precise counting, run the same topology with `--stdout` and count the lines — one span per line:
 
 ```sh
 motel run --stdout --duration 2m docs/examples/stress-test.yaml | wc -l

--- a/docs/how-to/test-ottl-transforms.md
+++ b/docs/how-to/test-ottl-transforms.md
@@ -32,13 +32,16 @@ Pick a few representative spans and note the attributes you want to change. For 
 ```json
 {
   "Name": "POST /api/checkout",
-  "Attributes": {
-    "httpStatusCode": "200",
-    "request.metadata": "region=eu-west-1;priority=high",
-    "customer.id": "cust-42"
-  }
+  "Attributes": [
+    {"Key": "httpStatusCode", "Value": {"Type": "INT64", "Value": 200}},
+    {"Key": "request.metadata", "Value": {"Type": "STRING", "Value": "region=eu-west-1;priority=high"}},
+    {"Key": "customer.id", "Value": {"Type": "STRING", "Value": "cust-42"}}
+  ]
 }
 ```
+
+Note that `httpStatusCode` is an integer attribute — this matters for OTTL,
+where `Int` and `String` comparisons behave differently.
 
 ## 3. Write a collector config with OTTL rules
 
@@ -143,7 +146,7 @@ The feedback loop is fast because motel generates deterministic, controllable tr
 
 - **Start with one rule at a time.** Add a single statement, verify it works, then add the next. OTTL errors are easier to diagnose in isolation.
 - **Use `--duration 2s` and a low traffic rate** (the example uses `20/s`) so you get enough spans to verify without drowning in output.
-- **Use weighted values to test conditional logic.** The example topology generates `httpStatusCode` with weighted values including `"500"` — you can write OTTL rules that behave differently for error status codes.
+- **Use weighted values to test conditional logic.** The example topology generates `httpStatusCode` with weighted integer values including `500` — you can write OTTL rules that behave differently for error status codes.
 - **Test edge cases with attribute generators.** Use `sequence` to produce predictable IDs, `range` for numeric boundaries, and `values` with weights to control the distribution of attribute values your OTTL rules will encounter.
 
 ## Further reading

--- a/docs/how-to/understand-attribute-placement.md
+++ b/docs/how-to/understand-attribute-placement.md
@@ -215,25 +215,24 @@ To isolate the effect of a single attribute, run the topology twice — once wit
 
 ## Semantic conventions and correct placement
 
-The `--semconv` flag helps ensure attributes are placed correctly according to OpenTelemetry semantic conventions. It validates that attribute names and placements match convention definitions.
+Instead of hand-writing well-known attributes — and risking typos or wrong placement — you can set a `domain` on an operation and let motel generate convention-correct attributes for you:
 
-```sh
-motel validate --semconv /path/to/semconv topology.yaml
+```yaml
+operations:
+  GET /users:
+    duration: 30ms +/- 10ms
+    domain: http
 ```
 
-The `--semconv` flag points to a directory containing semantic convention YAML files. motel loads the embedded OpenTelemetry conventions by default and merges any additional conventions you provide.
+The `domain` shorthand draws attribute names, types, and example values from the embedded OpenTelemetry semantic convention registry, so the generated attributes always match the conventions. See [How motel uses OTel semantic conventions](../explanation/semantic-conventions.md) for details.
 
-This catches common mistakes:
-
-- Using a deprecated attribute name when a replacement exists
-- Placing an attribute at the wrong level (resource vs span)
-- Misspelling a well-known attribute name
-
-You can also use `--semconv` with `motel run` to validate at generation time:
+The `--semconv` flag points to a directory of additional semantic convention YAML files, which motel merges with the embedded conventions. Use it to make custom domains available to the `domain` shorthand:
 
 ```sh
 motel run --stdout --semconv /path/to/semconv --duration 5s topology.yaml
 ```
+
+Note that motel does not validate hand-written attribute names against the conventions — `motel validate` checks topology structure, not attribute spelling or placement. If you want convention-correct attributes, use `domain`; if you write attributes by hand, the names are emitted exactly as you wrote them.
 
 ## Further reading
 

--- a/docs/how-to/visualise-traces.md
+++ b/docs/how-to/visualise-traces.md
@@ -82,8 +82,6 @@ motel run --endpoint localhost:4318 --protocol http/protobuf \
 
 Open <http://localhost:16686> in your browser. Select the `gateway` service from the dropdown and click **Find Traces**. Click a trace to see the waterfall view showing calls fanning out from `gateway` through the backend services to the datastores.
 
-![Jaeger trace waterfall](images/jaeger-trace-waterfall.png)
-
 Things to check:
 
 - All five services appear in the service dropdown
@@ -228,8 +226,6 @@ motel run --endpoint localhost:4318 --protocol http/protobuf \
 ### Inspect results
 
 Open <http://localhost:3000/explore> in your browser. Select **Tempo** as the data source, switch to the **Search** tab, and choose `gateway` from the service name dropdown. Run the query to see a list of traces. Click a trace to open the waterfall panel.
-
-![Grafana Tempo trace panel](images/grafana-tempo-trace-panel.png)
 
 ### Clean up
 

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -20,8 +20,12 @@ URL fetches have a 10-second timeout and a 10 MB response body limit. Redirects 
 Check a topology for errors without generating any output.
 
 ```sh
-motel validate <topology.yaml | URL>
+motel validate <topology.yaml | URL> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--semconv` | string | | Directory of additional semantic convention YAML files |
 
 Prints a summary on success (e.g. `Configuration valid: 5 services, 2 root operations`) or a precise error on failure including the service name, operation name, and field.
 
@@ -35,13 +39,20 @@ motel run <topology.yaml | URL> [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--duration` | duration | from config, or 1m | Simulation duration |
+| `--duration` | duration | `1m` | Simulation duration |
 | `--endpoint` | string | | OTLP endpoint (e.g. `localhost:4318`) |
 | `--protocol` | string | `http/protobuf` | OTLP protocol (`http/protobuf` or `grpc`) |
 | `--signals` | string | `traces` | Comma-separated signals: `traces`, `metrics`, `logs` |
-| `--slow-threshold` | duration | `1s` | Spans exceeding this duration emit a slow-span log record. Only has an effect when `logs` is included in `--signals` |
-| `--max-spans-per-trace` | int | 10000 | Maximum spans per trace (safety limit for deep topologies) |
+| `--slow-threshold` | duration | `1s` | Spans exceeding this duration emit a slow-span log record. Warns and has no effect unless `logs` is included in `--signals` |
+| `--max-spans-per-trace` | int | 0 | Maximum spans per trace (safety limit for deep topologies); 0 means the default of 10000 |
 | `--stdout` | bool | false | Emit signals to stdout as JSON instead of sending to an endpoint |
+| `--semconv` | string | | Directory of additional semantic convention YAML files |
+| `--label-scenarios` | bool | false | Add a `synth.scenarios` attribute to spans listing active scenario names |
+| `--time-offset` | duration | 0 | Shift span timestamps by this duration (e.g. `-1h` for past, `1h` for future) |
+| `--realtime` | bool | false | Emit spans at wall-clock times matching simulated timestamps |
+| `--pprof` | string | | Start a pprof HTTP server on this address (e.g. `:6060`) |
+
+`--realtime` and `--time-offset` are mutually exclusive.
 
 #### Output format
 
@@ -65,6 +76,28 @@ motel run --stdout --duration 5s topology.yaml > spans.jsonl 2> stats.json
 
 The stdout format is the same format accepted by `motel import`, so you can round-trip: generate traces, then infer a topology from them.
 
+### emit
+
+Emit one or more single-span traces from command-line arguments, without a topology file. For multi-service topologies or call graphs, use `motel run`.
+
+```sh
+motel emit --service <name> --operation <name> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--service` | string | | Service name (required) |
+| `--operation` | string | | Operation name (required) |
+| `--span-duration` | duration | `100ms` | Span duration |
+| `--duration` | duration | | Simulation duration, e.g. `10s`, `5m` |
+| `--error-rate` | string | | Error rate (e.g. `5%`, `0.05`) |
+| `--attr` | string | | Span attribute in `key=value` format (repeatable) |
+| `--count` | int | 1 | Number of traces to emit |
+| `--rate` | string | `10/s` | Trace rate when count > 1 (e.g. `10/s`, `100/m`) |
+| `--endpoint` | string | | OTLP endpoint (e.g. `localhost:4318`) |
+| `--protocol` | string | `http/protobuf` | OTLP protocol (`http/protobuf` or `grpc`) |
+| `--stdout` | bool | false | Emit signals to stdout as JSON |
+
 ### check
 
 Run structural checks on a topology before sending traffic.
@@ -82,6 +115,7 @@ Computes worst-case trace depth, fan-out per span, and total spans per trace usi
 | `--max-spans` | int | 10000 | Fail if worst-case spans per trace exceeds this |
 | `--samples` | int | 1000 | Sampled traces for empirical measurement (0 to skip) |
 | `--seed` | uint | 0 | Random seed for reproducibility (0 = random) |
+| `--max-spans-per-trace` | int | 0 | Maximum spans per sampled trace; 0 means the default of 10000 |
 | `--semconv` | string | | Directory of additional semantic convention YAML files |
 
 Output is one line per check showing PASS/FAIL, the measured value, and the limit. Depth checks include the worst-case path; fan-out checks identify the worst operation; span checks show both static worst-case and observed values from sampling.
@@ -104,6 +138,27 @@ Reads trace spans and generates a YAML topology. If no file is given, reads from
 The `auto` format detector examines the first line to determine whether the input is stdouttrace JSON (one span per line) or OTLP JSON (batched export format).
 
 Output is written to stdout as a YAML topology with a commented header noting how many traces and spans were analysed.
+
+### preview
+
+Render the traffic rate over time as an SVG chart.
+
+```sh
+motel preview <topology.yaml | URL> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--duration` | duration | inferred from topology | Preview duration |
+| `--output`, `-o` | string | stdout | Output file path |
+
+### version
+
+Print the motel version, commit, and build time.
+
+```sh
+motel version
+```
 
 ## Topology DSL
 

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -112,6 +112,6 @@ The full DSL reference — services, operations, calls, attributes, traffic, and
 ## Further reading
 
 - [Getting started tutorial](../tutorials/getting-started.md)
-- [Example topologies](../examples/)
+- [Example topologies](../examples/README.md)
 - [How import infers a topology](../explanation/import-pipeline/README.md)
 - [Modelling your services](../how-to/model-your-services.md)

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -152,6 +152,6 @@ This sends traces over HTTP to the OTLP endpoint. The collector receives them as
 ## Next steps
 
 - **[Visualise traces](../how-to/visualise-traces.md)** — set up Jaeger, Grafana + Tempo, or a hosted backend to see your traces
-- **[Example topologies](../examples/)** — ready-to-use YAML files covering error cascading, traffic patterns, scenarios, and more
+- **[Example topologies](../examples/README.md)** — ready-to-use YAML files covering error cascading, traffic patterns, scenarios, and more
 - **[motel reference](../reference/synth.md)** — CLI reference for all commands and flags
 - **[DSL reference](../../cmd/motel/README.md)** — full topology DSL reference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,72 @@
+site_name: motel
+site_description: Synthetic OpenTelemetry generator
+site_url: https://andrewh.github.io/motel/
+repo_url: https://github.com/andrewh/motel
+repo_name: andrewh/motel
+edit_uri: ""
+
+docs_dir: .site
+site_dir: site
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.top
+    - navigation.footer
+    - search.suggest
+    - content.code.copy
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.highlight
+  - pymdownx.superfences
+
+validation:
+  links:
+    absolute_links: ignore
+
+not_in_nav: |
+  docs/demos/
+  docs/research/
+
+nav:
+  - Home: index.md
+  - Tutorials:
+      - docs/tutorials/getting-started.md
+  - How-to guides:
+      - docs/how-to/model-your-services.md
+      - docs/how-to/validate-collector-pipeline.md
+      - docs/how-to/stress-test-collector.md
+      - docs/how-to/test-tail-sampling.md
+      - docs/how-to/test-ottl-transforms.md
+      - docs/how-to/test-alert-thresholds.md
+      - docs/how-to/test-backend-integration.md
+      - docs/how-to/understand-attribute-placement.md
+      - docs/how-to/use-with-otel-cli.md
+      - docs/how-to/visualise-traces.md
+  - Examples:
+      - Overview: docs/examples/README.md
+      - docs/examples/dsb/README.md
+  - Explanation:
+      - docs/explanation/import-pipeline/README.md
+      - docs/explanation/semantic-conventions.md
+      - docs/explanation/performance-profile.md
+      - docs/explanation/property-testing.md
+  - Reference:
+      - CLI reference: docs/reference/synth.md
+      - DSL reference: cmd/motel/README.md


### PR DESCRIPTION
Closes #124.

Builds a static documentation site from the existing markdown docs using MkDocs Material, deployed to GitHub Pages via a new `docs` workflow on push to `main`.

## Approach

- **No docs restructuring.** `make site` stages sources into `.site/` mirroring the repository layout — `README.md` becomes the landing page (`index.md`), `docs/` is copied as-is, and `cmd/motel/README.md` keeps its path. Existing relative links (including the seven cross-links into the DSL reference at `../../cmd/motel/README.md`) resolve unchanged, and they continue to work when browsing on GitHub.
- **Landing page** is the existing README: project description, install, and quick start — matching the issue scope without duplicating content.
- **Navigation** mirrors the Diátaxis layout: Tutorials, How-to guides, Examples, Explanation, Reference (CLI reference plus the DSL reference). Demo scripts and research notes are built but kept out of the nav per the issue scope. Example YAML files ship as static assets so download links work.
- **Strict link checking** (`mkdocs build --strict`) runs on every build, so broken cross-references fail CI.
- **Deployment** uses the standard `upload-pages-artifact`/`deploy-pages` flow, triggered by pushes to `main` that touch docs sources, plus `workflow_dispatch`.

## Testing locally

```sh
pip install 'mkdocs-material~=9.6'

# Build with strict link checking (output in site/)
make site

# Or serve with live reload at http://localhost:8000
make site && mkdocs serve
```

`make site` stages the doc sources into `.site/` and runs `mkdocs build --strict`, exactly as CI does. Both `.site/` and `site/` are gitignored. Re-run `make site` after editing docs so `mkdocs serve` picks up the changes (it watches the staged copy, not the originals).

## Link fixes surfaced by the strict build

- Directory-style links (`docs/examples/`, `../examples/`, `dsb/`) now point at their `README.md`/index pages.
- Two image embeds in `docs/how-to/visualise-traces.md` referenced screenshots that were never committed — broken on GitHub today as well. Removed; the surrounding prose already describes what to look for.
- The `pkg/synth/` link in the DSL reference now points at the GitHub tree URL, since source code isn't part of the site.

## Verified

- `mkdocs build --strict` passes with zero warnings (mkdocs 1.6.1, mkdocs-material 9.6).
- `make test` passes.
- Generated output checked: landing page, per-section pages, search index, DSL reference at `/cmd/motel/`, and static YAML assets all present.

## After merge

One-time setup: in repository **Settings → Pages**, set the source to **GitHub Actions**. The site will publish to https://andrewh.github.io/motel/ on the next push to `main` (or via manual dispatch of the `docs` workflow).

https://claude.ai/code/session_01GXCaHS4EUtHRmWFe1WwpLN