### PR TITLE
Update GitHub Actions to use latest versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.12'
       - run: pip install 'mkdocs-material~=9.6'
       - run: make site
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -46,4 +46,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Update GitHub Actions workflow to use the latest versions of upload-pages-artifact and deploy-pages actions.

**Changes:**
- Bump `actions/upload-pages-artifact` from v4 to v5
- Bump `actions/deploy-pages` from v4 to v5

These updates ensure the documentation deployment workflow uses the latest stable versions of the GitHub Actions, which may include bug fixes, security updates, and performance improvements.

https://claude.ai/code/session_01ToVcfXf62XhMDNCzqvjzzM