### PR TITLE
Add scenario-aware exploration to motel check

### DIFF
--- a/cmd/motel/check.go
+++ b/cmd/motel/check.go
@@ -17,6 +17,7 @@ func checkCmd() *cobra.Command {
 		samples          int
 		seed             uint64
 		semconvDir       string
+		skipScenarios    bool
 	)
 
 	cmd := &cobra.Command{
@@ -24,7 +25,11 @@ func checkCmd() *cobra.Command {
 		Short: "Run structural checks on a topology",
 		Long: "Run structural checks on a topology.\n\n" +
 			"The topology source can be a local file path or an HTTP/HTTPS URL.\n" +
-			"URL fetches have a 10-second timeout and a 10 MB response body limit.",
+			"URL fetches have a 10-second timeout and a 10 MB response body limit.\n\n" +
+			"Scenarios defined in the topology are explored automatically: every\n" +
+			"distinct combination of co-active scenarios is checked alongside the\n" +
+			"baseline, and each check reports the combination that produces the\n" +
+			"worst case. Use --skip-scenarios to check the baseline topology only.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("missing topology file or URL\n\nUsage: motel check <topology.yaml | URL>")
@@ -48,6 +53,14 @@ func checkCmd() *cobra.Command {
 				return err
 			}
 
+			var scenarios []synth.Scenario
+			if !skipScenarios {
+				scenarios, err = synth.BuildScenarios(cfg.Scenarios, topo)
+				if err != nil {
+					return err
+				}
+			}
+
 			opts := synth.CheckOptions{
 				MaxDepth:         maxDepth,
 				MaxFanOut:        maxFanOut,
@@ -55,6 +68,7 @@ func checkCmd() *cobra.Command {
 				MaxSpansPerTrace: maxSpansPerTrace,
 				Samples:          samples,
 				Seed:             seed,
+				Scenarios:        scenarios,
 			}
 
 			results := synth.Check(topo, opts)
@@ -90,6 +104,10 @@ func checkCmd() *cobra.Command {
 					_, _ = fmt.Fprintf(w, "%s  %s: %d (limit: %d)\n", status, r.Name, r.Actual, r.Limit)
 				}
 
+				if len(r.Scenarios) > 0 {
+					_, _ = fmt.Fprintf(w, "      scenarios: %s\n", strings.Join(r.Scenarios, " + "))
+				}
+
 				if r.Distribution != nil {
 					d := r.Distribution
 					_, _ = fmt.Fprintf(w, "      p50: %d  p95: %d  p99: %d  max: %d  (%d samples)\n",
@@ -111,6 +129,7 @@ func checkCmd() *cobra.Command {
 	cmd.Flags().Uint64Var(&seed, "seed", 0, "random seed for reproducibility (0 = random)")
 	cmd.Flags().IntVar(&maxSpansPerTrace, "max-spans-per-trace", 0, fmt.Sprintf("maximum spans per sampled trace (0 = default %d)", synth.DefaultMaxSpansPerTrace))
 	cmd.Flags().StringVar(&semconvDir, "semconv", "", "directory of additional semantic convention YAML files")
+	cmd.Flags().BoolVar(&skipScenarios, "skip-scenarios", false, "check the baseline topology only, ignoring scenarios")
 
 	return cmd
 }

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -1119,3 +1119,59 @@ func TestMetricShutdownExporterOrder(t *testing.T) {
 			"provider %d shut down after exporter", i)
 	}
 }
+
+func TestCheckCommandScenarios(t *testing.T) {
+	t.Parallel()
+
+	const cfg = `
+version: 1
+services:
+  svc:
+    operations:
+      a:
+        duration: 10ms
+        calls:
+          - svc.b
+      b:
+        duration: 10ms
+      c:
+        duration: 10ms
+scenarios:
+  - name: deepen
+    at: +1m
+    duration: 1m
+    override:
+      svc.b:
+        add_calls:
+          - svc.c
+traffic:
+  rate: 10/s
+`
+
+	t.Run("scenario worst case reported and fails tight limit", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, cfg)
+		root := rootCmd()
+		root.SetArgs([]string{"check", path, "--max-depth", "1", "--samples", "10", "--seed", "42"})
+		var out bytes.Buffer
+		root.SetOut(&out)
+
+		err := root.Execute()
+		require.Error(t, err, "depth 2 under scenario must fail limit 1")
+		assert.Contains(t, out.String(), "FAIL  max-depth: 2")
+		assert.Contains(t, out.String(), "scenarios: deepen")
+	})
+
+	t.Run("skip-scenarios checks baseline only", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, cfg)
+		root := rootCmd()
+		root.SetArgs([]string{"check", path, "--max-depth", "1", "--samples", "10", "--seed", "42", "--skip-scenarios"})
+		var out bytes.Buffer
+		root.SetOut(&out)
+
+		err := root.Execute()
+		require.NoError(t, err, "baseline depth 1 passes limit 1")
+		assert.NotContains(t, out.String(), "scenarios:")
+	})
+}

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -75,16 +75,19 @@ motel check <topology.yaml | URL> [flags]
 
 Computes worst-case trace depth, fan-out per span, and total spans per trace using static graph analysis. Optionally runs sampled exploration with the engine to measure empirical values. Exits with code 0 if all checks pass, 1 if any check fails.
 
+Scenarios defined in the topology are explored automatically. Scenario windows are swept to find every distinct combination of co-active scenarios, and each combination — plus the baseline with no scenarios — is checked with its overrides applied (including `add_calls` and `remove_calls`). Each check reports the worst case found and which scenario combination produced it, so a topology that passes in isolation but explodes when a scenario adds calls fails the check.
+
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--max-depth` | int | 10 | Fail if worst-case trace depth exceeds this |
 | `--max-fan-out` | int | 100 | Fail if worst-case children per span exceeds this |
 | `--max-spans` | int | 10000 | Fail if worst-case spans per trace exceeds this |
-| `--samples` | int | 1000 | Sampled traces for empirical measurement (0 to skip) |
+| `--samples` | int | 1000 | Sampled traces for empirical measurement per scenario combination (0 to skip) |
 | `--seed` | uint | 0 | Random seed for reproducibility (0 = random) |
 | `--semconv` | string | | Directory of additional semantic convention YAML files |
+| `--skip-scenarios` | bool | false | Check the baseline topology only, ignoring scenarios |
 
-Output is one line per check showing PASS/FAIL, the measured value, and the limit. Depth checks include the worst-case path; fan-out checks identify the worst operation; span checks show both static worst-case and observed values from sampling.
+Output is one line per check showing PASS/FAIL, the measured value, and the limit. Depth checks include the worst-case path; fan-out checks identify the worst operation; span checks show both static worst-case and observed values from sampling. When a scenario combination produces the worst case, the check is annotated with `scenarios:` naming it.
 
 ### import
 

--- a/pkg/synth/check.go
+++ b/pkg/synth/check.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/rand/v2"
 	"slices"
+	"strings"
 	"time"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -15,6 +16,8 @@ import (
 )
 
 // CheckResult holds the outcome of a single structural check.
+// Scenarios names the scenario combination that produced the worst case;
+// empty means the baseline topology (no scenarios active).
 type CheckResult struct {
 	Name         string
 	Pass         bool
@@ -24,6 +27,7 @@ type CheckResult struct {
 	SamplesRun   int
 	Path         []string
 	Ref          string
+	Scenarios    []string
 	Distribution *DistributionSummary
 }
 
@@ -74,6 +78,8 @@ func percentileFromSorted(sorted []int, p float64) int {
 }
 
 // CheckOptions configures the thresholds and sampling for Check.
+// When Scenarios is non-empty, every distinct combination of co-active
+// scenarios is checked and the worst case reported per check.
 type CheckOptions struct {
 	MaxDepth         int
 	MaxFanOut        int
@@ -81,6 +87,7 @@ type CheckOptions struct {
 	MaxSpansPerTrace int
 	Samples          int
 	Seed             uint64
+	Scenarios        []Scenario
 }
 
 // SampleResults holds empirical measurements from sampled trace generation.
@@ -97,11 +104,17 @@ const maxSpansCap = math.MaxInt32
 
 // MaxDepth returns the longest path (edge count) from any root to any leaf
 // and the operation refs along that path.
+func MaxDepth(topo *Topology) (int, []string) {
+	return maxDepthWith(topo, nil)
+}
+
+// maxDepthWith computes MaxDepth with scenario call overrides applied.
 //
-// Memoisation is safe because BuildTopology guarantees the topology is acyclic.
+// Memoisation is safe because BuildTopology guarantees the topology is acyclic
+// (and BuildScenarios rejects scenario call changes that create cycles).
 // In a DAG, a node's subtree depth is the same regardless of which path reaches it,
 // so the memo produces correct results under any visited set.
-func MaxDepth(topo *Topology) (int, []string) {
+func maxDepthWith(topo *Topology, overrides map[string]Override) (int, []string) {
 	type result struct {
 		depth int
 		path  []string
@@ -117,7 +130,7 @@ func MaxDepth(topo *Topology) (int, []string) {
 
 		best := result{depth: 0, path: []string{op.Ref}}
 
-		for _, call := range op.Calls {
+		for _, call := range effectiveCalls(op, overrides) {
 			if visited[call.Operation] {
 				continue
 			}
@@ -151,13 +164,18 @@ func MaxDepth(topo *Topology) (int, []string) {
 // operation produces it. For each operation, it sums
 // max(call.Count, 1) * (1 + call.Retries) across all calls.
 func MaxFanOut(topo *Topology) (int, string) {
+	return maxFanOutWith(topo, nil)
+}
+
+// maxFanOutWith computes MaxFanOut with scenario call overrides applied.
+func maxFanOutWith(topo *Topology, overrides map[string]Override) (int, string) {
 	maxFan := 0
 	worstRef := ""
 
 	for _, svc := range topo.Services {
 		for _, op := range svc.Operations {
 			fan := 0
-			for _, call := range op.Calls {
+			for _, call := range effectiveCalls(op, overrides) {
 				count := max(call.Count, 1)
 				attempts := 1 + call.Retries
 				fan += count * attempts
@@ -176,11 +194,17 @@ func MaxFanOut(topo *Topology) (int, string) {
 // It multiplies fan-out at each level. Both on-error and on-success paths are
 // included (conservative — real traces cannot take both).
 // Returns the max and which root produces it.
+func MaxSpans(topo *Topology) (int, string) {
+	return maxSpansWith(topo, nil)
+}
+
+// maxSpansWith computes MaxSpans with scenario call overrides applied.
 //
-// Memoisation is safe because BuildTopology guarantees the topology is acyclic.
+// Memoisation is safe because BuildTopology guarantees the topology is acyclic
+// (and BuildScenarios rejects scenario call changes that create cycles).
 // In a DAG, a node's subtree span count is the same regardless of which path
 // reaches it, so the memo produces correct results under any visited set.
-func MaxSpans(topo *Topology) (int, string) {
+func maxSpansWith(topo *Topology, overrides map[string]Override) (int, string) {
 	memo := make(map[*Operation]int)
 
 	var dfs func(op *Operation, visited map[*Operation]bool) int
@@ -191,7 +215,7 @@ func MaxSpans(topo *Topology) (int, string) {
 
 		total := 1 // the operation's own span
 
-		for _, call := range op.Calls {
+		for _, call := range effectiveCalls(op, overrides) {
 			if visited[call.Operation] {
 				continue
 			}
@@ -237,6 +261,11 @@ func MaxSpans(topo *Topology) (int, string) {
 // maxSpansPerTrace (or DefaultMaxSpansPerTrace when 0), so for topologies whose
 // static worst-case exceeds that limit, the observed value will plateau.
 func SampleTraces(topo *Topology, n int, seed uint64, maxSpansPerTrace int) SampleResults {
+	return sampleTracesWith(topo, n, seed, maxSpansPerTrace, nil)
+}
+
+// sampleTracesWith runs SampleTraces with scenario overrides applied to every trace.
+func sampleTracesWith(topo *Topology, n int, seed uint64, maxSpansPerTrace int, overrides map[string]Override) SampleResults {
 	if maxSpansPerTrace <= 0 {
 		maxSpansPerTrace = DefaultMaxSpansPerTrace
 	}
@@ -273,7 +302,7 @@ func SampleTraces(topo *Topology, n int, seed uint64, maxSpansPerTrace int) Samp
 		root := topo.Roots[rng.IntN(len(topo.Roots))]
 		var stats Stats
 		spanCount := 0
-		engine.walkTrace(context.Background(), root, time.Now(), 0, nil, nil, &stats, &spanCount, maxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), root, time.Now(), 0, overrides, nil, &stats, &spanCount, maxSpansPerTrace, false)
 		_ = tp.ForceFlush(context.Background())
 
 		spans := exporter.GetSpans()
@@ -352,66 +381,157 @@ func measureTrace(spans []tracetest.SpanStub) (depth, fanOut int) {
 // intPtr returns a pointer to v.
 func intPtr(v int) *int { return &v }
 
+// ScenarioSet is a distinct combination of scenarios that are active together
+// at some point in the simulation timeline. The zero value is the baseline
+// (no scenarios active).
+type ScenarioSet struct {
+	Names     []string
+	Overrides map[string]Override
+}
+
+// ScenarioSets enumerates the distinct combinations of co-active scenarios by
+// evaluating the active set at every window boundary — active sets only change
+// when a scenario starts or ends, so the boundaries cover every combination
+// that occurs in time. The baseline (no scenarios) is always first.
+func ScenarioSets(scenarios []Scenario) []ScenarioSet {
+	sets := []ScenarioSet{{}}
+	if len(scenarios) == 0 {
+		return sets
+	}
+
+	boundaries := make([]time.Duration, 0, len(scenarios)*2)
+	for _, sc := range scenarios {
+		boundaries = append(boundaries, sc.Start, sc.End)
+	}
+	slices.Sort(boundaries)
+	boundaries = slices.Compact(boundaries)
+
+	seen := map[string]bool{"": true}
+	for _, t := range boundaries {
+		active := ActiveScenarios(scenarios, t)
+		if len(active) == 0 {
+			continue
+		}
+		names := make([]string, len(active))
+		for i, sc := range active {
+			names[i] = sc.Name
+		}
+		key := strings.Join(names, "\x00")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		sets = append(sets, ScenarioSet{Names: names, Overrides: ResolveOverrides(active)})
+	}
+	return sets
+}
+
+// setEvaluation holds the static and sampled measurements for one scenario set.
+type setEvaluation struct {
+	names     []string
+	depth     int
+	depthPath []string
+	fanOut    int
+	fanOutRef string
+	spans     int
+	sampled   SampleResults
+}
+
 // Check runs structural analysis and sampled exploration, returning one result
-// per check.
+// per check. When opts.Scenarios is non-empty, the baseline topology and every
+// distinct combination of co-active scenarios are evaluated; each result
+// reports the worst case and the scenario combination that produced it
+// (selected by static value, with the sampled maximum as tie-breaker).
 func Check(topo *Topology, opts CheckOptions) []CheckResult {
-	staticDepth, depthPath := MaxDepth(topo)
-	staticFanOut, fanOutRef := MaxFanOut(topo)
-	staticSpans, _ := MaxSpans(topo)
+	sets := ScenarioSets(opts.Scenarios)
 
-	var sampled SampleResults
-	if opts.Samples > 0 {
-		sampled = SampleTraces(topo, opts.Samples, opts.Seed, opts.MaxSpansPerTrace)
+	// Fix the seed once so every scenario set samples the same trace sequence.
+	seed := opts.Seed
+	if opts.Samples > 0 && seed == 0 {
+		seed = rand.Uint64() //nolint:gosec // not security-sensitive
 	}
 
-	var depthDist, spansDist, fanOutDist *DistributionSummary
-	if opts.Samples > 0 {
-		dd, sd, fd := sampled.Distribution.Summary()
-		depthDist = &dd
-		spansDist = &sd
-		fanOutDist = &fd
+	evals := make([]setEvaluation, 0, len(sets))
+	for _, set := range sets {
+		ev := setEvaluation{names: set.Names}
+		ev.depth, ev.depthPath = maxDepthWith(topo, set.Overrides)
+		ev.fanOut, ev.fanOutRef = maxFanOutWith(topo, set.Overrides)
+		ev.spans, _ = maxSpansWith(topo, set.Overrides)
+		if opts.Samples > 0 {
+			ev.sampled = sampleTracesWith(topo, opts.Samples, seed, opts.MaxSpansPerTrace, set.Overrides)
+		}
+		evals = append(evals, ev)
 	}
+
+	// worst returns the evaluation with the highest static value for a check.
+	// Ties go to the sampled maximum, then to the earlier set (baseline first).
+	worst := func(static, sampledMax func(setEvaluation) int) setEvaluation {
+		best := evals[0]
+		for _, ev := range evals[1:] {
+			if static(ev) > static(best) ||
+				(static(ev) == static(best) && opts.Samples > 0 && sampledMax(ev) > sampledMax(best)) {
+				best = ev
+			}
+		}
+		return best
+	}
+
+	depthEval := worst(
+		func(e setEvaluation) int { return e.depth },
+		func(e setEvaluation) int { return e.sampled.MaxDepth })
+	fanOutEval := worst(
+		func(e setEvaluation) int { return e.fanOut },
+		func(e setEvaluation) int { return e.sampled.MaxFanOut })
+	spansEval := worst(
+		func(e setEvaluation) int { return e.spans },
+		func(e setEvaluation) int { return e.sampled.MaxSpans })
 
 	results := make([]CheckResult, 0, 3)
 
 	depthResult := CheckResult{
-		Name:         "max-depth",
-		Pass:         staticDepth <= opts.MaxDepth,
-		Limit:        opts.MaxDepth,
-		Actual:       staticDepth,
-		SamplesRun:   sampled.TracesRun,
-		Path:         depthPath,
-		Distribution: depthDist,
+		Name:       "max-depth",
+		Pass:       depthEval.depth <= opts.MaxDepth,
+		Limit:      opts.MaxDepth,
+		Actual:     depthEval.depth,
+		SamplesRun: depthEval.sampled.TracesRun,
+		Path:       depthEval.depthPath,
+		Scenarios:  depthEval.names,
 	}
 	if opts.Samples > 0 {
-		depthResult.Sampled = intPtr(sampled.MaxDepth)
+		depthResult.Sampled = intPtr(depthEval.sampled.MaxDepth)
+		dd := summarise(depthEval.sampled.Distribution.Depths)
+		depthResult.Distribution = &dd
 	}
 	results = append(results, depthResult)
 
 	fanOutResult := CheckResult{
-		Name:         "max-fan-out",
-		Pass:         staticFanOut <= opts.MaxFanOut,
-		Limit:        opts.MaxFanOut,
-		Actual:       staticFanOut,
-		SamplesRun:   sampled.TracesRun,
-		Ref:          fanOutRef,
-		Distribution: fanOutDist,
+		Name:       "max-fan-out",
+		Pass:       fanOutEval.fanOut <= opts.MaxFanOut,
+		Limit:      opts.MaxFanOut,
+		Actual:     fanOutEval.fanOut,
+		SamplesRun: fanOutEval.sampled.TracesRun,
+		Ref:        fanOutEval.fanOutRef,
+		Scenarios:  fanOutEval.names,
 	}
 	if opts.Samples > 0 {
-		fanOutResult.Sampled = intPtr(sampled.MaxFanOut)
+		fanOutResult.Sampled = intPtr(fanOutEval.sampled.MaxFanOut)
+		fd := summarise(fanOutEval.sampled.Distribution.FanOuts)
+		fanOutResult.Distribution = &fd
 	}
 	results = append(results, fanOutResult)
 
 	spansResult := CheckResult{
-		Name:         "max-spans",
-		Pass:         staticSpans <= opts.MaxSpans,
-		Limit:        opts.MaxSpans,
-		Actual:       staticSpans,
-		SamplesRun:   sampled.TracesRun,
-		Distribution: spansDist,
+		Name:       "max-spans",
+		Pass:       spansEval.spans <= opts.MaxSpans,
+		Limit:      opts.MaxSpans,
+		Actual:     spansEval.spans,
+		SamplesRun: spansEval.sampled.TracesRun,
+		Scenarios:  spansEval.names,
 	}
 	if opts.Samples > 0 {
-		spansResult.Sampled = intPtr(sampled.MaxSpans)
+		spansResult.Sampled = intPtr(spansEval.sampled.MaxSpans)
+		sd := summarise(spansEval.sampled.Distribution.Spans)
+		spansResult.Distribution = &sd
 	}
 	results = append(results, spansResult)
 

--- a/pkg/synth/check_test.go
+++ b/pkg/synth/check_test.go
@@ -812,3 +812,164 @@ func TestRealisticSampledWithinStatic(t *testing.T) {
 		}
 	})
 }
+
+// --- Scenario-aware checks ---
+
+func TestScenarioSets_Empty(t *testing.T) {
+	sets := ScenarioSets(nil)
+	if len(sets) != 1 {
+		t.Fatalf("expected baseline only, got %d sets", len(sets))
+	}
+	if len(sets[0].Names) != 0 || sets[0].Overrides != nil {
+		t.Fatalf("baseline set should be empty, got %+v", sets[0])
+	}
+}
+
+func TestScenarioSets_OverlappingWindows(t *testing.T) {
+	scenarios := []Scenario{
+		{Name: "a", Start: 1 * time.Minute, End: 3 * time.Minute},
+		{Name: "b", Start: 2 * time.Minute, End: 4 * time.Minute},
+	}
+
+	sets := ScenarioSets(scenarios)
+
+	var got [][]string
+	for _, s := range sets {
+		got = append(got, s.Names)
+	}
+	want := [][]string{nil, {"a"}, {"a", "b"}, {"b"}}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d sets %v, got %d: %v", len(want), want, len(got), got)
+	}
+	for i := range want {
+		if len(got[i]) != len(want[i]) {
+			t.Fatalf("set %d: expected %v, got %v", i, want[i], got[i])
+		}
+		for j := range want[i] {
+			if got[i][j] != want[i][j] {
+				t.Fatalf("set %d: expected %v, got %v", i, want[i], got[i])
+			}
+		}
+	}
+}
+
+func TestScenarioSets_DisjointWindowsDeduplicated(t *testing.T) {
+	// Identical override behaviour but distinct names — both appear once each.
+	scenarios := []Scenario{
+		{Name: "early", Start: 0, End: 1 * time.Minute},
+		{Name: "late", Start: 5 * time.Minute, End: 6 * time.Minute},
+	}
+
+	sets := ScenarioSets(scenarios)
+	if len(sets) != 3 {
+		t.Fatalf("expected baseline + 2 singleton sets, got %d", len(sets))
+	}
+}
+
+// scenarioCheckTopo builds A→B with an isolated C, plus a scenario that adds
+// B→C during its window (deepening the worst-case trace from 1 to 2).
+func scenarioCheckTopo(t *testing.T) (*Topology, []Scenario) {
+	t.Helper()
+	s := &Service{Name: "s", Operations: make(map[string]*Operation)}
+	opC := &Operation{Service: s, Name: "C", Ref: "s.C",
+		Duration: Distribution{Mean: 10 * time.Millisecond}}
+	opB := &Operation{Service: s, Name: "B", Ref: "s.B",
+		Duration: Distribution{Mean: 10 * time.Millisecond}}
+	opA := &Operation{Service: s, Name: "A", Ref: "s.A",
+		Duration: Distribution{Mean: 10 * time.Millisecond},
+		Calls:    []Call{{Operation: opB}}}
+	s.Operations["A"] = opA
+	s.Operations["B"] = opB
+	s.Operations["C"] = opC
+
+	topo := &Topology{
+		Services: map[string]*Service{"s": s},
+		Roots:    []*Operation{opA, opC},
+	}
+	scenarios := []Scenario{{
+		Name:  "deepen",
+		Start: 1 * time.Minute,
+		End:   2 * time.Minute,
+		Overrides: map[string]Override{
+			"s.B": {AddCalls: []Call{{Operation: opC}}},
+		},
+	}}
+	return topo, scenarios
+}
+
+func TestCheck_ScenarioProducesWorstCase(t *testing.T) {
+	topo, scenarios := scenarioCheckTopo(t)
+
+	results := Check(topo, CheckOptions{
+		MaxDepth:  1,
+		MaxFanOut: 100,
+		MaxSpans:  10000,
+		Samples:   20,
+		Seed:      42,
+		Scenarios: scenarios,
+	})
+
+	var depthResult *CheckResult
+	for i := range results {
+		if results[i].Name == "max-depth" {
+			depthResult = &results[i]
+		}
+	}
+	if depthResult == nil {
+		t.Fatal("missing max-depth result")
+	}
+	if depthResult.Pass {
+		t.Fatalf("depth check should fail under scenario: actual=%d", depthResult.Actual)
+	}
+	if depthResult.Actual != 2 {
+		t.Fatalf("expected scenario worst-case depth 2, got %d", depthResult.Actual)
+	}
+	if len(depthResult.Scenarios) != 1 || depthResult.Scenarios[0] != "deepen" {
+		t.Fatalf("expected worst case attributed to scenario %q, got %v", "deepen", depthResult.Scenarios)
+	}
+	if depthResult.Sampled == nil || *depthResult.Sampled != 2 {
+		t.Fatalf("expected sampled depth 2 under scenario overrides, got %v", depthResult.Sampled)
+	}
+}
+
+func TestCheck_BaselineWinsWithoutScenarios(t *testing.T) {
+	topo, _ := scenarioCheckTopo(t)
+
+	// Without scenarios the same topology passes the tight depth limit.
+	results := Check(topo, CheckOptions{
+		MaxDepth:  1,
+		MaxFanOut: 100,
+		MaxSpans:  10000,
+		Samples:   20,
+		Seed:      42,
+	})
+	for _, r := range results {
+		if !r.Pass {
+			t.Fatalf("baseline check %s should pass, got FAIL (actual=%d)", r.Name, r.Actual)
+		}
+		if len(r.Scenarios) != 0 {
+			t.Fatalf("baseline check %s should not name scenarios, got %v", r.Name, r.Scenarios)
+		}
+	}
+
+	// A scenario that only removes calls never beats the baseline worst case.
+	shrink := []Scenario{{
+		Name:  "shrink",
+		Start: 0,
+		End:   time.Minute,
+		Overrides: map[string]Override{
+			"s.A": {RemoveCalls: map[string]bool{"s.B": true}},
+		},
+	}}
+	results = Check(topo, CheckOptions{
+		MaxDepth:  10,
+		MaxFanOut: 100,
+		MaxSpans:  10000,
+		Scenarios: shrink,
+	})
+	for _, r := range results {
+		if len(r.Scenarios) != 0 {
+			t.Fatalf("check %s: baseline should win over call-removing scenario, got %v", r.Name, r.Scenarios)
+		}
+	}
+}


### PR DESCRIPTION
Closes #70 (part of the property-testing epic, issue 62).

`motel check` previously analysed the topology in isolation: a topology that passes all checks could still violate bounds when a scenario adds calls or retries. It now reads the `scenarios:` block already present in the topology YAML — per the design discussion on the issue, no new input flags are needed.

## How it works

- **Combination enumeration**: scenario windows are swept at their start/end boundaries to find every distinct combination of co-active scenarios (active sets only change at boundaries, so this covers every combination that occurs in time). This answers the issue's open questions: rather than varying activation randomly per sample or sweeping continuously, every reachable combination is checked deterministically.
- **Static analysis under overrides**: worst-case depth, fan-out, and span analysis apply each combination's `add_calls`/`remove_calls` via the engine's existing `effectiveCalls` resolution. Exported `MaxDepth`/`MaxFanOut`/`MaxSpans`/`SampleTraces` signatures are unchanged; they delegate to override-aware internals.
- **Sampled exploration under overrides**: each combination is sampled with its overrides active, using a shared seed so combinations sample the same trace sequence.
- **Worst-case attribution**: each check reports the combination that produced the worst case (by static value, sampled maximum as tie-breaker; ties go to the baseline) in a new `CheckResult.Scenarios` field, rendered as a `scenarios:` annotation in the CLI output.
- **Opt-out**: `--skip-scenarios` restores baseline-only checking, per the issue discussion.

## Example

```
$ motel check topology.yaml --samples 100
PASS  max-depth: 1 (limit: 10)
      path: gateway.handle → backend.process
      p50: 1  p95: 1  p99: 1  max: 1  (100 samples)
PASS  max-fan-out: 5 (limit: 100)
      worst: gateway.handle
      scenarios: retry storm
      p50: 2  p95: 2  p99: 2  max: 2  (100 samples)
PASS  max-spans: 6 static worst-case, 3 observed/100 samples (limit: 10000)
      scenarios: retry storm
      p50: 3  p95: 3  p99: 3  max: 3  (100 samples)
```

## Testing

- Unit tests for `ScenarioSets` enumeration (empty, overlapping windows, disjoint dedup) and for `Check` attribution (scenario producing the worst case fails a tight limit and is named; baseline wins ties and call-removing scenarios)
- CLI tests covering the `scenarios:` output annotation and `--skip-scenarios`
- All existing check/property tests pass unchanged; `make test` and `make lint` green

Independent of PR 140 — branched from main.

https://claude.ai/code/session_01TgWavXRfzQiTWDZccuS2pf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgWavXRfzQiTWDZccuS2pf)_