### PR TITLE
Validate motel check against published empirical trace metrics

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -25,6 +25,8 @@ motel run --stdout --duration 5s docs/examples/basic-topology.yaml
 | `ottl-transforms.yaml` | Messy, realistic attributes for practising OTTL transformations. |
 | `stress-test.yaml` | High-volume bursty topology for stress-testing collector queues. |
 | `tail-sampling-test.yaml` | Mix of normal, slow, error, and VIP traces for testing tail sampling policies. |
+| `alibaba-call-graph.yaml` | Alibaba-style call graph modelling published trace study characteristics (depth 6, fan-out 10, 16% repeated calls). |
+| `meta-wide-fanout.yaml` | Meta-style wide fan-out workflow (50 children at the aggregation tier) from published trace studies. |
 
 ## Subdirectories
 

--- a/docs/examples/alibaba-call-graph.yaml
+++ b/docs/examples/alibaba-call-graph.yaml
@@ -1,0 +1,133 @@
+# Alibaba-style call graph modelled on published trace studies
+#
+# Models the structural characteristics reported by Luo et al., "An In-Depth
+# Study of Microservice Call Graph and Runtime Performance" (IEEE TPDS 2022):
+#   - Call graph depth 6 (top services show depths 2-6)
+#   - Maximum children set size 10 (reported range 1-10)
+#   - Repeated call rate 3/18 = 16.7% of call edges (reported: 16.2%)
+#   - Memcached-dominated leaf tier (the paper reports heavy cache access)
+#
+# Expected `motel check` static results: depth 6, fan-out 10, spans 24.
+# Validated by TestEmpiricalAlibaba* in pkg/synth/empirical_test.go.
+
+version: 1
+
+services:
+  gateway:
+    resource_attributes:
+      deployment.environment: production
+    operations:
+      POST /checkout:
+        duration: 45ms +/- 15ms
+        error_rate: 0.1%
+        calls:
+          - target: orchestrator.compose
+
+  orchestrator:
+    operations:
+      compose:
+        duration: 30ms +/- 10ms
+        error_rate: 0.2%
+        call_style: parallel
+        calls:
+          - target: product.detail
+          - target: customer.profile
+          - target: cart.summary
+            probability: 0.9
+          - target: promotion.evaluate
+            probability: 0.7
+          - target: memcached.get
+            count: 3
+          - target: shipping.estimate
+            probability: 0.8
+          - target: recommend.related
+            count: 2
+            probability: 0.5
+
+  product:
+    operations:
+      detail:
+        duration: 15ms +/- 5ms
+        calls:
+          - target: inventory.check
+            probability: 0.75
+          - target: memcached.get
+
+  inventory:
+    operations:
+      check:
+        duration: 10ms +/- 3ms
+        calls:
+          - target: reservation.hold
+            probability: 0.8
+
+  reservation:
+    operations:
+      hold:
+        duration: 8ms +/- 2ms
+        calls:
+          - target: cache.get
+            probability: 0.9
+
+  cache:
+    operations:
+      get:
+        duration: 2ms +/- 1ms
+        calls:
+          - target: memcached.get
+            count: 2
+
+  customer:
+    operations:
+      profile:
+        duration: 12ms +/- 4ms
+        calls:
+          - target: db.query
+
+  cart:
+    operations:
+      summary:
+        duration: 10ms +/- 3ms
+        calls:
+          - target: memcached.get
+
+  promotion:
+    operations:
+      evaluate:
+        duration: 9ms +/- 3ms
+        calls:
+          - target: db.query
+
+  shipping:
+    operations:
+      estimate:
+        duration: 14ms +/- 5ms
+        calls:
+          - target: geo.lookup
+
+  recommend:
+    operations:
+      related:
+        duration: 11ms +/- 4ms
+        calls:
+          - target: memcached.get
+
+  memcached:
+    operations:
+      get:
+        duration: 1ms +/- 0.5ms
+        error_rate: 0.01%
+
+  db:
+    operations:
+      query:
+        duration: 5ms +/- 2ms
+        error_rate: 0.1%
+
+  geo:
+    operations:
+      lookup:
+        duration: 6ms +/- 2ms
+
+traffic:
+  rate: 20/s

--- a/docs/examples/meta-wide-fanout.yaml
+++ b/docs/examples/meta-wide-fanout.yaml
@@ -1,0 +1,77 @@
+# Meta-style wide fan-out workflow modelled on published trace studies
+#
+# Models the structural characteristics reported by Huye, Shkuro, and
+# Sambasivan, "Lifting the Veil on Meta's Microservice Architecture"
+# (USENIX ATC 2023) and Du et al., "A Microservice Graph Generator with
+# Production Characteristics" (ICS 2025):
+#   - Children set size 50 at the aggregation tier (Du et al. report up
+#     to 50 children per service at Meta, versus 1-10 at Alibaba)
+#   - Shallow, wide workflow shape: an aggregator fanning out to many
+#     ranking leaves, typical of feed and ranking request workflows
+#
+# Expected `motel check` static results: depth 3, fan-out 50, spans 54.
+# Validated by TestEmpiricalMeta* in pkg/synth/empirical_test.go.
+
+version: 1
+
+services:
+  web:
+    resource_attributes:
+      deployment.environment: production
+    operations:
+      GET /feed:
+        duration: 120ms +/- 40ms
+        error_rate: 0.1%
+        calls:
+          - target: feed-agg.rank
+
+  feed-agg:
+    operations:
+      rank:
+        duration: 80ms +/- 25ms
+        error_rate: 0.2%
+        call_style: parallel
+        calls:
+          - target: ranking-leaf.score
+            count: 40
+          - target: cache.get
+            count: 8
+          - target: social-graph.follows
+          - target: content-store.fetch
+
+  ranking-leaf:
+    operations:
+      score:
+        duration: 10ms +/- 4ms
+
+  cache:
+    operations:
+      get:
+        duration: 1ms +/- 0.5ms
+
+  social-graph:
+    operations:
+      follows:
+        duration: 8ms +/- 3ms
+        calls:
+          - target: social-db.query
+
+  social-db:
+    operations:
+      query:
+        duration: 4ms +/- 1ms
+
+  content-store:
+    operations:
+      fetch:
+        duration: 12ms +/- 4ms
+        calls:
+          - target: blob-cache.get
+
+  blob-cache:
+    operations:
+      get:
+        duration: 2ms +/- 1ms
+
+traffic:
+  rate: 50/s

--- a/docs/research/empirical-validation.md
+++ b/docs/research/empirical-validation.md
@@ -1,0 +1,141 @@
+# Validating motel check Against Published Trace Studies
+
+`motel check` computes static worst-case bounds and Monte Carlo percentile
+distributions for trace depth, fan-out, and span count. The Alibaba and Meta
+trace studies report empirical distributions for the same structural metrics,
+measured from production traffic. This document validates `check` against
+those independently published numbers: topologies under `docs/examples/` were
+constructed to exhibit the reported characteristics, and the test suite in
+`pkg/synth/empirical_test.go` verifies that `check` reproduces them.
+
+## Method
+
+1. Model the structural characteristics each paper reports as a topology
+   (`docs/examples/alibaba-call-graph.yaml`, `docs/examples/meta-wide-fanout.yaml`).
+2. Verify the static analysis (`MaxDepth`, `MaxFanOut`, `MaxSpans`) returns
+   exactly the values the topology was constructed to exhibit.
+3. Run Monte Carlo sampling (1000 traces, fixed seed) and verify the
+   p50/p95/p99/max distributions stay within the published ranges and never
+   exceed the static bounds.
+
+This validates the analysis engine in both directions: the static DFS agrees
+with hand-computed expectations on realistic graph shapes, and the simulation
+engine produces trace populations consistent with both the static bounds and
+the published distributions.
+
+## Alibaba (Luo et al., IEEE TPDS 2022)
+
+The paper analyses production call graphs from Alibaba clusters and reports:
+
+| Published metric           | Reported value          | Modelled in topology         | check agrees |
+| -------------------------- | ----------------------- | ---------------------------- | ------------ |
+| Call graph depth           | 2–6 for top services    | Longest path depth 6         | Yes          |
+| Children set sizes         | 1–10                    | Max fan-out 10               | Yes          |
+| Repeated call rate         | 16.2%                   | 3 of 18 call edges (16.7%)   | Yes          |
+| Cache-dominated leaf tier  | Heavy memcached access  | memcached is the common leaf | n/a (shape)  |
+
+`motel check --seed 42 docs/examples/alibaba-call-graph.yaml` reports:
+
+```
+PASS  max-depth: 6 (limit: 10)
+      path: gateway.POST /checkout → orchestrator.compose → product.detail → inventory.check → reservation.hold → cache.get → memcached.get
+      p50: 6  p95: 6  p99: 6  max: 6  (1000 samples)
+PASS  max-fan-out: 10 (limit: 100)
+      worst: orchestrator.compose
+      p50: 8  p95: 10  p99: 10  max: 10  (1000 samples)
+PASS  max-spans: 24 static worst-case, 24 observed/1000 samples (limit: 10000)
+      p50: 19  p95: 24  p99: 24  max: 24  (1000 samples)
+```
+
+The static bounds (depth 6, fan-out 10, spans 24) match hand-computed
+expectations exactly. The sampled distributions behave as the model predicts:
+fan-out varies between the deterministic floor (5 children) and the bound
+(10) according to the per-call probabilities, span counts spread below the
+worst case, and no sampled value exceeds a static bound.
+
+The repeated call rate is checked against the topology definition rather
+than `check` output: `check` does not report repeated calls as a metric, so
+the test computes the fraction of call edges with `count > 1` directly from
+the parsed config (16.7%, within tolerance of the published 16.2%).
+
+## Meta (Huye et al., USENIX ATC 2023; Du et al., ICS 2025)
+
+Huye et al. characterise Meta's request workflows as wide and shallow at the
+aggregation tier; Du et al. quantify children set sizes of up to 50 at Meta
+(versus 1–10 at Alibaba). The modelled topology is a feed-style workflow with
+an aggregator fanning out to 40 ranking leaves plus cache and metadata calls.
+
+| Published metric   | Reported value           | Modelled in topology | check agrees |
+| ------------------ | ------------------------ | -------------------- | ------------ |
+| Children set sizes | Up to 50 (Meta)          | Fan-out 50           | Yes          |
+| Workflow shape     | Wide, shallow aggregation | Depth 3, 54 spans    | Yes          |
+
+`motel check --seed 42 docs/examples/meta-wide-fanout.yaml` reports:
+
+```
+PASS  max-depth: 3 (limit: 10)
+      path: web.GET /feed → feed-agg.rank → social-graph.follows → social-db.query
+      p50: 3  p95: 3  p99: 3  max: 3  (1000 samples)
+PASS  max-fan-out: 50 (limit: 100)
+      worst: feed-agg.rank
+      p50: 50  p95: 50  p99: 50  max: 50  (1000 samples)
+PASS  max-spans: 54 static worst-case, 54 observed/1000 samples (limit: 10000)
+      p50: 54  p95: 54  p99: 54  max: 54  (1000 samples)
+```
+
+This topology is fully deterministic, so it doubles as an exactness check:
+every sampled trace must realise the static worst case, and the percentile
+distributions must be constant. They are.
+
+## Discrepancies and limitations
+
+No disagreements between `check` and the modelled values were found. The
+following published metrics could not be validated through `check` and are
+documented as limitations:
+
+- **Overlap rate (77.1%, Luo et al.).** Measures how often the same call
+  graph topology recurs across traces of the same entry service. This is a
+  cross-trace population metric; `check` analyses one topology and reports
+  per-trace structure, so there is no corresponding output to compare. The
+  simulation engine does produce overlapping topologies (probabilistic calls
+  make trace shapes recur), but quantifying that would require a new metric.
+- **Repeated call rate (16.2%, Luo et al.).** Validated against the topology
+  definition, not `check` output, because `check` does not report repeated
+  calls as a separate metric. Repeated calls are reflected in fan-out and
+  span counts (a `count: 3` edge contributes 3 to its caller's fan-out).
+- **Topology dynamics over time (Huye et al.).** Meta's paper reports churn
+  in the service topology itself. motel models this with scenarios
+  (`add_calls`/`remove_calls`), but `check` analyses the base topology
+  without scenario overlays, so dynamics are out of scope here.
+- **Depth distribution shape.** Luo et al. report that most call graphs are
+  shallow with a long tail. A single topology cannot reproduce a
+  population-level depth distribution across many distinct entry services;
+  the modelled topology instead represents one deep (depth-6) entry service
+  from the top of the published range. The property-based generator in
+  `pkg/synth/check_test.go` (`genRealisticConfig`) covers the population
+  view by drawing many topologies from the published distributions.
+
+## Reproducing
+
+```sh
+make build
+build/motel check --seed 42 docs/examples/alibaba-call-graph.yaml
+build/motel check --seed 42 docs/examples/meta-wide-fanout.yaml
+go test ./pkg/synth/ -run TestEmpirical -v
+```
+
+## References
+
+- Luo et al., "An In-Depth Study of Microservice Call Graph and Runtime
+  Performance," _IEEE TPDS_, 2022.
+  [IEEE Xplore](https://ieeexplore.ieee.org/document/9774016/)
+- Luo et al., "Characterizing Microservice Dependency and Performance:
+  Alibaba Trace Analysis," _SoCC_, 2021.
+  [ACM DL](https://dl.acm.org/doi/10.1145/3472883.3487003)
+- Huye, Shkuro, and Sambasivan, "Lifting the Veil on Meta's Microservice
+  Architecture," _USENIX ATC_, 2023.
+  [USENIX](https://www.usenix.org/conference/atc23/presentation/huye)
+- Du et al., "A Microservice Graph Generator with Production
+  Characteristics," _ICS_, 2025.
+  [arXiv](https://arxiv.org/html/2412.19083v1)
+- [Related work survey](related-work.md)

--- a/docs/research/related-work.md
+++ b/docs/research/related-work.md
@@ -46,7 +46,9 @@ but from production traces rather than a model.
 
 These papers do the inverse of what `check` does -- they observe production
 traffic to measure trace shape. `check` predicts it from a model. The metrics
-are the same.
+are the same. [empirical-validation.md](empirical-validation.md) validates
+`check` against the numbers these studies report, using topologies under
+`docs/examples/` that model the published characteristics.
 
 ## Static worst-case analysis
 

--- a/pkg/synth/empirical_test.go
+++ b/pkg/synth/empirical_test.go
@@ -1,0 +1,225 @@
+package synth
+
+import (
+	"math"
+	"testing"
+)
+
+// Validation of Check against published empirical trace studies.
+//
+// The topologies under docs/examples model structural characteristics
+// reported from production trace analyses:
+//
+//   - Luo et al., "An In-Depth Study of Microservice Call Graph and Runtime
+//     Performance" (IEEE TPDS 2022): Alibaba call graphs with depth 2-6 for
+//     top services, children set sizes 1-10, and a 16.2% repeated call rate.
+//   - Huye, Shkuro, and Sambasivan, "Lifting the Veil on Meta's Microservice
+//     Architecture" (USENIX ATC 2023) and Du et al., "A Microservice Graph
+//     Generator with Production Characteristics" (ICS 2025): wide, shallow
+//     Meta workflows with children set sizes up to 50.
+//
+// These tests verify that the static analysis reproduces the structural
+// bounds the topologies were built to exhibit, and that Monte Carlo sampling
+// stays within both the static bounds and the published ranges. See
+// docs/research/empirical-validation.md for the full comparison.
+
+const (
+	alibabaTopologyPath = "../../docs/examples/alibaba-call-graph.yaml"
+	metaTopologyPath    = "../../docs/examples/meta-wide-fanout.yaml"
+
+	empiricalSamples = 1000
+	empiricalSeed    = 42
+)
+
+// Published Alibaba characteristics (Luo et al. TPDS 2022) and the values
+// the modelled topology is constructed to exhibit.
+const (
+	alibabaDepth     = 6
+	alibabaMinDepth  = 2
+	alibabaFanOut    = 10
+	alibabaWorstCase = 24
+
+	// Deterministic calls alone give orchestrator.compose five children
+	// (product, customer, and three memcached calls), so sampled fan-out
+	// can never drop below this.
+	alibabaMinFanOut = 5
+
+	publishedRepeatedCallRate = 0.162
+	repeatedCallRateTolerance = 0.01
+)
+
+// Published Meta characteristics (Huye et al. ATC 2023, Du et al. ICS 2025)
+// and the values the modelled topology is constructed to exhibit. The
+// topology is fully deterministic, so sampled values must match exactly.
+const (
+	metaDepth     = 3
+	metaFanOut    = 50
+	metaWorstCase = 54
+)
+
+func loadEmpiricalTopology(t *testing.T, path string) (*Config, *Topology) {
+	t.Helper()
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig(%s): %v", path, err)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig(%s): %v", path, err)
+	}
+	topo, err := BuildTopology(cfg)
+	if err != nil {
+		t.Fatalf("BuildTopology(%s): %v", path, err)
+	}
+	return cfg, topo
+}
+
+// repeatedCallRate returns the fraction of call edges with count > 1,
+// matching Luo et al.'s definition of repeated calls: the same caller
+// invoking the same callee more than once within a call graph.
+func repeatedCallRate(cfg *Config) float64 {
+	total, repeated := 0, 0
+	for _, svc := range cfg.Services {
+		for _, op := range svc.Operations {
+			for _, call := range op.Calls {
+				total++
+				if call.Count > 1 {
+					repeated++
+				}
+			}
+		}
+	}
+	if total == 0 {
+		return 0
+	}
+	return float64(repeated) / float64(total)
+}
+
+func TestEmpiricalAlibabaStaticBounds(t *testing.T) {
+	_, topo := loadEmpiricalTopology(t, alibabaTopologyPath)
+
+	depth, path := MaxDepth(topo)
+	if depth != alibabaDepth {
+		t.Errorf("static depth: expected %d, got %d (path: %v)", alibabaDepth, depth, path)
+	}
+	if len(path) != alibabaDepth+1 {
+		t.Errorf("depth path: expected %d operations, got %d: %v", alibabaDepth+1, len(path), path)
+	}
+
+	fanOut, ref := MaxFanOut(topo)
+	if fanOut != alibabaFanOut {
+		t.Errorf("static fan-out: expected %d, got %d", alibabaFanOut, fanOut)
+	}
+	if ref != "orchestrator.compose" {
+		t.Errorf("worst fan-out ref: expected orchestrator.compose, got %s", ref)
+	}
+
+	spans, root := MaxSpans(topo)
+	if spans != alibabaWorstCase {
+		t.Errorf("static spans: expected %d, got %d", alibabaWorstCase, spans)
+	}
+	if root != "gateway.POST /checkout" {
+		t.Errorf("worst root: expected gateway.POST /checkout, got %s", root)
+	}
+}
+
+func TestEmpiricalAlibabaRepeatedCallRate(t *testing.T) {
+	cfg, _ := loadEmpiricalTopology(t, alibabaTopologyPath)
+
+	rate := repeatedCallRate(cfg)
+	if math.Abs(rate-publishedRepeatedCallRate) > repeatedCallRateTolerance {
+		t.Errorf("repeated call rate: expected %.3f +/- %.3f (Luo et al. TPDS 2022), got %.3f",
+			publishedRepeatedCallRate, repeatedCallRateTolerance, rate)
+	}
+}
+
+func TestEmpiricalAlibabaSampledDistribution(t *testing.T) {
+	_, topo := loadEmpiricalTopology(t, alibabaTopologyPath)
+
+	sampled := SampleTraces(topo, empiricalSamples, empiricalSeed, 0)
+	if sampled.TracesRun != empiricalSamples {
+		t.Fatalf("expected %d traces, got %d", empiricalSamples, sampled.TracesRun)
+	}
+
+	if sampled.MaxDepth != alibabaDepth {
+		t.Errorf("sampled max depth: expected %d, got %d", alibabaDepth, sampled.MaxDepth)
+	}
+	if sampled.MaxFanOut < alibabaMinFanOut || sampled.MaxFanOut > alibabaFanOut {
+		t.Errorf("sampled max fan-out: expected within [%d, %d], got %d",
+			alibabaMinFanOut, alibabaFanOut, sampled.MaxFanOut)
+	}
+	if sampled.MaxSpans > alibabaWorstCase {
+		t.Errorf("sampled max spans %d exceeds static worst case %d", sampled.MaxSpans, alibabaWorstCase)
+	}
+
+	depthDist, _, fanOutDist := sampled.Distribution.Summary()
+	if depthDist.P50 < alibabaMinDepth || depthDist.P50 > alibabaDepth {
+		t.Errorf("depth p50: expected within published range [%d, %d], got %d",
+			alibabaMinDepth, alibabaDepth, depthDist.P50)
+	}
+	if depthDist.P99 > alibabaDepth {
+		t.Errorf("depth p99: expected at most %d, got %d", alibabaDepth, depthDist.P99)
+	}
+	if fanOutDist.P99 > alibabaFanOut {
+		t.Errorf("fan-out p99: expected at most %d, got %d", alibabaFanOut, fanOutDist.P99)
+	}
+}
+
+func TestEmpiricalMetaStaticBounds(t *testing.T) {
+	_, topo := loadEmpiricalTopology(t, metaTopologyPath)
+
+	depth, path := MaxDepth(topo)
+	if depth != metaDepth {
+		t.Errorf("static depth: expected %d, got %d (path: %v)", metaDepth, depth, path)
+	}
+
+	fanOut, ref := MaxFanOut(topo)
+	if fanOut != metaFanOut {
+		t.Errorf("static fan-out: expected %d, got %d", metaFanOut, fanOut)
+	}
+	if ref != "feed-agg.rank" {
+		t.Errorf("worst fan-out ref: expected feed-agg.rank, got %s", ref)
+	}
+
+	spans, root := MaxSpans(topo)
+	if spans != metaWorstCase {
+		t.Errorf("static spans: expected %d, got %d", metaWorstCase, spans)
+	}
+	if root != "web.GET /feed" {
+		t.Errorf("worst root: expected web.GET /feed, got %s", root)
+	}
+}
+
+func TestEmpiricalMetaSampledMatchesStatic(t *testing.T) {
+	_, topo := loadEmpiricalTopology(t, metaTopologyPath)
+
+	sampled := SampleTraces(topo, empiricalSamples, empiricalSeed, 0)
+	if sampled.TracesRun != empiricalSamples {
+		t.Fatalf("expected %d traces, got %d", empiricalSamples, sampled.TracesRun)
+	}
+
+	// The topology has no probabilistic or conditional calls, so every
+	// sampled trace must realise the static worst case exactly.
+	if sampled.MaxDepth != metaDepth {
+		t.Errorf("sampled max depth: expected %d, got %d", metaDepth, sampled.MaxDepth)
+	}
+	if sampled.MaxFanOut != metaFanOut {
+		t.Errorf("sampled max fan-out: expected %d, got %d", metaFanOut, sampled.MaxFanOut)
+	}
+	if sampled.MaxSpans != metaWorstCase {
+		t.Errorf("sampled max spans: expected %d, got %d", metaWorstCase, sampled.MaxSpans)
+	}
+
+	depthDist, spansDist, fanOutDist := sampled.Distribution.Summary()
+	if depthDist.P50 != metaDepth || depthDist.Max != metaDepth {
+		t.Errorf("depth distribution: expected constant %d, got p50=%d max=%d",
+			metaDepth, depthDist.P50, depthDist.Max)
+	}
+	if spansDist.P50 != metaWorstCase || spansDist.Max != metaWorstCase {
+		t.Errorf("spans distribution: expected constant %d, got p50=%d max=%d",
+			metaWorstCase, spansDist.P50, spansDist.Max)
+	}
+	if fanOutDist.P50 != metaFanOut || fanOutDist.Max != metaFanOut {
+		t.Errorf("fan-out distribution: expected constant %d, got p50=%d max=%d",
+			metaFanOut, fanOutDist.P50, fanOutDist.Max)
+	}
+}


### PR DESCRIPTION
Closes #94.

Validates the `motel check` analysis engine against independent ground truth from the Alibaba and Meta trace studies by constructing topologies that exhibit the published structural characteristics and verifying `check` reproduces them.

## What's included

**Example topologies** (`docs/examples/`):
- `alibaba-call-graph.yaml` — models Luo et al. (IEEE TPDS 2022): call graph depth 6 (published range 2–6 for top services), max children set size 10 (published 1–10), repeated call rate 16.7% (published 16.2%), memcached-dominated leaf tier. Static results: depth 6, fan-out 10, spans 24.
- `meta-wide-fanout.yaml` — models Huye et al. (USENIX ATC 2023) and Du et al. (ICS 2025): wide, shallow feed-style workflow with 50 children at the aggregation tier (published: up to 50 at Meta). Static results: depth 3, fan-out 50, spans 54. Fully deterministic, so it doubles as an exactness check — sampled distributions must be constant and equal to the static bounds.

**Test suite** (`pkg/synth/empirical_test.go`):
- Asserts static `MaxDepth`/`MaxFanOut`/`MaxSpans` match hand-computed expectations, including the worst-case path and refs.
- Runs Monte Carlo sampling (1000 traces, fixed seed) and asserts p50/p99 distributions stay within the published ranges and never exceed the static bounds.
- Verifies the modelled repeated call rate is within 0.01 of the published 16.2%, computed from the topology definition since `check` does not report repeated calls as a metric.

**Documentation** (`docs/research/empirical-validation.md`):
- Methodology, per-paper comparison tables, captured `motel check` output, and reproduction steps.
- Discrepancies and limitations section: overlap rate (77.1%) is a cross-trace population metric `check` cannot report; repeated call rate is validated against the topology rather than `check` output; topology dynamics and population-level depth distribution shape are out of scope for a single-topology analysis (the latter is covered by the existing `genRealisticConfig` property tests).

## Results

No disagreements between `check` and the modelled values were found — all static bounds match exactly, and sampled distributions behave as the model predicts.

`make test` and `make lint` pass.

https://claude.ai/code/session_01XUMUcHZyxiTbC8VYGcGHyu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUMUcHZyxiTbC8VYGcGHyu)_