### PR TITLE
import: prefer resource service.name over scope name in stdouttrace parser

### DIFF
--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -775,6 +775,58 @@ func TestImportCommand(t *testing.T) {
 	})
 }
 
+func TestRunStdoutImportRoundTrip(t *testing.T) {
+	// Not parallel: swaps os.Stdout, which the stdouttrace exporter writes to.
+	// Regression test for issue 146: the stdouttrace parser used the constant
+	// instrumentation scope name as the service name, collapsing every span
+	// into one service named after the Go module path.
+	topoPath := writeTestConfig(t, validConfig)
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	var traces bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = traces.ReadFrom(r)
+	}()
+
+	runCmd := rootCmd()
+	runCmd.SetArgs([]string{"run", "--stdout", "--duration", "100ms", topoPath})
+	runErr := runCmd.Execute()
+
+	w.Close()
+	os.Stdout = origStdout
+	<-done
+	require.NoError(t, runErr)
+	require.NotEmpty(t, traces.Bytes(), "run --stdout produced no trace output")
+
+	dir := t.TempDir()
+	tracesPath := filepath.Join(dir, "traces.jsonl")
+	require.NoError(t, os.WriteFile(tracesPath, traces.Bytes(), 0o600))
+
+	importCmd := rootCmd()
+	importCmd.SetArgs([]string{"import", tracesPath})
+	var inferred bytes.Buffer
+	importCmd.SetOut(&inferred)
+	require.NoError(t, importCmd.Execute())
+	assert.Contains(t, inferred.String(), "gateway:")
+	assert.Contains(t, inferred.String(), "backend:")
+	assert.NotContains(t, inferred.String(), "github.com/andrewh/motel")
+
+	inferredPath := filepath.Join(dir, "inferred.yaml")
+	require.NoError(t, os.WriteFile(inferredPath, inferred.Bytes(), 0o600))
+
+	validateCmd := rootCmd()
+	validateCmd.SetArgs([]string{"validate", inferredPath})
+	var validateOut bytes.Buffer
+	validateCmd.SetOut(&validateOut)
+	require.NoError(t, validateCmd.Execute())
+}
+
 // mockShutdownable records shutdown calls and executes a configurable function.
 type mockShutdownable struct {
 	shutdownFunc func(context.Context) error

--- a/pkg/synth/traceimport/span.go
+++ b/pkg/synth/traceimport/span.go
@@ -123,6 +123,7 @@ type stdouttraceEvent struct {
 	StartTime            time.Time `json:"StartTime"`
 	EndTime              time.Time `json:"EndTime"`
 	Attributes           []sdkAttr `json:"Attributes"`
+	Resource             []sdkAttr `json:"Resource"`
 	Status               sdkStatus `json:"Status"`
 	InstrumentationScope struct {
 		Name string `json:"Name"`
@@ -141,15 +142,24 @@ type sdkStatus struct {
 	Code string `json:"Code"`
 }
 
+// Attribute keys consulted when determining a span's service name.
+// unknownServicePrefix is the placeholder the OTel SDK assigns to
+// service.name when none was configured; it carries no service identity.
+const (
+	serviceNameKey       = "service.name"
+	synthServiceKey      = "synth.service"
+	unknownServicePrefix = "unknown_service"
+)
+
 // excludedAttributes are engine-internal or infrastructure attributes to omit.
 var excludedAttributes = map[string]bool{
-	"synth.service":          true,
+	synthServiceKey:          true,
 	"synth.operation":        true,
 	"synth.scenarios":        true,
 	"telemetry.sdk.language": true,
 	"telemetry.sdk.name":     true,
 	"telemetry.sdk.version":  true,
-	"service.name":           true,
+	serviceNameKey:           true,
 }
 
 func parseStdouttrace(data []byte) ([]Span, error) {
@@ -170,16 +180,16 @@ func parseStdouttrace(data []byte) ([]Span, error) {
 			return nil, fmt.Errorf("line %d: %w", lineNum, err)
 		}
 
-		// Determine service name: InstrumentationScope.Name, with synth.service fallback
-		service := evt.InstrumentationScope.Name
+		// Service name precedence: resource service.name, then the
+		// synth.service attribute, then the instrumentation scope name —
+		// matching the OTLP path. The scope name comes last because current
+		// motel binaries emit a constant module-path scope name on every span.
+		service := realServiceName(stringAttr(evt.Resource, serviceNameKey))
 		if service == "" {
-			for _, attr := range evt.Attributes {
-				if attr.Key == "synth.service" {
-					if s, ok := attr.Value.Value.(string); ok {
-						service = s
-					}
-				}
-			}
+			service = stringAttr(evt.Attributes, synthServiceKey)
+		}
+		if service == "" {
+			service = evt.InstrumentationScope.Name
 		}
 
 		// Determine parent ID, treating all-zeros as empty (root span)
@@ -231,10 +241,11 @@ func parseOTLP(data []byte) ([]Span, error) {
 		// Extract service.name from resource attributes
 		serviceName := ""
 		for _, attr := range rs.Resource.GetAttributes() {
-			if attr.Key == "service.name" {
+			if attr.Key == serviceNameKey {
 				serviceName = attr.Value.GetStringValue()
 			}
 		}
+		serviceName = realServiceName(serviceName)
 
 		for _, ss := range rs.ScopeSpans {
 			scopeName := ss.Scope.GetName()
@@ -279,6 +290,28 @@ func parseOTLP(data []byte) ([]Span, error) {
 		return nil, fmt.Errorf("no spans found in input")
 	}
 	return spans, nil
+}
+
+// stringAttr returns the string value of the attribute with the given key,
+// or empty if the key is absent or not a string.
+func stringAttr(attrs []sdkAttr, key string) string {
+	for _, attr := range attrs {
+		if attr.Key == key {
+			if s, ok := attr.Value.Value.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// realServiceName filters out the SDK's unknown_service placeholder so
+// callers fall through to more specific sources of the service name.
+func realServiceName(name string) string {
+	if strings.HasPrefix(name, unknownServicePrefix) {
+		return ""
+	}
+	return name
 }
 
 // isZeroID checks if a hex-encoded ID is all zeros.

--- a/pkg/synth/traceimport/span_test.go
+++ b/pkg/synth/traceimport/span_test.go
@@ -176,6 +176,41 @@ func TestParseStdouttrace_ServiceFallback(t *testing.T) {
 	assert.Equal(t, "fallback-svc", spans[0].Service)
 }
 
+func TestParseStdouttrace_ServiceNamePrecedence(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			// Current binaries: per-service resource, constant module-path scope name.
+			name: "resource service.name wins over scope name",
+			line: `{"Name":"op","SpanContext":{"TraceID":"t1","SpanID":"s1"},"Parent":{"TraceID":"t1","SpanID":"0000000000000000"},"StartTime":"2024-01-01T00:00:00Z","EndTime":"2024-01-01T00:00:01Z","Attributes":[{"Key":"synth.service","Value":{"Type":"STRING","Value":"checkout"}}],"Resource":[{"Key":"service.name","Value":{"Type":"STRING","Value":"checkout"}}],"Status":{"Code":"Unset"},"InstrumentationScope":{"Name":"github.com/andrewh/motel"}}`,
+			want: "checkout",
+		},
+		{
+			// Older binaries: placeholder resource, synth.service attribute set.
+			name: "unknown_service placeholder falls back to synth.service",
+			line: `{"Name":"op","SpanContext":{"TraceID":"t1","SpanID":"s1"},"Parent":{"TraceID":"t1","SpanID":"0000000000000000"},"StartTime":"2024-01-01T00:00:00Z","EndTime":"2024-01-01T00:00:01Z","Attributes":[{"Key":"synth.service","Value":{"Type":"STRING","Value":"checkout"}}],"Resource":[{"Key":"service.name","Value":{"Type":"STRING","Value":"unknown_service:motel-synth"}}],"Status":{"Code":"Unset"},"InstrumentationScope":{"Name":"checkout-scope"}}`,
+			want: "checkout",
+		},
+		{
+			name: "unknown_service placeholder without synth.service falls back to scope name",
+			line: `{"Name":"op","SpanContext":{"TraceID":"t1","SpanID":"s1"},"Parent":{"TraceID":"t1","SpanID":"0000000000000000"},"StartTime":"2024-01-01T00:00:00Z","EndTime":"2024-01-01T00:00:01Z","Attributes":[],"Resource":[{"Key":"service.name","Value":{"Type":"STRING","Value":"unknown_service:app"}}],"Status":{"Code":"Unset"},"InstrumentationScope":{"Name":"checkout"}}`,
+			want: "checkout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spans, err := ParseSpans(strings.NewReader(tt.line), FormatStdouttrace)
+			require.NoError(t, err)
+			require.Len(t, spans, 1)
+			assert.Equal(t, tt.want, spans[0].Service)
+		})
+	}
+}
+
 func TestParseStdouttrace_MultipleSpans(t *testing.T) {
 	lines := strings.Join([]string{
 		`{"Name":"root","SpanContext":{"TraceID":"t1","SpanID":"s1"},"Parent":{"TraceID":"t1","SpanID":"0000000000000000"},"StartTime":"2024-01-01T00:00:00Z","EndTime":"2024-01-01T00:00:01Z","Attributes":[],"Status":{"Code":"Unset"},"InstrumentationScope":{"Name":"svc"}}`,


### PR DESCRIPTION
Fixes #146

The stdouttrace parser took the service name from `InstrumentationScope.Name`, falling back to the `synth.service` attribute only when the scope name was empty. Current binaries emit a constant module-path scope name (`github.com/andrewh/motel`) on every span, so importing motel's own `--stdout` output collapsed all spans into a single service named after the Go module path, and the resulting topology failed validation.

## Changes

- The stdouttrace event struct now decodes the `Resource` attributes, and the service name precedence is: resource `service.name`, then the `synth.service` attribute, then the instrumentation scope name — matching the OTLP path.
- The SDK's `unknown_service` placeholder is treated as absent in both the stdouttrace and OTLP paths, so output from older binaries (placeholder resource `service.name`, per-service scope names) still imports correctly. The checked-in fixtures continue to pass for this reason, now via the `synth.service` fallback rather than the scope name.
- Added `serviceNameKey`/`synthServiceKey` constants in place of repeated string literals.

## Tests

- Table-driven unit tests covering the three precedence cases (current binary shape, older binary shape with the placeholder resource, placeholder resource without `synth.service`).
- A round-trip regression test (`TestRunStdoutImportRoundTrip`) that runs `run --stdout` and feeds the fresh output through `import` and `validate`, rather than relying on the checked-in fixture that masked this regression. It also asserts the inferred topology does not contain the module path as a service name.

Verified the exact repro from the issue with the built binary: `run --stdout` → `import` → `validate` now produces a valid topology with the original service names.

https://claude.ai/code/session_01L9tNd23CewbWJ8hMTGheyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9tNd23CewbWJ8hMTGheyf)_