### PR TITLE
Semconv signal-type queries and log attribute validation

### DIFF
--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -355,6 +355,9 @@ func validateCmd() *cobra.Command {
 			for _, w := range semconvMetricWarnings(cfg, reg) {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", w)
 			}
+			for _, w := range semconvLogWarnings(cfg, reg) {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", w)
+			}
 			svcLabel := "services"
 			if len(topo.Services) == 1 {
 				svcLabel = "service"
@@ -957,6 +960,52 @@ func semconvMetricWarnings(cfg *synth.Config, reg *semconv.Registry) []string {
 		}
 	}
 	return warnings
+}
+
+// semconvLogWarnings checks log attribute names in the topology against the
+// semantic convention registry, returning warnings for deprecated attributes
+// and static values outside a known enum's members. Unknown attribute names
+// are not warned about — users may define custom attributes freely.
+func semconvLogWarnings(cfg *synth.Config, reg *semconv.Registry) []string {
+	var warnings []string
+	check := func(scope string, attrs map[string]synth.AttributeValueConfig) {
+		for _, name := range slices.Sorted(maps.Keys(attrs)) {
+			def := reg.Attribute(name)
+			if def == nil {
+				continue
+			}
+			if def.Deprecated != nil {
+				warnings = append(warnings, fmt.Sprintf("%s: attribute %q is deprecated in the semantic conventions",
+					scope, name))
+			}
+			if v := attrs[name].Value; v != nil && def.Type.Value == "enum" && !enumAllows(def, v) {
+				warnings = append(warnings, fmt.Sprintf("%s: attribute %q: value %v is not a member of the semantic convention enum",
+					scope, name, v))
+			}
+		}
+	}
+	for _, svc := range cfg.Services {
+		for i, lc := range svc.Logs {
+			check(fmt.Sprintf("service %q log[%d]", svc.Name, i), lc.Attributes)
+		}
+		for _, op := range svc.Operations {
+			for i, lc := range op.Logs {
+				check(fmt.Sprintf("service %q operation %q log[%d]", svc.Name, op.Name, i), lc.Attributes)
+			}
+		}
+	}
+	return warnings
+}
+
+// enumAllows reports whether v matches one of the enum members of def,
+// comparing string representations to tolerate YAML scalar typing.
+func enumAllows(def *semconv.Attribute, v any) bool {
+	for _, m := range def.Type.Members {
+		if fmt.Sprint(m.Value) == fmt.Sprint(v) {
+			return true
+		}
+	}
+	return false
 }
 
 // topoHasMetrics reports whether any service or operation in the topology defines at least one metric.

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -12,8 +12,11 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/fstest"
 	"time"
 
+	"github.com/andrewh/motel/pkg/semconv"
+	"github.com/andrewh/motel/pkg/synth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1288,4 +1291,108 @@ traffic:
 	require.NoError(t, root.Execute())
 	assert.Contains(t, errOut.String(), `unit is not set; semantic convention specifies "s"`)
 	assert.NotContains(t, errOut.String(), `unit ""`)
+}
+
+func newLogWarningsRegistry(t *testing.T) *semconv.Registry {
+	t.Helper()
+	fsys := fstest.MapFS{
+		"log/registry.yaml": &fstest.MapFile{
+			Data: []byte(`
+groups:
+  - id: registry.log
+    type: attribute_group
+    brief: 'Log attributes.'
+    attributes:
+      - id: log.iostream
+        type:
+          members:
+            - id: stdout
+              value: 'stdout'
+              brief: 'Standard output.'
+            - id: stderr
+              value: 'stderr'
+              brief: 'Standard error.'
+        brief: 'The stream the log was emitted to.'
+      - id: log.record.uid
+        type: string
+        brief: 'Unique identifier of the log record.'
+      - id: log.legacy.field
+        type: string
+        brief: 'Old field.'
+        deprecated: 'Use log.record.uid instead.'
+`),
+		},
+	}
+	reg, err := semconv.Load(fsys)
+	require.NoError(t, err)
+	return reg
+}
+
+func TestSemconvLogWarnings(t *testing.T) {
+	t.Parallel()
+	reg := newLogWarningsRegistry(t)
+
+	cfg := &synth.Config{
+		Services: []synth.ServiceConfig{
+			{
+				Name: "gateway",
+				Logs: []synth.LogConfig{
+					{
+						Severity: "INFO",
+						Body:     "started",
+						Attributes: map[string]synth.AttributeValueConfig{
+							"log.legacy.field": {Value: "x"},
+						},
+					},
+				},
+				Operations: []synth.OperationConfig{
+					{
+						Name: "handle",
+						Logs: []synth.LogConfig{
+							{
+								Severity: "ERROR",
+								Body:     "boom",
+								Attributes: map[string]synth.AttributeValueConfig{
+									"log.iostream":   {Value: "syslog"},
+									"log.record.uid": {Value: "abc"},
+									"my.custom.attr": {Value: 42},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	warnings := semconvLogWarnings(cfg, reg)
+	require.Len(t, warnings, 2)
+	assert.Contains(t, warnings[0], `service "gateway" log[0]`)
+	assert.Contains(t, warnings[0], `"log.legacy.field" is deprecated`)
+	assert.Contains(t, warnings[1], `service "gateway" operation "handle" log[0]`)
+	assert.Contains(t, warnings[1], `"log.iostream": value syslog is not a member`)
+}
+
+func TestSemconvLogWarnings_ValidEnumValue(t *testing.T) {
+	t.Parallel()
+	reg := newLogWarningsRegistry(t)
+
+	cfg := &synth.Config{
+		Services: []synth.ServiceConfig{
+			{
+				Name: "gateway",
+				Logs: []synth.LogConfig{
+					{
+						Severity: "INFO",
+						Body:     "ok",
+						Attributes: map[string]synth.AttributeValueConfig{
+							"log.iostream": {Value: "stdout"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Empty(t, semconvLogWarnings(cfg, reg))
 }

--- a/pkg/semconv/registry.go
+++ b/pkg/semconv/registry.go
@@ -102,6 +102,36 @@ func (r *Registry) MetricByName(name string) *Group {
 	return r.byMetricName[name]
 }
 
+// Metrics returns all metric groups.
+func (r *Registry) Metrics() []*Group {
+	return r.groupsByType("metric")
+}
+
+// Spans returns all span groups.
+func (r *Registry) Spans() []*Group {
+	return r.groupsByType("span")
+}
+
+// Events returns all event groups.
+func (r *Registry) Events() []*Group {
+	return r.groupsByType("event")
+}
+
+// Entities returns all entity groups.
+func (r *Registry) Entities() []*Group {
+	return r.groupsByType("entity")
+}
+
+func (r *Registry) groupsByType(typ string) []*Group {
+	var result []*Group
+	for i := range r.groups {
+		if r.groups[i].Type == typ {
+			result = append(result, &r.groups[i])
+		}
+	}
+	return result
+}
+
 // Domain returns all groups belonging to the given domain.
 func (r *Registry) Domain(name string) []*Group {
 	return r.byDomain[name]

--- a/pkg/semconv/registry_test.go
+++ b/pkg/semconv/registry_test.go
@@ -684,3 +684,97 @@ func TestMetricByName(t *testing.T) {
 	assert.Nil(t, reg.MetricByName("my.custom.metric"), "unknown metric names return nil")
 	assert.Nil(t, reg.MetricByName(""), "empty name returns nil")
 }
+
+func newMixedTypeFS() fstest.MapFS {
+	return fstest.MapFS{
+		"http/metrics.yaml": &fstest.MapFile{
+			Data: []byte(`
+groups:
+  - id: metric.http.duration
+    type: metric
+    metric_name: http.server.request.duration
+    brief: 'HTTP request duration.'
+    instrument: histogram
+    unit: s
+  - id: metric.http.request.size
+    type: metric
+    metric_name: http.server.request.body.size
+    brief: 'HTTP request body size.'
+    instrument: histogram
+    unit: By
+`),
+		},
+		"http/spans.yaml": &fstest.MapFile{
+			Data: []byte(`
+groups:
+  - id: span.http.client
+    type: span
+    brief: 'HTTP client span.'
+  - id: span.http.server
+    type: span
+    brief: 'HTTP server span.'
+`),
+		},
+		"log/events.yaml": &fstest.MapFile{
+			Data: []byte(`
+groups:
+  - id: event.log.record
+    type: event
+    brief: 'Log event.'
+`),
+		},
+		"infra/entities.yaml": &fstest.MapFile{
+			Data: []byte(`
+groups:
+  - id: entity.host
+    type: entity
+    brief: 'Host entity.'
+`),
+		},
+		"http/registry.yaml": &fstest.MapFile{
+			Data: []byte(`
+groups:
+  - id: registry.http
+    type: attribute_group
+    brief: 'HTTP attributes.'
+`),
+		},
+	}
+}
+
+func TestGroupsByType(t *testing.T) {
+	t.Parallel()
+	reg, err := Load(newMixedTypeFS())
+	require.NoError(t, err)
+
+	metrics := reg.Metrics()
+	assert.Len(t, metrics, 2)
+	for _, m := range metrics {
+		assert.Equal(t, "metric", m.Type)
+	}
+
+	spans := reg.Spans()
+	assert.Len(t, spans, 2)
+	for _, s := range spans {
+		assert.Equal(t, "span", s.Type)
+	}
+
+	events := reg.Events()
+	require.Len(t, events, 1)
+	assert.Equal(t, "event.log.record", events[0].ID)
+
+	entities := reg.Entities()
+	require.Len(t, entities, 1)
+	assert.Equal(t, "entity.host", entities[0].ID)
+}
+
+func TestGroupsByType_Embedded(t *testing.T) {
+	t.Parallel()
+	reg, err := LoadEmbedded()
+	require.NoError(t, err)
+
+	assert.Greater(t, len(reg.Metrics()), 10, "expected at least 10 metrics in embedded data")
+	assert.Greater(t, len(reg.Spans()), 10, "expected at least 10 spans in embedded data")
+	assert.NotEmpty(t, reg.Events())
+	assert.NotEmpty(t, reg.Entities())
+}


### PR DESCRIPTION
Completes the remaining work for issue 113 (work item 4 was split out to issue 157).

## Signal-type query methods in `pkg/semconv`

The registry previously exposed only `MetricByName` for signal-aware lookups. This adds the type filters identified in the issue 113 audit:

- `Metrics()`, `Spans()`, `Events()`, `Entities()` — return all groups of the given type
- Covered by a mixed-type fixture test and an embedded-data smoke test

These are the building blocks for semconv suggestions (issue 157).

## Log attribute validation in `motel validate`

Issue 112 added `logs:` to the topology DSL with arbitrary attribute maps, but attribute names were never checked against the semantic conventions. `motel validate` now warns when a log attribute:

- is **deprecated** in the semconv registry (e.g. an attribute superseded by a renamed one), or
- has a static value that is **not a member of a known enum** (e.g. `log.iostream: syslog` when the convention allows only `stdout`/`stderr`)

Unknown attribute names produce no warning — custom attributes remain allowed, consistent with the existing metric warnings (`semconvMetricWarnings`), which this mirrors.

## Notes

- Warnings go to stderr and do not fail validation
- `make test` and `make lint` pass

https://claude.ai/code/session_0134t4ENXTnwsTJfv6LJfF5e