### PR TITLE
Add dgggen tool to generate production-shaped call graphs

### DIFF
--- a/docs/demos/demo-dgg.md
+++ b/docs/demos/demo-dgg.md
@@ -199,5 +199,59 @@ spans:    20x1  14x2  19x3  11x4  11x5  9x6  14x7  7x8  3x9  1x10  2x11
 
 The format is `countxvalue` — for example, `45x2` means 45 topologies have max depth 2. The corpus covers depths 0-4, fan-outs 0-8, and span counts 1-11. The 20 topologies at depth 0 and fan-out 0 are single-service graphs (type5 in DGG's clustering). The heaviest topologies have 11 spans per trace.
 
-These are small by production standards — Alibaba's traces in the Du et al. paper reach depths of 15+ and hundreds of spans. The sample corpus represents clustered archetypes rather than the full distribution. Running the DGG generator itself with different parameters would produce deeper and wider graphs for more aggressive stress testing.
+These are small by production standards — Alibaba's traces in the Du et al. paper reach depths of 15+ and hundreds of spans. The sample corpus represents clustered archetypes rather than the full distribution. The `dgggen` tool below fills that gap.
+
+## Generating a production-shaped corpus
+
+The `dgggen` tool generates DGG-format JSON graphs with shape distributions drawn from the production measurements in the Du et al. paper: heavy-tailed graph sizes reaching hundreds of nodes, depths reaching 15+, hub services with high fan-out, and repeated calls with multiplicities into the hundreds. The corpus is stratified rather than frequency-matched — deep and wide graphs are oversampled so a corpus of 100 graphs still covers the tail. Output is deterministic for a given seed.
+
+```bash
+go run ./tools/dgggen -n 100 -seed 1 -out /tmp/dgg-prod
+go run ./tools/dgg2motel -dir /tmp/dgg-prod -out /tmp/dgg-prod-topologies
+```
+
+```output
+generated 100 graphs in /tmp/dgg-prod
+converted 100 graphs, skipped 0
+```
+
+The generated graphs exceed `motel check`'s default limits by design — that is the point of a production-shaped corpus. The `CHECK_ARGS` environment variable passes raised limits through `test_corpus.sh`.
+
+```bash
+CHECK_ARGS="--max-depth 25 --max-fan-out 500" ./tools/dgg2motel/test_corpus.sh /tmp/dgg-prod-topologies
+```
+
+```output
+testing 100 topologies from /tmp/dgg-prod-topologies
+motel: build/motel
+duration: 1s
+
+
+=== results ===
+check: 100 pass, 0 fail
+run:   100 pass, 0 fail, 0 timeout
+```
+
+## Production-shaped corpus distribution
+
+```bash
+for f in /tmp/dgg-prod-topologies/*.yaml; do
+    build/motel check --samples 0 --max-depth 25 --max-fan-out 500 "$f" 2>/dev/null
+done | awk '
+/max-depth:/   { d=$3+0; depths[d]++; if(d>maxd) maxd=d }
+/max-fan-out:/ { f=$3+0; if(f>maxf) maxf=f }
+/max-spans:/   { s=$3+0; if(s>maxs) maxs=s; sum+=s; n++ }
+END {
+    printf "depth:    "; for(i=0;i<=25;i++) if(depths[i]) printf "%dx%d  ", depths[i], i; print ""
+    printf "max depth: %d   max fan-out: %d   max spans: %d   mean spans: %.0f\n", maxd, maxf, maxs, sum/n
+}'
+
+```
+
+```output
+depth:    6x0  8x1  8x2  9x3  12x4  13x5  8x6  6x7  7x8  5x9  2x10  3x11  2x13  1x14  4x15  3x16  2x17  1x18  
+max depth: 18   max fan-out: 460   max spans: 4196   mean spans: 509
+```
+
+Where the DGG sample corpus tops out at depth 4 and 11 spans, this corpus reaches depth 18, fan-out of 460 (a hub calling a memcached instance hundreds of times), and traces of over 4000 spans — the scale the Du et al. paper reports for Alibaba production traces. Every topology still passes `motel check` and runs cleanly, which is the property the corpus exists to verify.
 

--- a/tools/dgg2motel/test_corpus.sh
+++ b/tools/dgg2motel/test_corpus.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 TOPO_DIR="${1:?usage: test_corpus.sh <topology-dir>}"
 MOTEL="${MOTEL:-build/motel}"
 DURATION="${DURATION:-1s}"
-RATE="${RATE:-}"  # override traffic rate if set
+RATE="${RATE:-}"              # override traffic rate if set
+CHECK_ARGS="${CHECK_ARGS:-}"  # extra flags for motel check, e.g. "--max-depth 25"
 
 if [ ! -x "$MOTEL" ]; then
     echo "error: $MOTEL not found or not executable" >&2
@@ -42,9 +43,11 @@ for f in "${files[@]}"; do
     rel="${f#"$TOPO_DIR"/}"
 
     # motel check
-    if ! "$MOTEL" check "$f" > /dev/null 2>&1; then
+    # shellcheck disable=SC2086
+    if ! "$MOTEL" check $CHECK_ARGS "$f" > /dev/null 2>&1; then
         echo "CHECK FAIL: $rel"
-        "$MOTEL" check "$f" 2>&1 | sed 's/^/  /'
+        # shellcheck disable=SC2086
+        "$MOTEL" check $CHECK_ARGS "$f" 2>&1 | sed 's/^/  /'
         check_fail=$((check_fail + 1))
     else
         check_pass=$((check_pass + 1))

--- a/tools/dgg2motel/test_corpus.sh
+++ b/tools/dgg2motel/test_corpus.sh
@@ -11,8 +11,10 @@ set -euo pipefail
 TOPO_DIR="${1:?usage: test_corpus.sh <topology-dir>}"
 MOTEL="${MOTEL:-build/motel}"
 DURATION="${DURATION:-1s}"
-RATE="${RATE:-}"              # override traffic rate if set
-CHECK_ARGS="${CHECK_ARGS:-}"  # extra flags for motel check, e.g. "--max-depth 25"
+RATE="${RATE:-}"  # override traffic rate if set
+# Parse CHECK_ARGS into an array to avoid word-splitting and glob expansion.
+# Example: CHECK_ARGS="--max-depth 25 --max-fan-out 500"
+read -ra check_args <<< "${CHECK_ARGS:-}"
 
 if [ ! -x "$MOTEL" ]; then
     echo "error: $MOTEL not found or not executable" >&2
@@ -43,11 +45,9 @@ for f in "${files[@]}"; do
     rel="${f#"$TOPO_DIR"/}"
 
     # motel check
-    # shellcheck disable=SC2086
-    if ! "$MOTEL" check $CHECK_ARGS "$f" > /dev/null 2>&1; then
+    if ! "$MOTEL" check "${check_args[@]}" "$f" > /dev/null 2>&1; then
         echo "CHECK FAIL: $rel"
-        # shellcheck disable=SC2086
-        "$MOTEL" check $CHECK_ARGS "$f" 2>&1 | sed 's/^/  /'
+        "$MOTEL" check "${check_args[@]}" "$f" 2>&1 | sed 's/^/  /'
         check_fail=$((check_fail + 1))
     else
         check_pass=$((check_pass + 1))

--- a/tools/dgggen/main.go
+++ b/tools/dgggen/main.go
@@ -321,14 +321,17 @@ func staticSpans(n *genNode, factor int) int {
 	return total
 }
 
-// clampSpans halves the largest leaf multiplicity until the static span
-// count fits under maxStaticSpans.
+// clampSpans halves the largest multiplicity on any node (leaf or interior)
+// until the static span count fits under maxStaticSpans. Interior nodes with
+// mult > 1 multiply their entire subtree, so they must be considered
+// alongside leaves — targeting only leaves can leave the bound unmet when
+// interior multiplicities drive the inflation.
 func clampSpans(root *genNode) {
 	for staticSpans(root, 1) > maxStaticSpans {
 		var largest *genNode
 		var walk func(*genNode)
 		walk = func(n *genNode) {
-			if len(n.children) == 0 && (largest == nil || n.mult > largest.mult) {
+			if n.mult > 1 && (largest == nil || n.mult > largest.mult) {
 				largest = n
 			}
 			for _, c := range n.children {
@@ -336,7 +339,7 @@ func clampSpans(root *genNode) {
 			}
 		}
 		walk(root)
-		if largest == nil || largest.mult <= 1 {
+		if largest == nil {
 			return
 		}
 		largest.mult /= 2

--- a/tools/dgggen/main.go
+++ b/tools/dgggen/main.go
@@ -1,0 +1,430 @@
+// dgggen generates synthetic call-graph JSON in DGG format
+// (https://github.com/dufanrong/DGG) with shape distributions drawn from
+// production measurements reported in Du et al., "DGG: A Novel Framework
+// for Microservice Call Graph Generation Based on Realistic Distributions"
+// (ICWS 2024), which characterises Alibaba production traces.
+//
+// The generated corpus is stratified rather than frequency-matched: deep
+// (15+ levels) and wide (hundreds of nodes) graphs are oversampled relative
+// to their production frequency so that a corpus of ~100 graphs still
+// exercises the tail of the distribution. Production characteristics
+// represented:
+//
+//   - Call graph depth: most graphs ≤ 6 levels, tail reaching ~20
+//   - Graph size: heavy-tailed, from single-service graphs to 400+ nodes
+//   - Fan-out: concentrated at 1-3 children, hubs reaching ~50
+//   - Repeated calls: mostly 1, heavy tail reaching into the hundreds
+//   - Services with multiple interfaces (~49% have >2 in production)
+//
+// Output is consumable by dgg2motel:
+//
+//	go run ./tools/dgggen -n 100 -out /tmp/dgg-prod
+//	go run ./tools/dgg2motel -dir /tmp/dgg-prod -out /tmp/dgg-prod-topologies
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+)
+
+// DGG JSON structures, matching the format dgg2motel consumes.
+
+type dggGraph struct {
+	Nodes []dggNode `json:"nodes"`
+	Edges []dggEdge `json:"edges"`
+	Num   int       `json:"num"`
+}
+
+type dggNode struct {
+	Node  string `json:"node"`
+	Label string `json:"label"`
+}
+
+type dggEdge struct {
+	RPCID   string `json:"rpcid"`
+	UM      string `json:"um"`
+	DM      string `json:"dm"`
+	Time    int    `json:"time"`
+	Compara string `json:"compara"`
+}
+
+// Service type labels used by DGG.
+const (
+	labelNormal    = "normal"
+	labelMemcached = "Memcached"
+	labelBlackhole = "blackhole"
+	labelRelay     = "relay"
+)
+
+// maxStaticSpans bounds the static worst-case spans per trace of a generated
+// graph, keeping it under motel's DefaultMaxSpansPerTrace (10,000) with room
+// to spare so converted topologies run without span bounding.
+const maxStaticSpans = 5000
+
+// maxFanOut caps children per node, matching the upper bound reported for
+// Meta in the DGG paper.
+const maxFanOut = 50
+
+// maxEffectiveFanOut caps the sum of call multiplicities across one node's
+// children — what motel counts as fan-out. The bound tracks the P99
+// repeated-call counts (374-469) reported in the DGG paper.
+const maxEffectiveFanOut = 500
+
+// bucket is a weighted integer range for sampling heavy-tailed distributions.
+type bucket struct {
+	weight   int
+	min, max int
+}
+
+// depthBuckets samples graph depth in node levels (root = 1). Production
+// depth is ≤ 6 for >99.99% of graphs with a max around 15; the tail here is
+// oversampled so a small corpus covers it.
+var depthBuckets = []bucket{
+	{8, 1, 1},
+	{20, 2, 3},
+	{24, 4, 5},
+	{18, 6, 7},
+	{12, 8, 10},
+	{10, 11, 14},
+	{6, 15, 17},
+	{2, 18, 20},
+}
+
+// sizeBuckets samples target node count. Heavy-tailed: most graphs are
+// small, the tail reaches hundreds of nodes.
+var sizeBuckets = []bucket{
+	{35, 3, 10},
+	{30, 11, 40},
+	{22, 41, 150},
+	{10, 151, 300},
+	{3, 301, 450},
+}
+
+func sampleBucket(r *rand.Rand, buckets []bucket) int {
+	total := 0
+	for _, b := range buckets {
+		total += b.weight
+	}
+	pick := r.Intn(total)
+	for _, b := range buckets {
+		if pick < b.weight {
+			return b.min + r.Intn(b.max-b.min+1)
+		}
+		pick -= b.weight
+	}
+	last := buckets[len(buckets)-1]
+	return last.max
+}
+
+// genNode is the in-memory tree node used during construction.
+type genNode struct {
+	name     string
+	label    string
+	depth    int
+	children []*genNode
+	mult     int // call multiplicity on the edge from the parent
+}
+
+func main() {
+	nFlag := flag.Int("n", 100, "number of graphs to generate")
+	seedFlag := flag.Int64("seed", 1, "random seed (deterministic output)")
+	outFlag := flag.String("out", "", "output directory (required)")
+	flag.Parse()
+
+	if *outFlag == "" {
+		fmt.Fprintln(os.Stderr, "usage: dgggen -n 100 -seed 1 -out path/")
+		os.Exit(1)
+	}
+	if err := os.MkdirAll(*outFlag, 0o755); err != nil {
+		fatal(err)
+	}
+
+	r := rand.New(rand.NewSource(*seedFlag))
+	for i := range *nFlag {
+		g := generate(r)
+		data, err := json.MarshalIndent(g, "", "    ")
+		if err != nil {
+			fatal(err)
+		}
+		path := filepath.Join(*outFlag, fmt.Sprintf("graph_%03d.json", i+1))
+		if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+			fatal(err)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "generated %d graphs in %s\n", *nFlag, *outFlag)
+}
+
+// generate builds one call graph as a tree rooted at a single entry service.
+func generate(r *rand.Rand) dggGraph {
+	depth := sampleBucket(r, depthBuckets)
+	size := sampleBucket(r, sizeBuckets)
+	if size < depth {
+		size = depth
+	}
+	if depth == 1 {
+		size = 1
+	}
+
+	// Build a spine guaranteeing the sampled depth, then attach the
+	// remaining nodes to random eligible parents. A small preferential-
+	// attachment bias produces the heavy-tailed fan-out seen in production.
+	root := &genNode{depth: 1, mult: 1}
+	nodes := []*genNode{root}
+	prev := root
+	for d := 2; d <= depth; d++ {
+		n := &genNode{depth: d, mult: 1}
+		prev.children = append(prev.children, n)
+		nodes = append(nodes, n)
+		prev = n
+	}
+	for len(nodes) < size {
+		parent := pickParent(r, nodes, depth)
+		if parent == nil {
+			break
+		}
+		n := &genNode{depth: parent.depth + 1, mult: 1}
+		parent.children = append(parent.children, n)
+		nodes = append(nodes, n)
+	}
+
+	assignLabels(r, root, nodes)
+	assignMultiplicities(r, nodes)
+	clampSpans(root)
+	assignNames(r, root)
+
+	g := dggGraph{Num: 1}
+	g.Nodes = append(g.Nodes, dggNode{Node: "USER", Label: labelRelay})
+	for _, n := range nodes {
+		g.Nodes = append(g.Nodes, dggNode{Node: n.name, Label: n.label})
+	}
+	g.Edges = append(g.Edges, dggEdge{
+		RPCID: "0", UM: "USER", DM: root.name, Time: 1, Compara: "http",
+	})
+	emitEdges(r, &g, root, "0")
+	return g
+}
+
+// pickParent selects an attachment point for a new node. Parents must be
+// shallower than the sampled depth so the graph never exceeds it, and below
+// the fan-out cap. 30% of the time the most-connected of three candidates
+// is chosen, biasing growth toward hubs.
+func pickParent(r *rand.Rand, nodes []*genNode, depth int) *genNode {
+	eligible := make([]*genNode, 0, len(nodes))
+	for _, n := range nodes {
+		if n.depth < depth && len(n.children) < maxFanOut {
+			eligible = append(eligible, n)
+		}
+	}
+	if len(eligible) == 0 {
+		return nil
+	}
+	if r.Intn(100) < 30 {
+		best := eligible[r.Intn(len(eligible))]
+		for range 2 {
+			c := eligible[r.Intn(len(eligible))]
+			if len(c.children) > len(best.children) {
+				best = c
+			}
+		}
+		return best
+	}
+	return eligible[r.Intn(len(eligible))]
+}
+
+// assignLabels gives each node a DGG service type. Leaves are often caches
+// or blackholes; interior nodes are almost always normal services.
+func assignLabels(r *rand.Rand, root *genNode, nodes []*genNode) {
+	for _, n := range nodes {
+		switch {
+		case n == root:
+			if r.Intn(100) < 20 {
+				n.label = labelRelay
+			} else {
+				n.label = labelNormal
+			}
+		case len(n.children) == 0:
+			switch p := r.Intn(100); {
+			case p < 35:
+				n.label = labelMemcached
+			case p < 50:
+				n.label = labelBlackhole
+			default:
+				n.label = labelNormal
+			}
+		default:
+			if r.Intn(100) < 5 {
+				n.label = labelRelay
+			} else {
+				n.label = labelNormal
+			}
+		}
+	}
+}
+
+// assignMultiplicities sets the call count on each node's inbound edge.
+// The paper reports repeated calls with a heavy tail (P99 in the hundreds).
+// Large multiplicities only appear on leaf edges, where they add spans
+// rather than multiplying entire subtrees.
+func assignMultiplicities(r *rand.Rand, nodes []*genNode) {
+	for _, n := range nodes {
+		if n.depth == 1 {
+			continue
+		}
+		if len(n.children) == 0 {
+			switch p := r.Intn(100); {
+			case p < 50:
+				n.mult = 1
+			case p < 85:
+				n.mult = 2 + r.Intn(4) // 2-5
+			case p < 97:
+				n.mult = 6 + r.Intn(45) // 6-50
+			default:
+				n.mult = 100 + r.Intn(301) // 100-400
+			}
+		} else if r.Intn(100) < 5 {
+			n.mult = 2
+		}
+	}
+
+	// Clamp each node's effective fan-out (sum of child multiplicities)
+	// by halving the largest child multiplicity until it fits.
+	for _, n := range nodes {
+		for {
+			total := 0
+			var largest *genNode
+			for _, c := range n.children {
+				total += c.mult
+				if largest == nil || c.mult > largest.mult {
+					largest = c
+				}
+			}
+			if total <= maxEffectiveFanOut || largest == nil || largest.mult <= 1 {
+				break
+			}
+			largest.mult /= 2
+		}
+	}
+}
+
+// staticSpans computes the worst-case spans per trace: every node
+// contributes the product of multiplicities along its path from the root.
+func staticSpans(n *genNode, factor int) int {
+	factor *= n.mult
+	total := factor
+	for _, c := range n.children {
+		total += staticSpans(c, factor)
+	}
+	return total
+}
+
+// clampSpans halves the largest leaf multiplicity until the static span
+// count fits under maxStaticSpans.
+func clampSpans(root *genNode) {
+	for staticSpans(root, 1) > maxStaticSpans {
+		var largest *genNode
+		var walk func(*genNode)
+		walk = func(n *genNode) {
+			if len(n.children) == 0 && (largest == nil || n.mult > largest.mult) {
+				largest = n
+			}
+			for _, c := range n.children {
+				walk(c)
+			}
+		}
+		walk(root)
+		if largest == nil || largest.mult <= 1 {
+			return
+		}
+		largest.mult /= 2
+		if largest.mult < 1 {
+			largest.mult = 1
+		}
+	}
+}
+
+// assignNames produces DGG-style node names. Normal services are sometimes
+// reused with a _funcN suffix so converted topologies contain services with
+// multiple operations, matching the ~49% of production services that expose
+// more than two interfaces.
+func assignNames(r *rand.Rand, root *genNode) {
+	type svc struct {
+		base  string
+		funcs int
+	}
+	var normals []*svc
+	counters := map[string]int{}
+
+	newName := func(n *genNode) string {
+		switch n.label {
+		case labelMemcached:
+			counters["mc"]++
+			return fmt.Sprintf("MS_Memcached.%d", counters["mc"])
+		case labelBlackhole:
+			counters["bh"]++
+			return fmt.Sprintf("MS_blackhole.%d", counters["bh"])
+		case labelRelay:
+			counters["relay"]++
+			return fmt.Sprintf("MS_relay+1.%d", counters["relay"])
+		default:
+			// Reuse an existing normal service as a new function 35% of
+			// the time, except for the root, which keeps its own service.
+			if n != root && len(normals) > 0 && r.Intn(100) < 35 {
+				s := normals[r.Intn(len(normals))]
+				s.funcs++
+				return fmt.Sprintf("%s_func%d", s.base, s.funcs)
+			}
+			counters["normal"]++
+			base := fmt.Sprintf("MS_normal+1.%d", counters["normal"])
+			normals = append(normals, &svc{base: base})
+			return base
+		}
+	}
+
+	var walk func(*genNode)
+	walk = func(n *genNode) {
+		n.name = newName(n)
+		for _, c := range n.children {
+			walk(c)
+		}
+	}
+	walk(root)
+}
+
+// emitEdges writes edges depth-first with hierarchical rpcids ("0.3.1" is
+// the first child of the third child of the root call).
+func emitEdges(r *rand.Rand, g *dggGraph, n *genNode, rpcid string) {
+	for i, c := range n.children {
+		childID := fmt.Sprintf("%s.%d", rpcid, i+1)
+		g.Edges = append(g.Edges, dggEdge{
+			RPCID:   childID,
+			UM:      n.name,
+			DM:      c.name,
+			Time:    c.mult,
+			Compara: protocolFor(r, c.label),
+		})
+		emitEdges(r, g, c, childID)
+	}
+}
+
+func protocolFor(r *rand.Rand, label string) string {
+	switch label {
+	case labelMemcached:
+		return "mc"
+	case labelBlackhole:
+		return "rpc"
+	default:
+		if r.Intn(100) < 40 {
+			return "http"
+		}
+		return "rpc"
+	}
+}
+
+func fatal(err error) {
+	fmt.Fprintf(os.Stderr, "dgggen: %v\n", err)
+	os.Exit(1)
+}

--- a/tools/dgggen/main_test.go
+++ b/tools/dgggen/main_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+const testCorpusSize = 100
+
+func genCorpus(seed int64) []dggGraph {
+	r := rand.New(rand.NewSource(seed))
+	graphs := make([]dggGraph, testCorpusSize)
+	for i := range graphs {
+		graphs[i] = generate(r)
+	}
+	return graphs
+}
+
+func TestDeterministic(t *testing.T) {
+	a, err := json.Marshal(genCorpus(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(genCorpus(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b) {
+		t.Error("same seed produced different corpora")
+	}
+}
+
+func TestGraphValidity(t *testing.T) {
+	for i, g := range genCorpus(1) {
+		names := make(map[string]bool, len(g.Nodes))
+		for _, n := range g.Nodes {
+			if names[n.Node] {
+				t.Errorf("graph %d: duplicate node name %q", i, n.Node)
+			}
+			names[n.Node] = true
+		}
+
+		rpcids := make(map[string]bool, len(g.Edges))
+		for _, e := range g.Edges {
+			if !names[e.UM] || !names[e.DM] {
+				t.Errorf("graph %d: edge %s references unknown node (%s -> %s)", i, e.RPCID, e.UM, e.DM)
+			}
+			if rpcids[e.RPCID] {
+				t.Errorf("graph %d: duplicate rpcid %q", i, e.RPCID)
+			}
+			rpcids[e.RPCID] = true
+			if e.Time < 1 {
+				t.Errorf("graph %d: edge %s has multiplicity %d", i, e.RPCID, e.Time)
+			}
+		}
+
+		if len(g.Edges) != len(g.Nodes)-1 {
+			t.Errorf("graph %d: %d edges for %d nodes, want a tree", i, len(g.Edges), len(g.Nodes))
+		}
+	}
+}
+
+func TestSpanAndFanOutBounds(t *testing.T) {
+	for i, g := range genCorpus(1) {
+		children := make(map[string][]dggEdge)
+		for _, e := range g.Edges {
+			children[e.UM] = append(children[e.UM], e)
+		}
+
+		for um, edges := range children {
+			if um == "USER" {
+				continue
+			}
+			total := 0
+			for _, e := range edges {
+				total += e.Time
+			}
+			if total > maxEffectiveFanOut {
+				t.Errorf("graph %d: node %s has effective fan-out %d > %d", i, um, total, maxEffectiveFanOut)
+			}
+		}
+
+		var spans func(node string, factor int) int
+		spans = func(node string, factor int) int {
+			total := 0
+			for _, e := range children[node] {
+				f := factor * e.Time
+				total += f + spans(e.DM, f)
+			}
+			return total
+		}
+		if s := spans("USER", 1); s > maxStaticSpans {
+			t.Errorf("graph %d: static spans %d > %d", i, s, maxStaticSpans)
+		}
+	}
+}
+
+// TestCorpusCoversProductionTail verifies the default-seed corpus reaches
+// the deep and wide tail of the production distribution: depths of 15+
+// and graphs with hundreds of spans, per the Du et al. measurements.
+func TestCorpusCoversProductionTail(t *testing.T) {
+	var maxDepth, maxNodes, maxSpans int
+	for _, g := range genCorpus(1) {
+		for _, e := range g.Edges {
+			// Depth in motel terms: edges below the root operation,
+			// which is the number of dots in the rpcid.
+			if d := strings.Count(e.RPCID, "."); d > maxDepth {
+				maxDepth = d
+			}
+		}
+		if len(g.Nodes) > maxNodes {
+			maxNodes = len(g.Nodes)
+		}
+
+		children := make(map[string][]dggEdge)
+		for _, e := range g.Edges {
+			children[e.UM] = append(children[e.UM], e)
+		}
+		var spans func(node string, factor int) int
+		spans = func(node string, factor int) int {
+			total := 0
+			for _, e := range children[node] {
+				f := factor * e.Time
+				total += f + spans(e.DM, f)
+			}
+			return total
+		}
+		if s := spans("USER", 1); s > maxSpans {
+			maxSpans = s
+		}
+	}
+
+	if maxDepth < 15 {
+		t.Errorf("corpus max depth %d, want >= 15", maxDepth)
+	}
+	if maxNodes < 150 {
+		t.Errorf("corpus max node count %d, want >= 150", maxNodes)
+	}
+	if maxSpans < 500 {
+		t.Errorf("corpus max spans %d, want >= 500", maxSpans)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `dgggen`, a new tool that generates synthetic DGG-format call graphs with shape distributions matching production measurements from the Du et al. paper on Alibaba microservice traces. This enables stress testing with realistic graph topologies that reach the tail of the distribution (depths 15+, hundreds of nodes, high fan-out).

## Key Changes

- **New tool: `tools/dgggen/main.go`** — Generates deterministic, stratified call graphs with:
  - Heavy-tailed graph sizes (3-450 nodes) and depths (1-20 levels)
  - Hub services with fan-out up to 50 and effective fan-out up to 500
  - Repeated calls with multiplicities reaching hundreds on leaf edges
  - Service type distribution (normal, Memcached, blackhole, relay) matching production
  - Multiple interfaces per service (~49% reuse) via function suffixes
  - Span count clamping to stay under motel's limits while covering the tail

- **Test suite: `tools/dgggen/main_test.go`** — Validates:
  - Deterministic output for a given seed
  - Graph structural validity (no duplicate nodes/edges, proper tree structure)
  - Span and fan-out bounds enforcement
  - Corpus covers production tail (depths 15+, 150+ nodes, 500+ spans)

- **Documentation: `docs/demos/demo-dgg.md`** — Added section showing:
  - How to generate and convert a 100-graph corpus
  - Example output demonstrating production-scale characteristics
  - Distribution analysis reaching depth 18, fan-out 460, 4000+ spans

- **Test infrastructure: `tools/dgg2motel/test_corpus.sh`** — Enhanced to support:
  - `CHECK_ARGS` environment variable for passing custom motel check flags
  - Allows testing with raised limits for production-shaped graphs

## Implementation Details

- Uses weighted bucket sampling to oversample the distribution tail while keeping corpus size manageable
- Builds graphs as trees with a guaranteed-depth spine plus preferential-attachment bias for hub formation
- Clamps multiplicities at two levels: per-node effective fan-out and global static span count
- Generates deterministic node names with DGG conventions (MS_* prefixes, _funcN suffixes for reuse)
- Outputs valid DGG JSON consumable by existing dgg2motel converter

https://claude.ai/code/session_014HnMuCVwwmEnBBfPRsERfn