### PR TITLE
Add scenario overrides for topology-driven logs

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -26,6 +26,7 @@ motel run --stdout --duration 5s docs/examples/basic-topology.yaml
 | `attribute-placement.yaml` | Resource attributes vs span attributes on the same service. |
 | `resource-attributes.yaml` | Per-service resource attributes (`deployment.environment`, `service.version`, etc.). |
 | `topology-driven-metrics.yaml` | All four metric instrument types at both service and operation level. |
+| `topology-driven-logs.yaml` | Log templates with conditions, probability, timing anchors, and scenario log overrides. |
 | `backpressure-queue.yaml` | Queue depth rejection, circuit breaker trips, and backpressure duration amplification. |
 | `internal-gateway.yaml` | Internal gateway pattern with async trace propagation through a service mesh. |
 | `ottl-transforms.yaml` | Messy, realistic attributes for practising OTTL transformations. |

--- a/docs/examples/topology-driven-logs.yaml
+++ b/docs/examples/topology-driven-logs.yaml
@@ -1,6 +1,7 @@
 # Topology-driven logs example
 # Demonstrates severity levels, body templates, conditions, probability,
-# timing anchors, and structured attributes at service and operation level.
+# timing anchors, structured attributes at service and operation level,
+# and scenario log overrides (add incident logs, mute base logs).
 # Run with:
 #   motel run --stdout --signals traces,logs --slow-threshold 100ms --duration 10s docs/examples/topology-driven-logs.yaml
 
@@ -49,3 +50,25 @@ services:
 
 traffic:
   rate: 20/s
+
+scenarios:
+  - name: db-degradation
+    at: 3s
+    duration: 4s
+    override:
+      backend.process:
+        error_rate: 15%
+        logs:
+          # Incident-specific log records, emitted only during the window.
+          # Adding logs switches backend from derived to topology logs.
+          add:
+            - severity: ERROR
+              body: "connection pool exhausted"
+              condition: error
+              attributes:
+                error.type:
+                  value: PoolExhaustedError
+      # Mute all of the gateway's base logs during the incident window
+      gateway:
+        logs:
+          disable: true

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -55,15 +55,16 @@ const (
 	logSeverityFatal = "FATAL"
 )
 
-// validLogSeverity lists supported log severity levels.
-var validLogSeverity = map[string]bool{
-	logSeverityTrace: true,
-	logSeverityDebug: true,
-	logSeverityInfo:  true,
-	logSeverityWarn:  true,
-	logSeverityError: true,
-	logSeverityFatal: true,
-}
+// validLogSeverity lists supported log severity levels. It is derived from
+// severityByName so the validation set cannot drift from the severities the
+// LogObserver can emit.
+var validLogSeverity = func() map[string]bool {
+	m := make(map[string]bool, len(severityByName))
+	for name := range severityByName {
+		m[name] = true
+	}
+	return m
+}()
 
 // Log condition constants controlling when a topology log record is emitted.
 const (

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -264,6 +264,16 @@ type OverrideConfig struct {
 	AddCalls    []CallConfig                    `yaml:"add_calls,omitempty"`
 	RemoveCalls []RemoveCallConfig              `yaml:"remove_calls,omitempty"`
 	Metrics     map[string]MetricOverrideConfig `yaml:"metrics,omitempty"`
+	Logs        *LogOverrideConfig              `yaml:"logs,omitempty"`
+}
+
+// LogOverrideConfig modifies topology log output during a scenario window.
+// Add defines extra log records emitted only while the scenario is active;
+// Disable mutes the base log definitions (topology templates and derived
+// error/slow logs) at the override's scope for the duration of the window.
+type LogOverrideConfig struct {
+	Add     []LogConfig `yaml:"add,omitempty"`
+	Disable bool        `yaml:"disable,omitempty"`
 }
 
 // MetricOverrideConfig overrides the value distribution of a named metric
@@ -669,10 +679,13 @@ func ValidateConfig(cfg *Config) error {
 				}
 				if override.Duration != "" || override.ErrorRate != "" || len(override.Attributes) > 0 ||
 					len(override.AddCalls) > 0 || len(override.RemoveCalls) > 0 {
-					return fmt.Errorf("scenario %q: override %q: service-level overrides support only metrics (use %s.<operation> for operation overrides)", sc.Name, ref, ref)
+					return fmt.Errorf("scenario %q: override %q: service-level overrides support only metrics and logs (use %s.<operation> for operation overrides)", sc.Name, ref, ref)
 				}
 			}
 			if err := validateMetricOverrides(sc.Name, ref, override.Metrics, metricsByScope[ref]); err != nil {
+				return err
+			}
+			if err := validateLogOverrides(sc.Name, ref, override.Logs); err != nil {
 				return err
 			}
 			if override.Duration != "" {
@@ -901,6 +914,23 @@ func validateMetricConfig(mc MetricConfig, prefix string) error {
 	for attrName, attrCfg := range mc.Attributes {
 		if _, err := NewAttributeGenerator(attrCfg); err != nil {
 			return fmt.Errorf("%s %q: attribute %q: %w", prefix, mc.Name, attrName, err)
+		}
+	}
+	return nil
+}
+
+// validateLogOverrides checks a scenario log override for structural correctness.
+func validateLogOverrides(scenarioName, ref string, lo *LogOverrideConfig) error {
+	if lo == nil {
+		return nil
+	}
+	if len(lo.Add) == 0 && !lo.Disable {
+		return fmt.Errorf("scenario %q: override %q: logs override must set add or disable", scenarioName, ref)
+	}
+	for i, lc := range lo.Add {
+		prefix := fmt.Sprintf("scenario %q: override %q: logs: add[%d]", scenarioName, ref, i)
+		if err := validateLogConfig(lc, prefix); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -2528,6 +2528,104 @@ func TestValidateConfigMetricOverrides(t *testing.T) {
 	})
 }
 
+func TestValidateConfigLogOverrides(t *testing.T) {
+	t.Parallel()
+
+	configWithScenario := func(override map[string]OverrideConfig) *Config {
+		return &Config{
+			Version: 1,
+			Services: []ServiceConfig{{
+				Name: "gateway",
+				Logs: []LogConfig{{Severity: "INFO", Body: "request handled"}},
+				Operations: []OperationConfig{{
+					Name:     "handle",
+					Duration: "50ms",
+				}},
+			}},
+			Traffic: TrafficConfig{Rate: "10/s"},
+			Scenarios: []ScenarioConfig{{
+				Name:     "incident",
+				At:       "+1m",
+				Duration: "5m",
+				Override: override,
+			}},
+		}
+	}
+
+	t.Run("operation-scope log add is valid", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway.handle": {Logs: &LogOverrideConfig{
+				Add: []LogConfig{{Severity: "ERROR", Body: "connection pool exhausted", Condition: "error"}},
+			}},
+		})
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("service-scope log add is valid", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway": {Logs: &LogOverrideConfig{
+				Add: []LogConfig{{Severity: "WARN", Body: "degraded mode"}},
+			}},
+		})
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("disable-only override is valid", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway": {Logs: &LogOverrideConfig{Disable: true}},
+		})
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
+	t.Run("empty logs override rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway": {Logs: &LogOverrideConfig{}},
+		})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "logs override must set add or disable")
+	})
+
+	t.Run("invalid added log rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway.handle": {Logs: &LogOverrideConfig{
+				Add: []LogConfig{{Severity: "LOUD", Body: "b"}},
+			}},
+		})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "severity must be one of")
+		assert.Contains(t, err.Error(), `scenario "incident"`)
+	})
+
+	t.Run("added log missing body rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"gateway.handle": {Logs: &LogOverrideConfig{
+				Add: []LogConfig{{Severity: "INFO"}},
+			}},
+		})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "body is required")
+	})
+
+	t.Run("unknown override key rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := configWithScenario(map[string]OverrideConfig{
+			"nosuch": {Logs: &LogOverrideConfig{Disable: true}},
+		})
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown operation or service")
+	})
+}
+
 func TestValidateConfigMetricWalkAndBounds(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/synth/logs.go
+++ b/pkg/synth/logs.go
@@ -7,6 +7,7 @@ package synth
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand/v2"
 	"regexp"
 	"slices"
@@ -50,8 +51,13 @@ type LogObserver struct {
 	loggers       map[string]log.Logger
 	slowThreshold time.Duration
 	templates     map[string][]logTemplate
+	serviceNames  map[string]bool // for disambiguating override refs containing dots
 	rng           *rand.Rand
 	mu            sync.Mutex
+
+	overrideMu   sync.RWMutex
+	addTemplates map[string][]logTemplate // scenario-added templates keyed by service
+	disabled     map[string]bool          // scopes whose base logs are muted, keyed by override ref
 }
 
 // NewLogObserver creates a LogObserver from topology log definitions.
@@ -65,7 +71,11 @@ func NewLogObserver(loggers map[string]log.Logger, topo *Topology, slowThreshold
 	}
 
 	templates := make(map[string][]logTemplate)
+	serviceNames := make(map[string]bool)
 	if topo != nil {
+		for svcName := range topo.Services {
+			serviceNames[svcName] = true
+		}
 		for svcName, svc := range topo.Services {
 			var tpls []logTemplate
 
@@ -104,8 +114,59 @@ func NewLogObserver(loggers map[string]log.Logger, topo *Topology, slowThreshold
 		loggers:       loggers,
 		slowThreshold: slowThreshold,
 		templates:     templates,
+		serviceNames:  serviceNames,
 		rng:           rng,
 	}, nil
+}
+
+// SetOverrides replaces the active scenario log overrides. The engine calls
+// this as scenario windows open and close; a nil map clears all overrides.
+// Added log definitions are pre-built into templates here so the per-span
+// path only performs map lookups.
+func (l *LogObserver) SetOverrides(overrides map[string]Override) {
+	var added map[string][]logTemplate
+	var disabled map[string]bool
+	for _, ref := range slices.Sorted(maps.Keys(overrides)) {
+		ov := overrides[ref]
+		if ov.DisableLogs {
+			if disabled == nil {
+				disabled = make(map[string]bool)
+			}
+			disabled[ref] = true
+		}
+		if len(ov.AddLogs) == 0 {
+			continue
+		}
+		svcName, opName := l.splitScopeRef(ref)
+		for _, ld := range ov.AddLogs {
+			tpl, err := newLogTemplate(ld, opName)
+			if err != nil {
+				continue // severity was validated at config load; unreachable
+			}
+			if added == nil {
+				added = make(map[string][]logTemplate)
+			}
+			added[svcName] = append(added[svcName], tpl)
+		}
+	}
+	l.overrideMu.Lock()
+	l.addTemplates = added
+	l.disabled = disabled
+	l.overrideMu.Unlock()
+}
+
+// splitScopeRef splits an override ref into service and operation names.
+// A ref matching a known service name is service-scoped (empty operation);
+// otherwise it is split at the first dot, like resolveRef.
+func (l *LogObserver) splitScopeRef(ref string) (service, operation string) {
+	if l.serviceNames[ref] {
+		return ref, ""
+	}
+	svcName, opName, ok := strings.Cut(ref, ".")
+	if !ok {
+		return ref, ""
+	}
+	return svcName, opName
 }
 
 // newLogTemplate builds a logTemplate from a resolved LogDefinition.
@@ -135,6 +196,8 @@ func newLogTemplate(ld LogDefinition, operation string) (logTemplate, error) {
 
 // Observe emits log records for the completed span. Services with topology
 // log templates emit those; services without fall back to derived error/slow logs.
+// Active scenario overrides can mute the base logs for a scope and add
+// window-scoped templates on top.
 func (l *LogObserver) Observe(info SpanInfo) {
 	logger := l.loggers[info.Service]
 	if logger == nil {
@@ -144,65 +207,78 @@ func (l *LogObserver) Observe(info SpanInfo) {
 	// Correlate emitted records with the span via the context's span context.
 	ctx := trace.ContextWithSpanContext(context.Background(), info.SpanContext)
 
+	l.overrideMu.RLock()
+	added := l.addTemplates[info.Service]
+	muted := l.disabled[info.Service] || l.disabled[info.Service+"."+info.Operation]
+	l.overrideMu.RUnlock()
+
 	templates := l.templates[info.Service]
-	if len(templates) == 0 {
-		l.emitDerived(ctx, logger, info)
+	if !muted {
+		if len(templates) == 0 && len(added) == 0 {
+			l.emitDerived(ctx, logger, info)
+			return
+		}
+		for i := range templates {
+			l.emitTemplate(ctx, logger, &templates[i], info)
+		}
+	}
+	for i := range added {
+		l.emitTemplate(ctx, logger, &added[i], info)
+	}
+}
+
+// emitTemplate emits one log record for a span if the template's operation
+// scope, condition, and probability allow it.
+func (l *LogObserver) emitTemplate(ctx context.Context, logger log.Logger, tpl *logTemplate, info SpanInfo) {
+	if tpl.operation != "" && tpl.operation != info.Operation {
 		return
 	}
-
-	for i := range templates {
-		tpl := &templates[i]
-
-		if tpl.operation != "" && tpl.operation != info.Operation {
-			continue
+	switch tpl.condition {
+	case logConditionError:
+		if !info.IsError {
+			return
 		}
-		switch tpl.condition {
-		case logConditionError:
-			if !info.IsError {
-				continue
-			}
-		case logConditionSuccess:
-			if info.IsError {
-				continue
-			}
-		case logConditionSlow:
-			if l.slowThreshold <= 0 || info.Duration <= l.slowThreshold {
-				continue
-			}
+	case logConditionSuccess:
+		if info.IsError {
+			return
 		}
-
-		// Lock only while sampling the RNG.
-		l.mu.Lock()
-		if l.rng.Float64() >= tpl.probability {
-			l.mu.Unlock()
-			continue
+	case logConditionSlow:
+		if l.slowThreshold <= 0 || info.Duration <= l.slowThreshold {
+			return
 		}
-		attrValues := make(map[string]any, len(tpl.attrGens))
-		for _, k := range tpl.attrKeys {
-			attrValues[k] = tpl.attrGens[k].Generate(l.rng)
-		}
-		l.mu.Unlock()
-
-		timestamp := info.Timestamp
-		if tpl.atEnd {
-			timestamp = timestamp.Add(info.Duration)
-		}
-		timestamp = timestamp.Add(tpl.delay)
-
-		attrs := make([]log.KeyValue, 0, len(tpl.attrKeys)+1)
-		attrs = append(attrs, log.String("operation.name", info.Operation))
-		for _, k := range tpl.attrKeys {
-			attrs = append(attrs, logKeyValue(k, attrValues[k]))
-		}
-
-		var rec log.Record
-		rec.SetTimestamp(timestamp)
-		rec.SetSeverity(tpl.severity)
-		rec.SetSeverityText(tpl.severityText)
-		rec.SetBody(log.StringValue(interpolateBody(tpl.body, attrValues, info)))
-		rec.AddAttributes(attrs...)
-		logger.Emit(ctx, rec)
 	}
+
+	// Lock only while sampling the RNG.
+	l.mu.Lock()
+	if l.rng.Float64() >= tpl.probability {
+		l.mu.Unlock()
+		return
+	}
+	attrValues := make(map[string]any, len(tpl.attrGens))
+	for _, k := range tpl.attrKeys {
+		attrValues[k] = tpl.attrGens[k].Generate(l.rng)
+	}
+	l.mu.Unlock()
+
+	timestamp := info.Timestamp
+	if tpl.atEnd {
+		timestamp = timestamp.Add(info.Duration)
+	}
+	timestamp = timestamp.Add(tpl.delay)
+
+	attrs := make([]log.KeyValue, 0, len(tpl.attrKeys)+1)
+	attrs = append(attrs, log.String("operation.name", info.Operation))
+	for _, k := range tpl.attrKeys {
+		attrs = append(attrs, logKeyValue(k, attrValues[k]))
+	}
+
+	var rec log.Record
+	rec.SetTimestamp(timestamp)
+	rec.SetSeverity(tpl.severity)
+	rec.SetSeverityText(tpl.severityText)
+	rec.SetBody(log.StringValue(interpolateBody(tpl.body, attrValues, info)))
+	rec.AddAttributes(attrs...)
+	logger.Emit(ctx, rec)
 }
 
 // emitDerived emits the built-in ERROR and WARN log records for services

--- a/pkg/synth/logs.go
+++ b/pkg/synth/logs.go
@@ -81,11 +81,7 @@ func NewLogObserver(loggers map[string]log.Logger, topo *Topology, slowThreshold
 
 			// Service-level logs (fire for every span in this service)
 			for _, ld := range svc.Logs {
-				tpl, err := newLogTemplate(ld, "")
-				if err != nil {
-					return nil, fmt.Errorf("service %q: %w", svcName, err)
-				}
-				tpls = append(tpls, tpl)
+				tpls = append(tpls, newLogTemplate(ld, ""))
 			}
 
 			// Operation-level logs (fire only for the specific operation)
@@ -96,11 +92,7 @@ func NewLogObserver(loggers map[string]log.Logger, topo *Topology, slowThreshold
 			slices.Sort(opNames)
 			for _, opName := range opNames {
 				for _, ld := range svc.Operations[opName].Logs {
-					tpl, err := newLogTemplate(ld, opName)
-					if err != nil {
-						return nil, fmt.Errorf("service %q operation %q: %w", svcName, opName, err)
-					}
-					tpls = append(tpls, tpl)
+					tpls = append(tpls, newLogTemplate(ld, opName))
 				}
 			}
 
@@ -138,15 +130,11 @@ func (l *LogObserver) SetOverrides(overrides map[string]Override) {
 			continue
 		}
 		svcName, opName := l.splitScopeRef(ref)
+		if added == nil {
+			added = make(map[string][]logTemplate)
+		}
 		for _, ld := range ov.AddLogs {
-			tpl, err := newLogTemplate(ld, opName)
-			if err != nil {
-				continue // severity was validated at config load; unreachable
-			}
-			if added == nil {
-				added = make(map[string][]logTemplate)
-			}
-			added[svcName] = append(added[svcName], tpl)
+			added[svcName] = append(added[svcName], newLogTemplate(ld, opName))
 		}
 	}
 	l.overrideMu.Lock()
@@ -170,18 +158,19 @@ func (l *LogObserver) splitScopeRef(ref string) (service, operation string) {
 }
 
 // newLogTemplate builds a logTemplate from a resolved LogDefinition.
-func newLogTemplate(ld LogDefinition, operation string) (logTemplate, error) {
-	sev, ok := severityByName[ld.Severity]
-	if !ok {
-		return logTemplate{}, fmt.Errorf("log severity %q is not one of TRACE, DEBUG, INFO, WARN, ERROR, FATAL", ld.Severity)
-	}
+// Severity is validated at config load (resolveLogs rejects names outside
+// validLogSeverity, which is derived from severityByName), so the lookup
+// cannot miss for resolved definitions. A hand-constructed definition with
+// an unknown severity maps to log.SeverityUndefined while preserving the
+// severity text, so the record still surfaces rather than disappearing.
+func newLogTemplate(ld LogDefinition, operation string) logTemplate {
 	attrKeys := make([]string, 0, len(ld.Attributes))
 	for k := range ld.Attributes {
 		attrKeys = append(attrKeys, k)
 	}
 	slices.Sort(attrKeys)
 	return logTemplate{
-		severity:     sev,
+		severity:     severityByName[ld.Severity],
 		severityText: ld.Severity,
 		body:         ld.Body,
 		condition:    ld.Condition,
@@ -191,7 +180,7 @@ func newLogTemplate(ld LogDefinition, operation string) (logTemplate, error) {
 		attrGens:     ld.Attributes,
 		attrKeys:     attrKeys,
 		operation:    operation,
-	}, nil
+	}
 }
 
 // Observe emits log records for the completed span. Services with topology

--- a/pkg/synth/logs_test.go
+++ b/pkg/synth/logs_test.go
@@ -481,6 +481,197 @@ func TestLogObserverDerivedTraceCorrelation(t *testing.T) {
 	assert.Equal(t, spanID, records[0].SpanID(), "derived log should carry the span's span ID")
 }
 
+func TestLogObserverScenarioAddOperationScope(t *testing.T) {
+	t.Parallel()
+
+	topo := testLogTopology("svc", nil, "query", nil)
+	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
+
+	obs.SetOverrides(map[string]Override{
+		"svc.query": {AddLogs: []LogDefinition{
+			{Severity: "ERROR", Body: "connection pool exhausted", Probability: 1.0},
+		}},
+	})
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query"})
+	obs.Observe(SpanInfo{Service: "svc", Operation: "other"})
+
+	records := exporter.get()
+	require.Len(t, records, 1, "operation-scoped added log should fire only for its operation")
+	assert.Equal(t, otellog.SeverityError, records[0].Severity())
+	assert.Equal(t, "connection pool exhausted", records[0].Body().AsString())
+}
+
+func TestLogObserverScenarioAddServiceScope(t *testing.T) {
+	t.Parallel()
+
+	topo := testLogTopology("svc", []LogDefinition{
+		alwaysLog("INFO", "base log"),
+	}, "query", nil)
+	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
+
+	obs.SetOverrides(map[string]Override{
+		"svc": {AddLogs: []LogDefinition{
+			{Severity: "WARN", Body: "degraded mode", Probability: 1.0},
+		}},
+	})
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query"})
+
+	records := exporter.get()
+	require.Len(t, records, 2, "base and added logs should both emit")
+	assert.Equal(t, "base log", records[0].Body().AsString())
+	assert.Equal(t, "degraded mode", records[1].Body().AsString())
+}
+
+func TestLogObserverScenarioAddRespectsCondition(t *testing.T) {
+	t.Parallel()
+
+	topo := testLogTopology("svc", nil, "query", nil)
+	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
+
+	obs.SetOverrides(map[string]Override{
+		"svc.query": {AddLogs: []LogDefinition{
+			{Severity: "ERROR", Body: "incident error", Condition: logConditionError, Probability: 1.0},
+		}},
+	})
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query", IsError: false})
+	assert.Empty(t, exporter.get(), "error-conditioned added log should not fire for success spans")
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query", IsError: true})
+	records := exporter.get()
+	require.Len(t, records, 1)
+	assert.Equal(t, "incident error", records[0].Body().AsString())
+}
+
+func TestLogObserverScenarioDisableMutesBase(t *testing.T) {
+	t.Parallel()
+
+	topo := testLogTopology("svc", []LogDefinition{
+		alwaysLog("INFO", "base log"),
+	}, "query", nil)
+	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
+
+	obs.SetOverrides(map[string]Override{
+		"svc": {DisableLogs: true},
+	})
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query", IsError: true})
+	assert.Empty(t, exporter.get(), "disable should mute base topology logs")
+
+	obs.SetOverrides(nil)
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query"})
+	records := exporter.get()
+	require.Len(t, records, 1, "clearing overrides should restore base logs")
+	assert.Equal(t, "base log", records[0].Body().AsString())
+}
+
+func TestLogObserverScenarioDisableOperationScope(t *testing.T) {
+	t.Parallel()
+
+	topo := testLogTopology("svc", []LogDefinition{
+		alwaysLog("INFO", "base log"),
+	}, "query", nil)
+	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
+
+	obs.SetOverrides(map[string]Override{
+		"svc.query": {DisableLogs: true},
+	})
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query"})
+	obs.Observe(SpanInfo{Service: "svc", Operation: "other"})
+
+	records := exporter.get()
+	require.Len(t, records, 1, "operation-scoped disable should mute only that operation's spans")
+	assert.Equal(t, "base log", records[0].Body().AsString())
+}
+
+func TestLogObserverScenarioDisableMutesDerived(t *testing.T) {
+	t.Parallel()
+
+	// Service with no topology logs: derived error logs normally fire.
+	topo := testLogTopology("svc", nil, "query", nil)
+	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
+
+	obs.SetOverrides(map[string]Override{
+		"svc": {DisableLogs: true},
+	})
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query", IsError: true})
+	assert.Empty(t, exporter.get(), "disable should mute derived error logs too")
+}
+
+func TestLogObserverScenarioAddAndDisableReplaces(t *testing.T) {
+	t.Parallel()
+
+	topo := testLogTopology("svc", []LogDefinition{
+		alwaysLog("INFO", "base log"),
+	}, "query", nil)
+	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
+
+	obs.SetOverrides(map[string]Override{
+		"svc": {
+			DisableLogs: true,
+			AddLogs: []LogDefinition{
+				{Severity: "FATAL", Body: "total outage", Probability: 1.0},
+			},
+		},
+	})
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query"})
+
+	records := exporter.get()
+	require.Len(t, records, 1, "disable plus add should replace base logs")
+	assert.Equal(t, "total outage", records[0].Body().AsString())
+}
+
+func TestLogObserverScenarioAddSuppressesDerived(t *testing.T) {
+	t.Parallel()
+
+	// Service with no topology logs: an added log counts as a topology log
+	// and suppresses the derived fallback while active.
+	topo := testLogTopology("svc", nil, "query", nil)
+	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
+
+	obs.SetOverrides(map[string]Override{
+		"svc.query": {AddLogs: []LogDefinition{
+			{Severity: "ERROR", Body: "incident error", Condition: logConditionError, Probability: 1.0},
+		}},
+	})
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query", IsError: true})
+
+	records := exporter.get()
+	require.Len(t, records, 1, "added log should replace the derived error log")
+	assert.Equal(t, "incident error", records[0].Body().AsString())
+}
+
+func TestLogObserverScenarioAddInterpolation(t *testing.T) {
+	t.Parallel()
+
+	gen, err := NewAttributeGenerator(AttributeValueConfig{Value: "PoolExhaustedError"})
+	require.NoError(t, err)
+
+	topo := testLogTopology("svc", nil, "query", nil)
+	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
+
+	obs.SetOverrides(map[string]Override{
+		"svc.query": {AddLogs: []LogDefinition{{
+			Severity:    "ERROR",
+			Body:        "{error.type} in {operation.name}",
+			Probability: 1.0,
+			Attributes:  map[string]AttributeGenerator{"error.type": gen},
+		}}},
+	})
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query"})
+
+	records := exporter.get()
+	require.Len(t, records, 1)
+	assert.Equal(t, "PoolExhaustedError in query", records[0].Body().AsString())
+	assert.Equal(t, "PoolExhaustedError", logAttrMap(records[0])["error.type"].AsString())
+}
+
 func TestLogObserverTopologyOtherServiceKeepsDerived(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/synth/logs_test.go
+++ b/pkg/synth/logs_test.go
@@ -601,6 +601,26 @@ func TestLogObserverScenarioDisableMutesDerived(t *testing.T) {
 	assert.Empty(t, exporter.get(), "disable should mute derived error logs too")
 }
 
+func TestLogObserverScenarioDisableOperationScopeMutesDerived(t *testing.T) {
+	t.Parallel()
+
+	// Service with no topology logs: derived error logs normally fire.
+	topo := testLogTopology("svc", nil, "query", nil)
+	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
+
+	obs.SetOverrides(map[string]Override{
+		"svc.query": {DisableLogs: true},
+	})
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "query", IsError: true})
+	assert.Empty(t, exporter.get(), "operation-scoped disable should mute derived logs for that operation")
+
+	obs.Observe(SpanInfo{Service: "svc", Operation: "other", IsError: true})
+	records := exporter.get()
+	require.Len(t, records, 1, "derived logs should still fire for other operations")
+	assert.Equal(t, otellog.SeverityError, records[0].Severity())
+}
+
 func TestLogObserverScenarioAddAndDisableReplaces(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/synth/scenario.go
+++ b/pkg/synth/scenario.go
@@ -30,6 +30,8 @@ type Override struct {
 	AddCalls     []Call
 	RemoveCalls  map[string]bool
 	Metrics      map[string]FloatDistribution
+	AddLogs      []LogDefinition
+	DisableLogs  bool
 }
 
 // ParseOffset parses a time offset string like "+5m" or "30s" into a duration.
@@ -127,6 +129,15 @@ func BuildScenarios(cfgs []ScenarioConfig, topo *Topology) ([]Scenario, error) {
 						return nil, fmt.Errorf("scenario %q override %q: metric %q: %w", cfg.Name, ref, name, distErr)
 					}
 					o.Metrics[name] = dist
+				}
+			}
+			if ov.Logs != nil {
+				o.DisableLogs = ov.Logs.Disable
+				if len(ov.Logs.Add) > 0 {
+					o.AddLogs, err = resolveLogs(ov.Logs.Add, fmt.Sprintf("scenario %q override %q: logs", cfg.Name, ref))
+					if err != nil {
+						return nil, err
+					}
 				}
 			}
 			overrides[ref] = o
@@ -297,6 +308,12 @@ func ResolveOverrides(active []Scenario) map[string]Override {
 				maps.Copy(newMetrics, existing.Metrics)
 				maps.Copy(newMetrics, ov.Metrics)
 				existing.Metrics = newMetrics
+			}
+			if len(ov.AddLogs) > 0 {
+				existing.AddLogs = append(slices.Clone(existing.AddLogs), ov.AddLogs...)
+			}
+			if ov.DisableLogs {
+				existing.DisableLogs = true
 			}
 			merged[ref] = existing
 		}

--- a/pkg/synth/scenario_test.go
+++ b/pkg/synth/scenario_test.go
@@ -848,3 +848,98 @@ func TestBuildScenariosParsesMetricOverrides(t *testing.T) {
 	assert.InDelta(t, 0.95, dist.Mean, 0.001)
 	assert.InDelta(t, 0.02, dist.StdDev, 0.001)
 }
+
+func TestBuildScenariosParsesLogOverrides(t *testing.T) {
+	t.Parallel()
+
+	topo := &Topology{Services: map[string]*Service{
+		"svc": {Name: "svc", Operations: map[string]*Operation{}},
+	}}
+
+	scenarios, err := BuildScenarios([]ScenarioConfig{{
+		Name:     "incident",
+		At:       "+1m",
+		Duration: "5m",
+		Override: map[string]OverrideConfig{
+			"svc": {Logs: &LogOverrideConfig{
+				Disable: true,
+				Add: []LogConfig{{
+					Severity:  "error",
+					Body:      "connection pool exhausted",
+					Condition: "error",
+					Delay:     "5ms",
+				}},
+			}},
+		},
+	}}, topo)
+	require.NoError(t, err)
+	require.Len(t, scenarios, 1)
+
+	ov := scenarios[0].Overrides["svc"]
+	assert.True(t, ov.DisableLogs)
+	require.Len(t, ov.AddLogs, 1)
+	assert.Equal(t, "ERROR", ov.AddLogs[0].Severity, "severity should be normalised to uppercase")
+	assert.Equal(t, "connection pool exhausted", ov.AddLogs[0].Body)
+	assert.Equal(t, "error", ov.AddLogs[0].Condition)
+	assert.InDelta(t, 1.0, ov.AddLogs[0].Probability, 0.001, "probability defaults to 1.0")
+	assert.Equal(t, 5*time.Millisecond, ov.AddLogs[0].Delay)
+}
+
+func TestBuildScenariosRejectsInvalidLogOverride(t *testing.T) {
+	t.Parallel()
+
+	topo := &Topology{Services: map[string]*Service{
+		"svc": {Name: "svc", Operations: map[string]*Operation{}},
+	}}
+
+	_, err := BuildScenarios([]ScenarioConfig{{
+		Name:     "incident",
+		At:       "+1m",
+		Duration: "5m",
+		Override: map[string]OverrideConfig{
+			"svc": {Logs: &LogOverrideConfig{
+				Add: []LogConfig{{Severity: "LOUD", Body: "b"}},
+			}},
+		},
+	}}, topo)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `scenario "incident"`)
+	assert.Contains(t, err.Error(), "invalid severity")
+}
+
+func TestResolveOverridesMergesLogs(t *testing.T) {
+	t.Parallel()
+
+	scenarios := []Scenario{
+		{
+			Name: "low", Start: 0, End: time.Hour, Priority: 1,
+			Overrides: map[string]Override{
+				"svc": {AddLogs: []LogDefinition{
+					{Severity: "WARN", Body: "degraded", Probability: 1.0},
+				}},
+			},
+		},
+		{
+			Name: "high", Start: 0, End: time.Hour, Priority: 2,
+			Overrides: map[string]Override{
+				"svc": {
+					DisableLogs: true,
+					AddLogs: []LogDefinition{
+						{Severity: "ERROR", Body: "outage", Probability: 1.0},
+					},
+				},
+			},
+		},
+	}
+
+	merged := ResolveOverrides(ActiveScenarios(scenarios, time.Minute))
+	require.Contains(t, merged, "svc")
+	require.Len(t, merged["svc"].AddLogs, 2, "added logs accumulate across scenarios")
+	assert.Equal(t, "degraded", merged["svc"].AddLogs[0].Body)
+	assert.Equal(t, "outage", merged["svc"].AddLogs[1].Body)
+	assert.True(t, merged["svc"].DisableLogs, "disable from any active scenario wins")
+
+	assert.Len(t, scenarios[0].Overrides["svc"].AddLogs, 1,
+		"original scenario should not be mutated")
+	assert.False(t, scenarios[0].Overrides["svc"].DisableLogs)
+}

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -138,7 +138,7 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 			svc.Metrics = resolved
 		}
 		if len(svcCfg.Logs) > 0 {
-			resolved, err := resolveLogs(svcCfg.Logs, svcCfg.Name, "")
+			resolved, err := resolveLogs(svcCfg.Logs, fmt.Sprintf("service %q", svcCfg.Name))
 			if err != nil {
 				return nil, err
 			}
@@ -196,7 +196,7 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 				op.Metrics = resolved
 			}
 			if len(opCfg.Logs) > 0 {
-				resolved, lErr := resolveLogs(opCfg.Logs, svcCfg.Name, opCfg.Name)
+				resolved, lErr := resolveLogs(opCfg.Logs, fmt.Sprintf("service %q operation %q", svcCfg.Name, opCfg.Name))
 				if lErr != nil {
 					return nil, lErr
 				}
@@ -378,13 +378,8 @@ func resolveMetrics(configs []MetricConfig, svcName, opName string) ([]MetricDef
 
 // resolveLogs converts LogConfig entries into LogDefinitions.
 // Severity is normalised to uppercase; delay strings are parsed to durations.
-func resolveLogs(configs []LogConfig, svcName, opName string) ([]LogDefinition, error) {
-	logCtx := func() string {
-		if opName != "" {
-			return fmt.Sprintf("service %q operation %q", svcName, opName)
-		}
-		return fmt.Sprintf("service %q", svcName)
-	}
+// errCtx prefixes error messages (e.g. `service "gateway"` or `scenario "incident" override "svc.op"`).
+func resolveLogs(configs []LogConfig, errCtx string) ([]LogDefinition, error) {
 	defs := make([]LogDefinition, len(configs))
 	for i, lc := range configs {
 		def := LogDefinition{
@@ -395,7 +390,7 @@ func resolveLogs(configs []LogConfig, svcName, opName string) ([]LogDefinition, 
 			Probability: 1.0,
 		}
 		if !validLogSeverity[def.Severity] {
-			return nil, fmt.Errorf("%s: log[%d]: invalid severity %q", logCtx(), i, lc.Severity)
+			return nil, fmt.Errorf("%s: log[%d]: invalid severity %q", errCtx, i, lc.Severity)
 		}
 		if lc.Probability != nil {
 			def.Probability = *lc.Probability
@@ -403,7 +398,7 @@ func resolveLogs(configs []LogConfig, svcName, opName string) ([]LogDefinition, 
 		if lc.Delay != "" {
 			d, err := time.ParseDuration(lc.Delay)
 			if err != nil {
-				return nil, fmt.Errorf("%s: log[%d]: invalid delay: %w", logCtx(), i, err)
+				return nil, fmt.Errorf("%s: log[%d]: invalid delay: %w", errCtx, i, err)
 			}
 			def.Delay = d
 		}
@@ -412,7 +407,7 @@ func resolveLogs(configs []LogConfig, svcName, opName string) ([]LogDefinition, 
 			for name, acfg := range lc.Attributes {
 				gen, err := NewAttributeGenerator(acfg)
 				if err != nil {
-					return nil, fmt.Errorf("%s: log[%d] attribute %q: %w", logCtx(), i, name, err)
+					return nil, fmt.Errorf("%s: log[%d] attribute %q: %w", errCtx, i, name, err)
 				}
 				def.Attributes[name] = gen
 			}


### PR DESCRIPTION
Closes #155. Follow-up to PR 145 (topology-driven log generation), mirroring the metric override pattern from `OverrideConfig.Metrics`.

## What

Scenarios can now modify log output during their activation window via a `logs:` block under `override`:

```yaml
scenarios:
  - name: db-degradation
    at: 2m
    duration: 5m
    override:
      postgres.query:
        error_rate: 15%
        logs:
          add:
            - severity: ERROR
              body: "connection pool exhausted"
              condition: error
              attributes:
                error.type:
                  value: PoolExhaustedError
          disable: true   # optional: mute base logs at this scope
```

- `add:` defines extra log records emitted only while the scenario window is active. Entries are full `LogConfig` definitions: severity, body templates, conditions (`error`/`success`/`slow`), probability, timing anchors (`at`/`delay`), and attribute generators all work.
- `disable: true` mutes the base logs at the override's scope for the duration of the window — both topology log templates and the derived error/slow fallback logs. Combined with `add:`, this gives replacement semantics.
- Both override scopes work, consistent with metric overrides: `service.operation` refs scope to one operation; bare service names scope to every span of the service.

## Design decisions (per the issue's open questions)

1. **Identity for modifying existing definitions**: deferred, as suggested. This first iteration supports `add:` and `disable: true` only; no `name`/`id` field was added to `LogConfig`. Log-storm simulation is achievable today with `disable: true` plus an `add:` entry that copies the base log with a higher probability.
2. **Derived-vs-topology switching**: adding logs to a service that previously had none switches it to topology logs for the window (suppressing the derived error/slow fallback), and `disable` mutes the derived logs too — so the suppression rule is now scenario-aware.

## Implementation

- `LogOverrideConfig` (`add`, `disable`) on `OverrideConfig`, validated at config load with the usual contextual messages (each `add` entry goes through `validateLogConfig`; an empty `logs:` block is rejected).
- `BuildScenarios` resolves added entries to `LogDefinition`s via the existing `resolveLogs` (its error-context parameter was generalised to support scenario contexts).
- `ResolveOverrides` merges across overlapping scenarios: adds accumulate in priority order, disable from any active scenario wins.
- `LogObserver` implements the existing `OverrideObserver` interface; the engine's `notifyOverrides` path needed no changes. Added definitions are pre-built into templates on scenario transitions so the per-span path only does map lookups under an RWMutex, matching `MetricObserver`.

## Testing

- Unit tests for validation, scenario building/merging, and observer behaviour (operation/service scoping, conditions, interpolation, disable semantics, derived-log interaction, override clearing).
- Verified end-to-end with the updated `docs/examples/topology-driven-logs.yaml`: the added ERROR log appears only inside the window on error spans, the gateway's base logs go quiet during it, and behaviour reverts when the window closes.
- `make test` and `make lint` pass.

https://claude.ai/code/session_01L12XgTDZiZMBQU6cMoFLpC

---
_Generated by [Claude Code](https://claude.ai/code/session_01L12XgTDZiZMBQU6cMoFLpC)_