### PR TITLE
Engine observability and seeded-run determinism

### DIFF
--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -88,6 +88,7 @@ func runCmd() *cobra.Command {
 		pprofAddr        string
 		timeOffset       time.Duration
 		realtime         bool
+		seed             uint64
 	)
 
 	cmd := &cobra.Command{
@@ -122,6 +123,7 @@ func runCmd() *cobra.Command {
 				pprofAddr:        pprofAddr,
 				timeOffset:       timeOffset,
 				realtime:         realtime,
+				seed:             seed,
 			})
 		},
 	}
@@ -138,6 +140,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().StringVar(&pprofAddr, "pprof", "", "start pprof HTTP server on this address (e.g. :6060)")
 	cmd.Flags().DurationVar(&timeOffset, "time-offset", 0, "shift span, metric, and log timestamps by this duration (e.g. -1h for past, 1h for future)")
 	cmd.Flags().BoolVar(&realtime, "realtime", false, "emit spans at wall-clock times matching simulated timestamps")
+	cmd.Flags().Uint64Var(&seed, "seed", 0, "seed for deterministic simulation decisions (0 = random); determinism is best-effort and not guaranteed across motel versions")
 
 	return cmd
 }
@@ -448,6 +451,26 @@ type runOptions struct {
 	pprofAddr        string
 	timeOffset       time.Duration
 	realtime         bool
+	seed             uint64
+}
+
+// RNG streams for seeded runs. Each consumer of randomness gets a fixed
+// stream of the same seed so that enabling or disabling one signal does
+// not perturb the sequences of the others.
+const (
+	rngStreamEngine  = 1
+	rngStreamMetrics = 2
+	rngStreamLogs    = 3
+)
+
+// newRunRng returns the RNG for one consumer of randomness during a run.
+// With a non-zero seed the RNG is deterministic on the given stream;
+// with seed 0 it is independently random.
+func newRunRng(seed, stream uint64) *rand.Rand {
+	if seed == 0 {
+		return rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // synthetic data, not security-sensitive
+	}
+	return rand.New(rand.NewPCG(seed, stream)) //nolint:gosec // synthetic data, not security-sensitive
 }
 
 var validSignals = map[string]bool{
@@ -619,8 +642,7 @@ func runGenerate(ctx context.Context, configPath string, opts runOptions) error 
 			return fmt.Errorf("creating metric providers: %w", mErr)
 		}
 		defer shutdownMetrics()
-		rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // synthetic data, not security-sensitive
-		obs, mErr := synth.NewMetricObserver(meters, topo, rng)
+		obs, mErr := synth.NewMetricObserver(meters, topo, newRunRng(opts.seed, rngStreamMetrics))
 		if mErr != nil {
 			return fmt.Errorf("creating metric observer: %w", mErr)
 		}
@@ -635,8 +657,7 @@ func runGenerate(ctx context.Context, configPath string, opts runOptions) error 
 			return fmt.Errorf("creating log providers: %w", lErr)
 		}
 		defer shutdownLogs()
-		rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // synthetic data, not security-sensitive
-		obs, lErr := synth.NewLogObserver(loggers, topo, opts.slowThreshold, rng)
+		obs, lErr := synth.NewLogObserver(loggers, topo, opts.slowThreshold, newRunRng(opts.seed, rngStreamLogs))
 		if lErr != nil {
 			return fmt.Errorf("creating log observer: %w", lErr)
 		}
@@ -665,7 +686,7 @@ func runGenerate(ctx context.Context, configPath string, opts runOptions) error 
 				),
 			)
 		},
-		Rng:              rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())), //nolint:gosec // synthetic data, not security-sensitive
+		Rng:              newRunRng(opts.seed, rngStreamEngine),
 		Duration:         duration,
 		Observers:        observers,
 		MaxSpansPerTrace: opts.maxSpansPerTrace,

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -1396,3 +1396,23 @@ func TestSemconvLogWarnings_ValidEnumValue(t *testing.T) {
 
 	assert.Empty(t, semconvLogWarnings(cfg, reg))
 }
+
+func TestNewRunRng(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same seed and stream produce identical sequences", func(t *testing.T) {
+		t.Parallel()
+		a := newRunRng(42, rngStreamEngine)
+		b := newRunRng(42, rngStreamEngine)
+		for range 10 {
+			assert.Equal(t, a.Uint64(), b.Uint64())
+		}
+	})
+
+	t.Run("different streams diverge", func(t *testing.T) {
+		t.Parallel()
+		a := newRunRng(42, rngStreamEngine)
+		b := newRunRng(42, rngStreamMetrics)
+		assert.NotEqual(t, a.Uint64(), b.Uint64())
+	})
+}

--- a/pkg/synth/attributes.go
+++ b/pkg/synth/attributes.go
@@ -4,6 +4,7 @@ package synth
 
 import (
 	"fmt"
+	"maps"
 	"math/rand/v2"
 	"slices"
 	"strconv"
@@ -25,6 +26,70 @@ type AttributeValueConfig struct {
 	Probability  *float64            `yaml:"probability,omitempty"`
 	Range        []int64             `yaml:"range,omitempty"`
 	Distribution *DistributionConfig `yaml:"distribution,omitempty"`
+}
+
+// Attribute pairs a key with its value generator.
+type Attribute struct {
+	Key string
+	Gen AttributeGenerator
+}
+
+// Attributes is an ordered attribute collection, sorted by key.
+// Iteration order is deterministic by construction, which keeps RNG
+// consumption order — and therefore seeded runs — reproducible without
+// per-call-site sorting. Construct with NewAttributes.
+type Attributes []Attribute
+
+// NewAttributes converts a generator map into a key-sorted Attributes.
+func NewAttributes(m map[string]AttributeGenerator) Attributes {
+	if len(m) == 0 {
+		return nil
+	}
+	attrs := make(Attributes, 0, len(m))
+	for _, k := range slices.Sorted(maps.Keys(m)) {
+		attrs = append(attrs, Attribute{Key: k, Gen: m[k]})
+	}
+	return attrs
+}
+
+// Merge returns the union of a and over, with over taking precedence on
+// key collisions. Both inputs must be key-sorted; the result is too.
+func (a Attributes) Merge(over Attributes) Attributes {
+	if len(over) == 0 {
+		return a
+	}
+	if len(a) == 0 {
+		return over
+	}
+	merged := make(Attributes, 0, len(a)+len(over))
+	i, j := 0, 0
+	for i < len(a) && j < len(over) {
+		switch {
+		case a[i].Key < over[j].Key:
+			merged = append(merged, a[i])
+			i++
+		case a[i].Key > over[j].Key:
+			merged = append(merged, over[j])
+			j++
+		default:
+			merged = append(merged, over[j])
+			i++
+			j++
+		}
+	}
+	merged = append(merged, a[i:]...)
+	merged = append(merged, over[j:]...)
+	return merged
+}
+
+// Get returns the generator for key, or nil if the key is absent.
+func (a Attributes) Get(key string) AttributeGenerator {
+	for _, attr := range a {
+		if attr.Key == key {
+			return attr.Gen
+		}
+	}
+	return nil
 }
 
 // AttributeGenerator produces typed values for a span attribute.

--- a/pkg/synth/attributes_test.go
+++ b/pkg/synth/attributes_test.go
@@ -381,3 +381,50 @@ func TestTypedAttribute(t *testing.T) {
 		assert.Equal(t, "7", kv.Value.AsString())
 	})
 }
+
+func TestNewAttributesSortsByKey(t *testing.T) {
+	t.Parallel()
+
+	attrs := NewAttributes(map[string]AttributeGenerator{
+		"zeta":  &StaticValue{Value: "z"},
+		"alpha": &StaticValue{Value: "a"},
+		"mid":   &StaticValue{Value: "m"},
+	})
+	require.Len(t, attrs, 3)
+	assert.Equal(t, "alpha", attrs[0].Key)
+	assert.Equal(t, "mid", attrs[1].Key)
+	assert.Equal(t, "zeta", attrs[2].Key)
+
+	assert.Nil(t, NewAttributes(nil))
+}
+
+func TestAttributesMerge(t *testing.T) {
+	t.Parallel()
+
+	base := NewAttributes(map[string]AttributeGenerator{
+		"a": &StaticValue{Value: "base-a"},
+		"c": &StaticValue{Value: "base-c"},
+	})
+	over := NewAttributes(map[string]AttributeGenerator{
+		"b": &StaticValue{Value: "over-b"},
+		"c": &StaticValue{Value: "over-c"},
+	})
+
+	merged := base.Merge(over)
+	require.Len(t, merged, 3)
+	assert.Equal(t, []string{"a", "b", "c"}, []string{merged[0].Key, merged[1].Key, merged[2].Key}, "result stays sorted")
+	assert.Equal(t, "base-a", merged.Get("a").Generate(nil))
+	assert.Equal(t, "over-b", merged.Get("b").Generate(nil))
+	assert.Equal(t, "over-c", merged.Get("c").Generate(nil), "override wins on collision")
+
+	assert.Equal(t, base, base.Merge(nil))
+	assert.Equal(t, over, Attributes(nil).Merge(over))
+}
+
+func TestAttributesGet(t *testing.T) {
+	t.Parallel()
+
+	attrs := NewAttributes(map[string]AttributeGenerator{"k": &StaticValue{Value: "v"}})
+	assert.Equal(t, "v", attrs.Get("k").Generate(nil))
+	assert.Nil(t, attrs.Get("missing"))
+}

--- a/pkg/synth/benchmark_test.go
+++ b/pkg/synth/benchmark_test.go
@@ -95,14 +95,14 @@ func BenchmarkWalkTrace(b *testing.B) {
 	for range b.N {
 		var stats Stats
 		spanCount := 0
-		engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &stats, &spanCount, DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, &spanCount, DefaultMaxSpansPerTrace, false)
 	}
 	b.StopTimer()
 
 	// Report spans per iteration for reference
 	var stats Stats
 	spanCount := 0
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &stats, &spanCount, DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, &spanCount, DefaultMaxSpansPerTrace, false)
 	b.ReportMetric(float64(stats.Spans), "spans/trace")
 }
 

--- a/pkg/synth/check.go
+++ b/pkg/synth/check.go
@@ -302,7 +302,7 @@ func sampleTracesWith(topo *Topology, n int, seed uint64, maxSpansPerTrace int, 
 		root := topo.Roots[rng.IntN(len(topo.Roots))]
 		var stats Stats
 		spanCount := 0
-		engine.walkTrace(context.Background(), root, time.Now(), 0, overrides, nil, &stats, &spanCount, maxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), root, nil, time.Now(), 0, overrides, nil, &stats, &spanCount, maxSpansPerTrace, false)
 		_ = tp.ForceFlush(context.Background())
 
 		spans := exporter.GetSpans()

--- a/pkg/synth/emit.go
+++ b/pkg/synth/emit.go
@@ -103,7 +103,7 @@ func emitTrace(ctx context.Context, plans []SpanPlan, baseSimTime time.Time, bas
 			if ls.Span == nil {
 				continue
 			}
-			finishSpan(ls.Span, plan, observers, rstats)
+			finishSpan(ls.Span, plan, plans, observers, rstats)
 			live[ev.Index] = liveSpan{}
 		}
 	}
@@ -138,8 +138,18 @@ func buildEvents(plans []SpanPlan) []spanEvent {
 	return events
 }
 
+// planParentNames returns the parent's service and operation names for a
+// plan, or empty strings for root spans.
+func planParentNames(plans []SpanPlan, plan *SpanPlan) (string, string) {
+	if plan.ParentIndex < 0 {
+		return "", ""
+	}
+	p := &plans[plan.ParentIndex]
+	return p.Service, p.Operation
+}
+
 // finishSpan ends a span, records errors, fires observers, and updates stats.
-func finishSpan(span trace.Span, plan *SpanPlan, observers []SpanObserver, rstats *realtimeStats) {
+func finishSpan(span trace.Span, plan *SpanPlan, plans []SpanPlan, observers []SpanObserver, rstats *realtimeStats) {
 	if plan.IsError {
 		if plan.Rejected {
 			span.SetStatus(codes.Error, plan.RejectionReason)
@@ -155,8 +165,10 @@ func finishSpan(span trace.Span, plan *SpanPlan, observers []SpanObserver, rstat
 	span.End(trace.WithTimestamp(plan.EndTime))
 
 	if len(observers) > 0 {
+		parentService, parentOperation := planParentNames(plans, plan)
 		info := newSpanInfo(
 			plan.Service, plan.Operation,
+			parentService, parentOperation,
 			plan.StartTime, plan.EndTime.Sub(plan.StartTime),
 			plan.IsError, plan.Kind,
 			plan.Attrs, plan.Scenarios,
@@ -183,8 +195,10 @@ func endAllOpen(live []liveSpan, plans []SpanPlan, observers []SpanObserver, rst
 		rstats.Errors.Add(1)
 		if len(observers) > 0 {
 			plan := &plans[i]
+			parentService, parentOperation := planParentNames(plans, plan)
 			info := newSpanInfo(
 				plan.Service, plan.Operation,
+				parentService, parentOperation,
 				plan.StartTime, now.Sub(plan.StartTime),
 				true, plan.Kind,
 				plan.Attrs, plan.Scenarios,

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -6,7 +6,6 @@ package synth
 import (
 	"context"
 	"fmt"
-	"maps"
 	"math/rand/v2"
 	"slices"
 	"sync"
@@ -398,10 +397,7 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 			errorRate = ov.ErrorRate
 		}
 		if len(ov.Attributes) > 0 {
-			merged := make(map[string]AttributeGenerator, len(op.Attributes)+len(ov.Attributes))
-			maps.Copy(merged, op.Attributes)
-			maps.Copy(merged, ov.Attributes)
-			opAttrs = merged
+			opAttrs = op.Attributes.Merge(ov.Attributes)
 		}
 	}
 
@@ -476,8 +472,8 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 	for k, v := range op.Service.Attributes {
 		spanAttrs = append(spanAttrs, attribute.String(k, v))
 	}
-	for k, gen := range opAttrs {
-		spanAttrs = append(spanAttrs, typedAttribute(k, gen.Generate(e.Rng)))
+	for _, a := range opAttrs {
+		spanAttrs = append(spanAttrs, typedAttribute(a.Key, a.Gen.Generate(e.Rng)))
 	}
 	span.SetAttributes(spanAttrs...)
 
@@ -487,8 +483,8 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 		}
 		if len(evt.Attributes) > 0 {
 			evtAttrs := make([]attribute.KeyValue, 0, len(evt.Attributes))
-			for k, gen := range evt.Attributes {
-				evtAttrs = append(evtAttrs, typedAttribute(k, gen.Generate(e.Rng)))
+			for _, a := range evt.Attributes {
+				evtAttrs = append(evtAttrs, typedAttribute(a.Key, a.Gen.Generate(e.Rng)))
 			}
 			evtOpts = append(evtOpts, trace.WithAttributes(evtAttrs...))
 		}

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -186,7 +186,7 @@ func (e *Engine) Run(ctx context.Context) (*Stats, error) {
 		spanStart := now.Add(e.TimeOffset)
 		spanLimit := e.maxSpansPerTrace()
 		spanCount := 0
-		_, rootErr := e.walkTrace(ctx, root, spanStart, elapsed, overrides, scenarioNames, &stats, &spanCount, spanLimit, false)
+		_, rootErr := e.walkTrace(ctx, root, nil, spanStart, elapsed, overrides, scenarioNames, &stats, &spanCount, spanLimit, false)
 		stats.Traces++
 		if rootErr {
 			stats.FailedTraces++
@@ -375,10 +375,11 @@ func (e *Engine) maxSpansPerTrace() int {
 
 // walkTrace recursively generates spans for an operation and its downstream calls.
 // Returns the span end time and whether the span errored (own error rate or cascaded from children).
+// parent is the calling operation, nil for roots; it is reported to observers.
 // spanCount tracks the number of spans generated in this trace; no new spans are created once it reaches spanLimit.
 // elapsed is the simulation wall-clock time since engine start, used for state tracking.
 // isAsync indicates the span was invoked via an async call and should use CONSUMER span kind.
-func (e *Engine) walkTrace(ctx context.Context, op *Operation, startTime time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, spanCount *int, spanLimit int, isAsync bool) (time.Time, bool) {
+func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, spanCount *int, spanLimit int, isAsync bool) (time.Time, bool) {
 	if *spanCount >= spanLimit {
 		return startTime, false
 	}
@@ -415,10 +416,12 @@ func (e *Engine) walkTrace(ctx context.Context, op *Operation, startTime time.Ti
 			switch reason {
 			case ReasonQueueFull:
 				stats.QueueRejections++
+				notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventQueueRejection, Service: op.Service.Name, Operation: op.Name, Timestamp: startTime})
 			case ReasonCircuitOpen:
 				stats.CircuitBreakerTrips++
+				notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventCircuitBreakerTrip, Service: op.Service.Name, Operation: op.Name, Timestamp: startTime})
 			}
-			return e.emitRejectionSpan(ctx, op, startTime, reason, scenarioNames, stats, spanCount, isAsync)
+			return e.emitRejectionSpan(ctx, op, parent, startTime, reason, scenarioNames, stats, spanCount, isAsync)
 		}
 		if durationMult > 1.0 {
 			duration.Mean = time.Duration(float64(duration.Mean) * durationMult)
@@ -528,7 +531,7 @@ func (e *Engine) walkTrace(ctx context.Context, op *Operation, startTime time.Ti
 		for _, call := range activeCalls {
 			count := max(call.Count, 1)
 			for range count {
-				perceivedEnd, failed := e.executeCall(ctx, call, nextStart, elapsed, overrides, scenarioNames, stats, spanCount, spanLimit)
+				perceivedEnd, failed := e.executeCall(ctx, call, op, nextStart, elapsed, overrides, scenarioNames, stats, spanCount, spanLimit)
 				if call.Async {
 					continue
 				}
@@ -545,7 +548,7 @@ func (e *Engine) walkTrace(ctx context.Context, op *Operation, startTime time.Ti
 		for _, call := range activeCalls {
 			count := max(call.Count, 1)
 			for range count {
-				perceivedEnd, failed := e.executeCall(ctx, call, childStartTime, elapsed, overrides, scenarioNames, stats, spanCount, spanLimit)
+				perceivedEnd, failed := e.executeCall(ctx, call, op, childStartTime, elapsed, overrides, scenarioNames, stats, spanCount, spanLimit)
 				if call.Async {
 					continue
 				}
@@ -582,8 +585,10 @@ func (e *Engine) walkTrace(ctx context.Context, op *Operation, startTime time.Ti
 	if len(e.Observers) > 0 {
 		attrsCopy := make([]attribute.KeyValue, len(spanAttrs))
 		copy(attrsCopy, spanAttrs)
+		parentService, parentOperation := parentNames(parent)
 		info := newSpanInfo(
 			op.Service.Name, op.Name,
+			parentService, parentOperation,
 			startTime, endTime.Sub(startTime),
 			isError, kind,
 			attrsCopy, scenarioNames,
@@ -597,8 +602,17 @@ func (e *Engine) walkTrace(ctx context.Context, op *Operation, startTime time.Ti
 	return endTime, isError
 }
 
+// parentNames returns the service and operation names of a parent operation,
+// or empty strings when parent is nil (root spans).
+func parentNames(parent *Operation) (string, string) {
+	if parent == nil {
+		return "", ""
+	}
+	return parent.Service.Name, parent.Name
+}
+
 // emitRejectionSpan creates a short error span for a rejected request.
-func (e *Engine) emitRejectionSpan(ctx context.Context, op *Operation, startTime time.Time, reason string, scenarioNames []string, stats *Stats, spanCount *int, isAsync bool) (time.Time, bool) {
+func (e *Engine) emitRejectionSpan(ctx context.Context, op, parent *Operation, startTime time.Time, reason string, scenarioNames []string, stats *Stats, spanCount *int, isAsync bool) (time.Time, bool) {
 	*spanCount++
 	tracer := e.Tracers(op.Service.Name)
 	endTime := startTime.Add(rejectionDuration)
@@ -634,8 +648,10 @@ func (e *Engine) emitRejectionSpan(ctx context.Context, op *Operation, startTime
 
 	if len(e.Observers) > 0 {
 		notifySpanStart(e.Observers, op.Service.Name, op.Name)
+		parentService, parentOperation := parentNames(parent)
 		info := newSpanInfo(
 			op.Service.Name, op.Name,
+			parentService, parentOperation,
 			startTime, rejectionDuration,
 			true, kind,
 			[]attribute.KeyValue{
@@ -654,12 +670,13 @@ func (e *Engine) emitRejectionSpan(ctx context.Context, op *Operation, startTime
 }
 
 // executeCall runs a single downstream call, applying timeout capping and retries.
-func (e *Engine) executeCall(ctx context.Context, call Call, callStart time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, spanCount *int, spanLimit int) (time.Time, bool) {
+// parent is the calling operation.
+func (e *Engine) executeCall(ctx context.Context, call Call, parent *Operation, callStart time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, spanCount *int, spanLimit int) (time.Time, bool) {
 	maxAttempts := 1 + call.Retries
 	attemptStart := callStart
 
 	for attempt := range maxAttempts {
-		childEnd, childErr := e.walkTrace(ctx, call.Operation, attemptStart, elapsed, overrides, scenarioNames, stats, spanCount, spanLimit, call.Async)
+		childEnd, childErr := e.walkTrace(ctx, call.Operation, parent, attemptStart, elapsed, overrides, scenarioNames, stats, spanCount, spanLimit, call.Async)
 		perceivedEnd := childEnd
 		failed := childErr
 
@@ -667,6 +684,7 @@ func (e *Engine) executeCall(ctx context.Context, call Call, callStart time.Time
 			perceivedEnd = attemptStart.Add(call.Timeout)
 			failed = true
 			stats.Timeouts++
+			notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventTimeout, Service: call.Operation.Service.Name, Operation: call.Operation.Name, Timestamp: perceivedEnd})
 		}
 
 		if !failed || attempt == maxAttempts-1 {
@@ -674,6 +692,7 @@ func (e *Engine) executeCall(ctx context.Context, call Call, callStart time.Time
 		}
 
 		stats.Retries++
+		notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventRetry, Service: call.Operation.Service.Name, Operation: call.Operation.Name, Timestamp: perceivedEnd})
 		attemptStart = perceivedEnd.Add(call.RetryBackoff)
 	}
 

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -327,7 +327,7 @@ func (e *Engine) runRealtime(ctx context.Context) (*Stats, error) {
 		// QueueRejections, and CircuitBreakerTrips which are plan-phase
 		// decisions.
 		var plans []SpanPlan
-		_, rootErr := e.planTrace(root, -1, spanStart, elapsed, overrides, scenarioNames, &stats, &plans, &spanCount, spanLimit)
+		_, rootErr := e.planTrace(root, -1, spanStart, elapsed, overrides, scenarioNames, &stats, &plans, &spanCount, spanLimit, false)
 		stats.Traces++
 		if rootErr {
 			stats.FailedTraces++
@@ -417,7 +417,7 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 				stats.CircuitBreakerTrips++
 				notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventCircuitBreakerTrip, Service: op.Service.Name, Operation: op.Name, Timestamp: startTime})
 			}
-			return e.emitRejectionSpan(ctx, op, parent, startTime, reason, scenarioNames, stats, spanCount, isAsync)
+			return e.emitRejectionSpan(ctx, op, parent, startTime, reason, scenarioNames, stats, isAsync)
 		}
 		if durationMult > 1.0 {
 			duration.Mean = time.Duration(float64(duration.Mean) * durationMult)
@@ -608,8 +608,9 @@ func parentNames(parent *Operation) (string, string) {
 }
 
 // emitRejectionSpan creates a short error span for a rejected request.
-func (e *Engine) emitRejectionSpan(ctx context.Context, op, parent *Operation, startTime time.Time, reason string, scenarioNames []string, stats *Stats, spanCount *int, isAsync bool) (time.Time, bool) {
-	*spanCount++
+// The caller (walkTrace) has already counted this span against the trace's
+// span limit, so spanCount is not incremented here.
+func (e *Engine) emitRejectionSpan(ctx context.Context, op, parent *Operation, startTime time.Time, reason string, scenarioNames []string, stats *Stats, isAsync bool) (time.Time, bool) {
 	tracer := e.Tracers(op.Service.Name)
 	endTime := startTime.Add(rejectionDuration)
 

--- a/pkg/synth/engine_test.go
+++ b/pkg/synth/engine_test.go
@@ -288,10 +288,10 @@ func TestEngineScenarioAttributeOverrides(t *testing.T) {
 		End:   time.Hour,
 		Overrides: map[string]Override{
 			"svc.op": {
-				Attributes: map[string]AttributeGenerator{
+				Attributes: NewAttributes(map[string]AttributeGenerator{
 					"status": &StaticValue{Value: "503"},
 					"extra":  &StaticValue{Value: "added"},
-				},
+				}),
 			},
 		},
 	}}
@@ -2791,4 +2791,77 @@ func TestEngineSpanLinksFirstTraceEmpty(t *testing.T) {
 	spans := exporter.GetSpans()
 	require.Len(t, spans, 1)
 	assert.Empty(t, spans[0].Links, "first trace should have no links (registry empty)")
+}
+
+// TestSeededRunsFullyDeterministic pins the determinism guarantee for seeded
+// engines: identical structure AND identical attribute values. The topology
+// deliberately gives one operation several RNG-consuming generators
+// including a normal distribution, whose ziggurat sampling draws a variable
+// number of values — if attribute iteration order were nondeterministic,
+// RNG streams would diverge between runs.
+func TestSeededRunsFullyDeterministic(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "gateway",
+				Operations: []OperationConfig{{
+					Name:      "request",
+					Duration:  "30ms +/- 10ms",
+					ErrorRate: "20%",
+					Attributes: map[string]AttributeValueConfig{
+						"payload.bytes": {Distribution: &DistributionConfig{Mean: 4096, StdDev: 1024}},
+						"queue.lag":     {Distribution: &DistributionConfig{Mean: 5, StdDev: 2}},
+						"http.status":   {Values: map[any]int{"200": 9, "500": 1}},
+						"attempt":       {Range: []int64{1, 5}},
+					},
+					Calls: []CallConfig{{Target: "backend.handle", Probability: 0.7}},
+				}},
+			},
+			{
+				Name: "backend",
+				Operations: []OperationConfig{{
+					Name:     "handle",
+					Duration: "20ms +/- 5ms",
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "100/s"},
+	}
+
+	type spanSnapshot struct {
+		Op    string
+		Err   bool
+		Dur   time.Duration
+		Attrs map[string]any
+	}
+
+	runOnce := func() []spanSnapshot {
+		engine, _, tp := newTestEngine(t, cfg)
+		engine.Rng = rand.New(rand.NewPCG(99, 1))
+		obs := &recordingObserver{}
+		engine.Observers = []SpanObserver{obs}
+
+		base := time.UnixMilli(0)
+		for range 50 {
+			engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, base, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		}
+		require.NoError(t, tp.ForceFlush(context.Background()))
+
+		records := obs.get()
+		snaps := make([]spanSnapshot, len(records))
+		for i, r := range records {
+			attrs := make(map[string]any, len(r.Attrs))
+			for _, kv := range r.Attrs {
+				attrs[string(kv.Key)] = kv.Value.AsInterface()
+			}
+			snaps[i] = spanSnapshot{Op: r.Operation, Err: r.IsError, Dur: r.Duration, Attrs: attrs}
+		}
+		return snaps
+	}
+
+	first := runOnce()
+	second := runOnce()
+	require.Equal(t, first, second, "seeded runs must produce identical spans, including attribute values")
 }

--- a/pkg/synth/engine_test.go
+++ b/pkg/synth/engine_test.go
@@ -79,7 +79,7 @@ func TestEngineWalkTrace(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 
 	// Force flush
 	require.NoError(t, tp.ForceFlush(context.Background()))
@@ -128,7 +128,7 @@ func TestEngineErrorInjection(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -241,7 +241,7 @@ func TestEngineScenarioOverrides(t *testing.T) {
 
 	// Walk trace with overrides active at elapsed=0
 	overrides := ResolveOverrides(ActiveScenarios(scenarios, 0))
-	engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -305,7 +305,7 @@ func TestEngineScenarioAttributeOverrides(t *testing.T) {
 	}
 
 	overrides := ResolveOverrides(ActiveScenarios(scenarios, 0))
-	engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -488,7 +488,7 @@ func TestEngineOperationAttributes(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -532,7 +532,7 @@ func TestEngineSequentialCallStyle(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -583,7 +583,7 @@ func TestEngineParallelCallStyle(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -668,7 +668,7 @@ func TestEngineSpanAttributes(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -720,7 +720,7 @@ func TestEngineProbabilisticCall(t *testing.T) {
 
 	for range trials {
 		exporter.Reset()
-		engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 
 		spans := exporter.GetSpans()
@@ -765,7 +765,7 @@ func TestEngineOnErrorCondition(t *testing.T) {
 		t.Parallel()
 		engine, exporter, tp := newTestEngine(t, makeConfig("100%"))
 		rootOp := engine.Topology.Roots[0]
-		engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 		spans := exporter.GetSpans()
 		assert.Len(t, spans, 2, "on-error child should be present when parent errors")
@@ -775,7 +775,7 @@ func TestEngineOnErrorCondition(t *testing.T) {
 		t.Parallel()
 		engine, exporter, tp := newTestEngine(t, makeConfig("0%"))
 		rootOp := engine.Topology.Roots[0]
-		engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 		spans := exporter.GetSpans()
 		assert.Len(t, spans, 1, "on-error child should be absent when parent succeeds")
@@ -813,7 +813,7 @@ func TestEngineOnSuccessCondition(t *testing.T) {
 		t.Parallel()
 		engine, exporter, tp := newTestEngine(t, makeConfig("0%"))
 		rootOp := engine.Topology.Roots[0]
-		engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 		spans := exporter.GetSpans()
 		assert.Len(t, spans, 2, "on-success child should be present when parent succeeds")
@@ -823,7 +823,7 @@ func TestEngineOnSuccessCondition(t *testing.T) {
 		t.Parallel()
 		engine, exporter, tp := newTestEngine(t, makeConfig("100%"))
 		rootOp := engine.Topology.Roots[0]
-		engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 		spans := exporter.GetSpans()
 		assert.Len(t, spans, 1, "on-success child should be absent when parent errors")
@@ -856,7 +856,7 @@ func TestEngineFanOutCount(t *testing.T) {
 
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -898,7 +898,7 @@ func TestEngineFanOutSequential(t *testing.T) {
 
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -953,7 +953,7 @@ func TestEngineFanOutParallel(t *testing.T) {
 
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1002,7 +1002,7 @@ func TestEngineCallTimeout(t *testing.T) {
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1060,7 +1060,7 @@ func TestEngineCallNoTimeout(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1110,7 +1110,7 @@ func TestEngineCallTimeoutSequential(t *testing.T) {
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1168,7 +1168,7 @@ func TestEngineCascadingError(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1216,7 +1216,7 @@ func TestEngineCascadingErrorPreservesConditions(t *testing.T) {
 
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1254,7 +1254,7 @@ func TestEngineRetryOnError(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1300,7 +1300,7 @@ func TestEngineRetrySuccess(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1347,7 +1347,7 @@ func TestEngineRetryBackoff(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1398,7 +1398,7 @@ func TestEngineRetryWithTimeout(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1437,7 +1437,7 @@ func TestEngineRetryStats(t *testing.T) {
 	engine, _, _ := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 
 	assert.Equal(t, int64(3), stats.Retries, "should retry 3 times")
 	// 1 parent + 4 child = 5 spans, all errored (child 100%, parent cascaded)
@@ -1473,7 +1473,7 @@ func TestEngineNoRetryWithoutConfig(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1519,14 +1519,14 @@ func TestEngineSpanBound(t *testing.T) {
 	rootOp := engine.Topology.Roots[0]
 
 	// Without bound: 1 + 5 + 25 = 31 spans
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 	assert.Equal(t, 31, len(exporter.GetSpans()))
 
 	// With bound of 10 spans
 	exporter.Reset()
 	spanCount := 0
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, &spanCount, 10, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, &spanCount, 10, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 	assert.LessOrEqual(t, len(exporter.GetSpans()), 10, "span count should be bounded")
 	assert.Greater(t, len(exporter.GetSpans()), 0, "should produce at least some spans")
@@ -1791,7 +1791,7 @@ func TestEngineWalkTraceWithAddCalls(t *testing.T) {
 	gatewayOp := topo.Services["gateway"].Operations["request"]
 
 	var stats Stats
-	engine.walkTrace(context.Background(), gatewayOp, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), gatewayOp, nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1848,7 +1848,7 @@ func TestEngineWalkTraceWithRemoveCalls(t *testing.T) {
 	}
 
 	var stats Stats
-	engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1995,7 +1995,7 @@ func TestEngineLabelScenarios(t *testing.T) {
 		scenarioNames[i] = s.Name
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, overrides, scenarioNames, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, scenarioNames, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2030,7 +2030,7 @@ func TestEngineLabelScenariosEmpty(t *testing.T) {
 	engine.LabelScenarios = true
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2065,7 +2065,7 @@ func TestEngineLabelScenariosDisabled(t *testing.T) {
 	// LabelScenarios defaults to false
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2133,7 +2133,7 @@ func TestPerServiceResource(t *testing.T) {
 	}
 
 	rootOp := topo.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 
 	for _, tp := range providers {
 		require.NoError(t, tp.ForceFlush(context.Background()))
@@ -2303,7 +2303,7 @@ func TestAsyncCallParentDoesNotWait(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2357,7 +2357,7 @@ func TestSyncCallSpanKindIsClient(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2408,7 +2408,7 @@ func TestAsyncCallErrorsDoNotCascade(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2469,7 +2469,7 @@ func TestAsyncSequentialDoesNotBlock(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2531,7 +2531,7 @@ func TestAsyncCallViaScenarioAddCalls(t *testing.T) {
 	rootOp := engine.Topology.Services["gateway"].Operations["handle"]
 	now := time.Now()
 	overrides := ResolveOverrides(ActiveScenarios(engine.Scenarios, 0))
-	engine.walkTrace(context.Background(), rootOp, now, 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2585,7 +2585,7 @@ func TestSpanEvents(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2730,7 +2730,7 @@ func TestEngineSpanLinks(t *testing.T) {
 	require.NotNil(t, consumerRoot)
 
 	// Run producer first to populate the registry
-	engine.walkTrace(context.Background(), producerRoot, now, 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), producerRoot, nil, now, 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	producerSpans := exporter.GetSpans()
@@ -2739,7 +2739,7 @@ func TestEngineSpanLinks(t *testing.T) {
 
 	// Run consumer — should link to producer
 	exporter.Reset()
-	engine.walkTrace(context.Background(), consumerRoot, now.Add(100*time.Millisecond), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), consumerRoot, nil, now.Add(100*time.Millisecond), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	consumerSpans := exporter.GetSpans()
@@ -2785,7 +2785,7 @@ func TestEngineSpanLinksFirstTraceEmpty(t *testing.T) {
 	}
 	require.NotNil(t, consumerRoot)
 
-	engine.walkTrace(context.Background(), consumerRoot, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), consumerRoot, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()

--- a/pkg/synth/logs.go
+++ b/pkg/synth/logs.go
@@ -41,9 +41,8 @@ type logTemplate struct {
 	probability  float64
 	atEnd        bool
 	delay        time.Duration
-	attrGens     map[string]AttributeGenerator
-	attrKeys     []string // sorted for deterministic attribute order
-	operation    string   // non-empty if operation-level (fires only for this op)
+	attrGens     Attributes // key-sorted; deterministic iteration order
+	operation    string     // non-empty if operation-level (fires only for this op)
 }
 
 // LogObserver emits log records for observed spans.
@@ -164,11 +163,6 @@ func (l *LogObserver) splitScopeRef(ref string) (service, operation string) {
 // an unknown severity maps to log.SeverityUndefined while preserving the
 // severity text, so the record still surfaces rather than disappearing.
 func newLogTemplate(ld LogDefinition, operation string) logTemplate {
-	attrKeys := make([]string, 0, len(ld.Attributes))
-	for k := range ld.Attributes {
-		attrKeys = append(attrKeys, k)
-	}
-	slices.Sort(attrKeys)
 	return logTemplate{
 		severity:     severityByName[ld.Severity],
 		severityText: ld.Severity,
@@ -178,7 +172,6 @@ func newLogTemplate(ld LogDefinition, operation string) logTemplate {
 		atEnd:        ld.AtEnd,
 		delay:        ld.Delay,
 		attrGens:     ld.Attributes,
-		attrKeys:     attrKeys,
 		operation:    operation,
 	}
 }
@@ -244,8 +237,8 @@ func (l *LogObserver) emitTemplate(ctx context.Context, logger log.Logger, tpl *
 		return
 	}
 	attrValues := make(map[string]any, len(tpl.attrGens))
-	for _, k := range tpl.attrKeys {
-		attrValues[k] = tpl.attrGens[k].Generate(l.rng)
+	for _, a := range tpl.attrGens {
+		attrValues[a.Key] = a.Gen.Generate(l.rng)
 	}
 	l.mu.Unlock()
 
@@ -255,10 +248,10 @@ func (l *LogObserver) emitTemplate(ctx context.Context, logger log.Logger, tpl *
 	}
 	timestamp = timestamp.Add(tpl.delay)
 
-	attrs := make([]log.KeyValue, 0, len(tpl.attrKeys)+1)
+	attrs := make([]log.KeyValue, 0, len(tpl.attrGens)+1)
 	attrs = append(attrs, log.String("operation.name", info.Operation))
-	for _, k := range tpl.attrKeys {
-		attrs = append(attrs, logKeyValue(k, attrValues[k]))
+	for _, a := range tpl.attrGens {
+		attrs = append(attrs, logKeyValue(a.Key, attrValues[a.Key]))
 	}
 
 	var rec log.Record

--- a/pkg/synth/logs_test.go
+++ b/pkg/synth/logs_test.go
@@ -370,7 +370,7 @@ func TestLogObserverTopologyBodyInterpolation(t *testing.T) {
 	require.NoError(t, err)
 
 	def := alwaysLog("ERROR", "{error.type} in {service.name} {operation.name}: method={http.request.method} missing={no.such.key}")
-	def.Attributes = map[string]AttributeGenerator{"error.type": gen}
+	def.Attributes = NewAttributes(map[string]AttributeGenerator{"error.type": gen})
 
 	topo := testLogTopology("svc", []LogDefinition{def}, "op", nil)
 	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
@@ -397,10 +397,10 @@ func TestLogObserverTopologyTypedAttributes(t *testing.T) {
 	require.NoError(t, err)
 
 	def := alwaysLog("INFO", "typed attributes")
-	def.Attributes = map[string]AttributeGenerator{
+	def.Attributes = NewAttributes(map[string]AttributeGenerator{
 		"app.flow":    strGen,
 		"app.retries": intGen,
-	}
+	})
 
 	topo := testLogTopology("svc", []LogDefinition{def}, "op", nil)
 	obs, exporter := newTestLogObserver(t, topo, 0, "svc")
@@ -680,7 +680,7 @@ func TestLogObserverScenarioAddInterpolation(t *testing.T) {
 			Severity:    "ERROR",
 			Body:        "{error.type} in {operation.name}",
 			Probability: 1.0,
-			Attributes:  map[string]AttributeGenerator{"error.type": gen},
+			Attributes:  NewAttributes(map[string]AttributeGenerator{"error.type": gen}),
 		}}},
 	})
 

--- a/pkg/synth/metrics.go
+++ b/pkg/synth/metrics.go
@@ -27,7 +27,7 @@ type metricInstrument struct {
 	scopeRef   string             // service name or "service.operation" — key into scenario overrides
 	value      *FloatDistribution // nil = span-derived
 	unit       string
-	attrGens   map[string]AttributeGenerator
+	attrGens   Attributes
 	operation  string        // non-empty if operation-level (fires only for this op)
 	errorsOnly bool          // if true, counter only increments for error spans
 	interval   time.Duration // non-zero = emit on a wall-clock timer instead of per span
@@ -337,13 +337,13 @@ func clampValue(v float64, minBound, maxBound *float64) float64 {
 }
 
 // buildMetricAttrs constructs metric attributes from generators and adds operation.name.
-func buildMetricAttrs(attrGens map[string]AttributeGenerator, operation string, rng *rand.Rand) metric.MeasurementOption {
+func buildMetricAttrs(attrGens Attributes, operation string, rng *rand.Rand) metric.MeasurementOption {
 	attrs := make([]attribute.KeyValue, 0, len(attrGens)+1)
 	if operation != "" {
 		attrs = append(attrs, attribute.String("operation.name", operation))
 	}
-	for k, gen := range attrGens {
-		attrs = append(attrs, typedAttribute(k, gen.Generate(rng)))
+	for _, a := range attrGens {
+		attrs = append(attrs, typedAttribute(a.Key, a.Gen.Generate(rng)))
 	}
 	return metric.WithAttributes(attrs...)
 }

--- a/pkg/synth/metrics_test.go
+++ b/pkg/synth/metrics_test.go
@@ -257,9 +257,9 @@ func TestMetricObserverAttributes(t *testing.T) {
 		{
 			Name: "order.count",
 			Type: "counter",
-			Attributes: map[string]AttributeGenerator{
+			Attributes: NewAttributes(map[string]AttributeGenerator{
 				"region": &StaticValue{Value: "us-east"},
-			},
+			}),
 		},
 	})
 

--- a/pkg/synth/observer.go
+++ b/pkg/synth/observer.go
@@ -10,16 +10,20 @@ import (
 )
 
 // SpanInfo holds span metadata for signal derivation.
+// ParentService and ParentOperation identify the calling operation;
+// both are empty for root spans.
 type SpanInfo struct {
-	Service     string
-	Operation   string
-	Timestamp   time.Time
-	Duration    time.Duration
-	IsError     bool
-	Kind        trace.SpanKind
-	Attrs       []attribute.KeyValue
-	Scenarios   []string
-	SpanContext trace.SpanContext
+	Service         string
+	Operation       string
+	ParentService   string
+	ParentOperation string
+	Timestamp       time.Time
+	Duration        time.Duration
+	IsError         bool
+	Kind            trace.SpanKind
+	Attrs           []attribute.KeyValue
+	Scenarios       []string
+	SpanContext     trace.SpanContext
 }
 
 // SpanObserver receives span metadata after each span is emitted.
@@ -38,6 +42,40 @@ func notifySpanStart(observers []SpanObserver, service, operation string) {
 	for _, obs := range observers {
 		if sso, ok := obs.(SpanStartObserver); ok {
 			sso.ObserveStart(service, operation)
+		}
+	}
+}
+
+// Plan event kinds reported to PlanEventObserver.
+const (
+	PlanEventTimeout            = "timeout"
+	PlanEventRetry              = "retry"
+	PlanEventQueueRejection     = "queue_rejection"
+	PlanEventCircuitBreakerTrip = "circuit_breaker_trip"
+)
+
+// PlanEvent describes a plan-phase decision made during trace generation.
+// These decisions (timeouts, retries, queue rejections, circuit breaker
+// trips) are simulation ground truth that does not appear as distinct
+// records in the emitted telemetry.
+type PlanEvent struct {
+	Kind      string
+	Service   string
+	Operation string
+	Timestamp time.Time
+}
+
+// PlanEventObserver receives plan-phase decisions as they are made.
+// Observers that record or display simulation ground truth implement this.
+type PlanEventObserver interface {
+	ObservePlanEvent(ev PlanEvent)
+}
+
+// notifyPlanEvent dispatches a PlanEvent to all observers that implement PlanEventObserver.
+func notifyPlanEvent(observers []SpanObserver, ev PlanEvent) {
+	for _, obs := range observers {
+		if peo, ok := obs.(PlanEventObserver); ok {
+			peo.ObservePlanEvent(ev)
 		}
 	}
 }
@@ -61,16 +99,19 @@ func notifyOverrides(observers []SpanObserver, overrides map[string]Override) {
 }
 
 // newSpanInfo constructs a SpanInfo from its component fields.
-func newSpanInfo(service, operation string, timestamp time.Time, duration time.Duration, isError bool, kind trace.SpanKind, attrs []attribute.KeyValue, scenarios []string, spanCtx trace.SpanContext) SpanInfo {
+// parentService and parentOperation are empty for root spans.
+func newSpanInfo(service, operation, parentService, parentOperation string, timestamp time.Time, duration time.Duration, isError bool, kind trace.SpanKind, attrs []attribute.KeyValue, scenarios []string, spanCtx trace.SpanContext) SpanInfo {
 	return SpanInfo{
-		Service:     service,
-		Operation:   operation,
-		Timestamp:   timestamp,
-		Duration:    duration,
-		IsError:     isError,
-		Kind:        kind,
-		Attrs:       attrs,
-		Scenarios:   scenarios,
-		SpanContext: spanCtx,
+		Service:         service,
+		Operation:       operation,
+		ParentService:   parentService,
+		ParentOperation: parentOperation,
+		Timestamp:       timestamp,
+		Duration:        duration,
+		IsError:         isError,
+		Kind:            kind,
+		Attrs:           attrs,
+		Scenarios:       scenarios,
+		SpanContext:     spanCtx,
 	}
 }

--- a/pkg/synth/observer_test.go
+++ b/pkg/synth/observer_test.go
@@ -78,7 +78,7 @@ func TestObserverCalledPerSpan(t *testing.T) {
 		Observers: []SpanObserver{obs},
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records := obs.get()
@@ -126,7 +126,7 @@ func TestObserverReceivesCorrectMetadata(t *testing.T) {
 		Observers: []SpanObserver{obs},
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records := obs.get()
@@ -188,7 +188,7 @@ func TestObserverDurationIsWallClock(t *testing.T) {
 		Observers: []SpanObserver{obs},
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records := obs.get()
@@ -224,7 +224,7 @@ func TestObserverNotCalledWhenNone(t *testing.T) {
 	}
 
 	engine, exporter, tp := newTestEngine(t, cfg)
-	engine.walkTrace(context.Background(), engine.Topology.Roots[0], time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -264,7 +264,7 @@ func TestMultipleObservers(t *testing.T) {
 		Observers: []SpanObserver{obs1, obs2},
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	assert.Len(t, obs1.get(), 1)
@@ -304,7 +304,7 @@ func TestObserverAttrsCopyIsolation(t *testing.T) {
 		Observers: []SpanObserver{obs},
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records := obs.get()
@@ -317,7 +317,7 @@ func TestObserverAttrsCopyIsolation(t *testing.T) {
 
 	// Generate another span and verify attrs are not corrupted
 	exporter.Reset()
-	engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records2 := obs.get()
@@ -327,4 +327,163 @@ func TestObserverAttrsCopyIsolation(t *testing.T) {
 		assert.NotEqual(t, "mutated", string(kv.Key),
 			"observer attrs should be an independent copy")
 	}
+}
+
+// planEventRecorder captures plan events alongside spans.
+type planEventRecorder struct {
+	recordingObserver
+	evMu   sync.Mutex
+	events []PlanEvent
+}
+
+func (r *planEventRecorder) ObservePlanEvent(ev PlanEvent) {
+	r.evMu.Lock()
+	defer r.evMu.Unlock()
+	r.events = append(r.events, ev)
+}
+
+func (r *planEventRecorder) getEvents() []PlanEvent {
+	r.evMu.Lock()
+	defer r.evMu.Unlock()
+	out := make([]PlanEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+func twoTierConfig(retries int, timeout string, errorRate string) *Config {
+	return &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "gateway",
+				Operations: []OperationConfig{{
+					Name:     "request",
+					Duration: "10ms",
+					Calls: []CallConfig{{
+						Target:  "backend.handle",
+						Retries: retries,
+						Timeout: timeout,
+					}},
+				}},
+			},
+			{
+				Name: "backend",
+				Operations: []OperationConfig{{
+					Name:      "handle",
+					Duration:  "50ms",
+					ErrorRate: errorRate,
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "100/s"},
+	}
+}
+
+func TestObserverReceivesParentAttribution(t *testing.T) {
+	t.Parallel()
+
+	cfg := twoTierConfig(0, "", "")
+	engine, _, tp := newTestEngine(t, cfg)
+	obs := &recordingObserver{}
+	engine.Observers = []SpanObserver{obs}
+
+	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	records := obs.get()
+	require.Len(t, records, 2)
+	byOp := map[string]SpanInfo{}
+	for _, r := range records {
+		byOp[r.Operation] = r
+	}
+
+	root := byOp["request"]
+	assert.Empty(t, root.ParentService, "root span has no parent")
+	assert.Empty(t, root.ParentOperation)
+
+	child := byOp["handle"]
+	assert.Equal(t, "gateway", child.ParentService)
+	assert.Equal(t, "request", child.ParentOperation)
+}
+
+func TestFinishSpanParentAttribution(t *testing.T) {
+	t.Parallel()
+
+	cfg := twoTierConfig(0, "", "")
+	engine, _, tp := newTestEngine(t, cfg)
+	obs := &recordingObserver{}
+
+	var plans []SpanPlan
+	now := time.Now()
+	engine.planTrace(engine.Topology.Roots[0], -1, now, 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace)
+	require.Len(t, plans, 2)
+
+	var rstats realtimeStats
+	emitTrace(context.Background(), plans, now, now, func(string) trace.Tracer { return tp.Tracer("t") }, []SpanObserver{obs}, &rstats, nil)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	records := obs.get()
+	require.Len(t, records, 2)
+	byOp := map[string]SpanInfo{}
+	for _, r := range records {
+		byOp[r.Operation] = r
+	}
+	assert.Empty(t, byOp["request"].ParentService)
+	assert.Equal(t, "gateway", byOp["handle"].ParentService)
+	assert.Equal(t, "request", byOp["handle"].ParentOperation)
+}
+
+func TestPlanEventObserverRetries(t *testing.T) {
+	t.Parallel()
+
+	cfg := twoTierConfig(2, "", "100%")
+	engine, _, tp := newTestEngine(t, cfg)
+	obs := &planEventRecorder{}
+	engine.Observers = []SpanObserver{obs}
+
+	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	events := obs.getEvents()
+	require.Len(t, events, 2, "two retries before the final failed attempt")
+	for _, ev := range events {
+		assert.Equal(t, PlanEventRetry, ev.Kind)
+		assert.Equal(t, "backend", ev.Service)
+		assert.Equal(t, "handle", ev.Operation)
+		assert.False(t, ev.Timestamp.IsZero())
+	}
+}
+
+func TestPlanEventObserverTimeouts(t *testing.T) {
+	t.Parallel()
+
+	cfg := twoTierConfig(0, "1ms", "")
+	engine, _, tp := newTestEngine(t, cfg)
+	obs := &planEventRecorder{}
+	engine.Observers = []SpanObserver{obs}
+
+	stats := &Stats{}
+	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	events := obs.getEvents()
+	require.Len(t, events, 1, "50ms child exceeds 1ms timeout")
+	assert.Equal(t, PlanEventTimeout, events[0].Kind)
+	assert.Equal(t, "backend", events[0].Service)
+	assert.Equal(t, int64(1), stats.Timeouts)
+}
+
+func TestPlanTracePlanEvents(t *testing.T) {
+	t.Parallel()
+
+	cfg := twoTierConfig(2, "", "100%")
+	engine, _, _ := newTestEngine(t, cfg)
+	obs := &planEventRecorder{}
+	engine.Observers = []SpanObserver{obs}
+
+	var plans []SpanPlan
+	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace)
+
+	events := obs.getEvents()
+	require.Len(t, events, 2)
+	assert.Equal(t, PlanEventRetry, events[0].Kind)
 }

--- a/pkg/synth/observer_test.go
+++ b/pkg/synth/observer_test.go
@@ -414,7 +414,7 @@ func TestFinishSpanParentAttribution(t *testing.T) {
 
 	var plans []SpanPlan
 	now := time.Now()
-	engine.planTrace(engine.Topology.Roots[0], -1, now, 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace)
+	engine.planTrace(engine.Topology.Roots[0], -1, now, 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false)
 	require.Len(t, plans, 2)
 
 	var rstats realtimeStats
@@ -481,7 +481,7 @@ func TestPlanTracePlanEvents(t *testing.T) {
 	engine.Observers = []SpanObserver{obs}
 
 	var plans []SpanPlan
-	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace)
+	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false)
 
 	events := obs.getEvents()
 	require.Len(t, events, 2)

--- a/pkg/synth/plan.go
+++ b/pkg/synth/plan.go
@@ -33,7 +33,7 @@ type SpanPlan struct {
 // mutations, same timing logic. The only difference is that it appends to plans
 // instead of creating OTel spans.
 // Returns the span end time and whether the span errored.
-func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, plans *[]SpanPlan, spanCount *int, spanLimit int) (time.Time, bool) {
+func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, plans *[]SpanPlan, spanCount *int, spanLimit int, isAsync bool) (time.Time, bool) {
 	if *spanCount >= spanLimit {
 		return startTime, false
 	}
@@ -71,7 +71,7 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 				stats.CircuitBreakerTrips++
 				notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventCircuitBreakerTrip, Service: op.Service.Name, Operation: op.Name, Timestamp: startTime})
 			}
-			return e.planRejectionSpan(op, parentIndex, startTime, reason, scenarioNames, plans, spanCount)
+			return e.planRejectionSpan(op, parentIndex, startTime, reason, scenarioNames, plans, isAsync)
 		}
 		if durationMult > 1.0 {
 			duration.Mean = time.Duration(float64(duration.Mean) * durationMult)
@@ -83,6 +83,8 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 	kind := trace.SpanKindClient
 	if isRoot(e.Topology, op) {
 		kind = trace.SpanKindServer
+	} else if isAsync {
+		kind = trace.SpanKindConsumer
 	}
 
 	startAttrs := []attribute.KeyValue{
@@ -198,13 +200,16 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 }
 
 // planRejectionSpan mirrors emitRejectionSpan but appends to plans.
-func (e *Engine) planRejectionSpan(op *Operation, parentIndex int, startTime time.Time, reason string, scenarioNames []string, plans *[]SpanPlan, spanCount *int) (time.Time, bool) {
-	*spanCount++
+// The caller (planTrace) has already counted this span against the trace's
+// span limit, so spanCount is not incremented here.
+func (e *Engine) planRejectionSpan(op *Operation, parentIndex int, startTime time.Time, reason string, scenarioNames []string, plans *[]SpanPlan, isAsync bool) (time.Time, bool) {
 	endTime := startTime.Add(rejectionDuration)
 
 	kind := trace.SpanKindClient
 	if isRoot(e.Topology, op) {
 		kind = trace.SpanKindServer
+	} else if isAsync {
+		kind = trace.SpanKindConsumer
 	}
 
 	rejAttrs := []attribute.KeyValue{
@@ -242,7 +247,7 @@ func (e *Engine) executePlanCall(call Call, parentIndex int, callStart time.Time
 	attemptStart := callStart
 
 	for attempt := range maxAttempts {
-		childEnd, childErr := e.planTrace(call.Operation, parentIndex, attemptStart, elapsed, overrides, scenarioNames, stats, plans, spanCount, spanLimit)
+		childEnd, childErr := e.planTrace(call.Operation, parentIndex, attemptStart, elapsed, overrides, scenarioNames, stats, plans, spanCount, spanLimit, call.Async)
 		perceivedEnd := childEnd
 		failed := childErr
 

--- a/pkg/synth/plan.go
+++ b/pkg/synth/plan.go
@@ -3,7 +3,6 @@
 package synth
 
 import (
-	"maps"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -53,10 +52,7 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 			errorRate = ov.ErrorRate
 		}
 		if len(ov.Attributes) > 0 {
-			merged := make(map[string]AttributeGenerator, len(op.Attributes)+len(ov.Attributes))
-			maps.Copy(merged, op.Attributes)
-			maps.Copy(merged, ov.Attributes)
-			opAttrs = merged
+			opAttrs = op.Attributes.Merge(ov.Attributes)
 		}
 	}
 
@@ -101,8 +97,8 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 	for k, v := range op.Service.Attributes {
 		spanAttrs = append(spanAttrs, attribute.String(k, v))
 	}
-	for k, gen := range opAttrs {
-		spanAttrs = append(spanAttrs, typedAttribute(k, gen.Generate(e.Rng)))
+	for _, a := range opAttrs {
+		spanAttrs = append(spanAttrs, typedAttribute(a.Key, a.Gen.Generate(e.Rng)))
 	}
 
 	ownError := e.Rng.Float64() < errorRate

--- a/pkg/synth/plan.go
+++ b/pkg/synth/plan.go
@@ -70,8 +70,10 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 			switch reason {
 			case ReasonQueueFull:
 				stats.QueueRejections++
+				notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventQueueRejection, Service: op.Service.Name, Operation: op.Name, Timestamp: startTime})
 			case ReasonCircuitOpen:
 				stats.CircuitBreakerTrips++
+				notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventCircuitBreakerTrip, Service: op.Service.Name, Operation: op.Name, Timestamp: startTime})
 			}
 			return e.planRejectionSpan(op, parentIndex, startTime, reason, scenarioNames, plans, spanCount)
 		}
@@ -252,6 +254,7 @@ func (e *Engine) executePlanCall(call Call, parentIndex int, callStart time.Time
 			perceivedEnd = attemptStart.Add(call.Timeout)
 			failed = true
 			stats.Timeouts++
+			notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventTimeout, Service: call.Operation.Service.Name, Operation: call.Operation.Name, Timestamp: perceivedEnd})
 		}
 
 		if !failed || attempt == maxAttempts-1 {
@@ -259,6 +262,7 @@ func (e *Engine) executePlanCall(call Call, parentIndex int, callStart time.Time
 		}
 
 		stats.Retries++
+		notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventRetry, Service: call.Operation.Service.Name, Operation: call.Operation.Name, Timestamp: perceivedEnd})
 		attemptStart = perceivedEnd.Add(call.RetryBackoff)
 	}
 

--- a/pkg/synth/plan_test.go
+++ b/pkg/synth/plan_test.go
@@ -45,7 +45,7 @@ func TestPlanTraceBasic(t *testing.T) {
 	spanCount := 0
 
 	engine.Rng = rand.New(rand.NewPCG(42, 0))
-	endTime, isError := engine.planTrace(rootOp, -1, now, 0, nil, nil, &stats, &plans, &spanCount, DefaultMaxSpansPerTrace)
+	endTime, isError := engine.planTrace(rootOp, -1, now, 0, nil, nil, &stats, &plans, &spanCount, DefaultMaxSpansPerTrace, false)
 
 	require.Len(t, plans, 2)
 
@@ -124,7 +124,7 @@ func TestPlanTraceMatchesWalkTrace(t *testing.T) {
 	planSpanCount := 0
 	planEnd, planErr := planEngine.planTrace(
 		planEngine.Topology.Roots[0], -1, now, 0, nil, nil,
-		&planStats, &plans, &planSpanCount, DefaultMaxSpansPerTrace,
+		&planStats, &plans, &planSpanCount, DefaultMaxSpansPerTrace, false,
 	)
 
 	// Run walkTrace with the same seed
@@ -202,7 +202,7 @@ func TestPlanTraceSpanLimit(t *testing.T) {
 	spanCount := 0
 
 	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil,
-		&stats, &plans, &spanCount, 2)
+		&stats, &plans, &spanCount, 2, false)
 
 	assert.Equal(t, 2, len(plans), "should stop at span limit")
 }
@@ -231,7 +231,7 @@ func TestPlanTraceRejection(t *testing.T) {
 	var stats1 Stats
 	var plans1 []SpanPlan
 	sc1 := 0
-	engine.planTrace(rootOp, -1, time.Now(), 0, nil, nil, &stats1, &plans1, &sc1, DefaultMaxSpansPerTrace)
+	engine.planTrace(rootOp, -1, time.Now(), 0, nil, nil, &stats1, &plans1, &sc1, DefaultMaxSpansPerTrace, false)
 
 	// Manually bump active requests to trigger queue full
 	opState := engine.State.Get(rootOp.Ref)
@@ -240,7 +240,7 @@ func TestPlanTraceRejection(t *testing.T) {
 	var stats2 Stats
 	var plans2 []SpanPlan
 	sc2 := 0
-	engine.planTrace(rootOp, -1, time.Now(), time.Second, nil, nil, &stats2, &plans2, &sc2, DefaultMaxSpansPerTrace)
+	engine.planTrace(rootOp, -1, time.Now(), time.Second, nil, nil, &stats2, &plans2, &sc2, DefaultMaxSpansPerTrace, false)
 
 	require.Len(t, plans2, 1)
 	assert.True(t, plans2[0].Rejected)
@@ -282,7 +282,7 @@ func TestPlanTraceSequentialCalls(t *testing.T) {
 	var plans []SpanPlan
 	psc := 0
 	planEngine.planTrace(planEngine.Topology.Roots[0], -1, now, 0, nil, nil,
-		&planStats, &plans, &psc, DefaultMaxSpansPerTrace)
+		&planStats, &plans, &psc, DefaultMaxSpansPerTrace, false)
 
 	// Walk path with same seed
 	walkEngine, exporter, tp := newTestEngine(t, cfg)
@@ -351,7 +351,7 @@ func TestPlanTraceRetries(t *testing.T) {
 	var plans []SpanPlan
 	psc := 0
 	planEngine.planTrace(planEngine.Topology.Roots[0], -1, now, 0, nil, nil,
-		&planStats, &plans, &psc, DefaultMaxSpansPerTrace)
+		&planStats, &plans, &psc, DefaultMaxSpansPerTrace, false)
 
 	// Walk
 	walkEngine, exporter, tp := newTestEngine(t, cfg)
@@ -365,4 +365,104 @@ func TestPlanTraceRetries(t *testing.T) {
 	spans := exporter.GetSpans()
 	require.Len(t, plans, len(spans), "should have same span count with retries")
 	assert.Equal(t, walkStats.Retries, planStats.Retries, "retry counts must match")
+}
+
+// twoTierStateConfig builds a gateway->backend topology where backend has a
+// queue depth of 1, so pre-filling its state forces a queue rejection.
+func twoTierQueueConfig() *Config {
+	return &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "gateway",
+				Operations: []OperationConfig{{
+					Name:     "request",
+					Duration: "10ms",
+					Calls:    []CallConfig{{Target: "backend.handle"}},
+				}},
+			},
+			{
+				Name: "backend",
+				Operations: []OperationConfig{{
+					Name:       "handle",
+					Duration:   "5ms",
+					QueueDepth: 1,
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "10/s"},
+	}
+}
+
+// TestRejectionSpanCountedOnce pins that a rejected operation consumes
+// exactly one slot of the per-trace span limit on both engine paths.
+// Previously the rejection helpers incremented spanCount a second time.
+func TestRejectionSpanCountedOnce(t *testing.T) {
+	t.Parallel()
+
+	t.Run("walk path", func(t *testing.T) {
+		t.Parallel()
+		engine, exporter, tp := newTestEngine(t, twoTierQueueConfig())
+		engine.State = NewSimulationState(engine.Topology)
+		engine.State.Get("backend.handle").Enter() // queue now full
+
+		spanCount := 0
+		engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, &spanCount, DefaultMaxSpansPerTrace, false)
+		require.NoError(t, tp.ForceFlush(context.Background()))
+
+		assert.Equal(t, 2, spanCount, "root span plus one rejected span")
+		assert.Len(t, exporter.GetSpans(), 2)
+	})
+
+	t.Run("plan path", func(t *testing.T) {
+		t.Parallel()
+		engine, _, _ := newTestEngine(t, twoTierQueueConfig())
+		engine.State = NewSimulationState(engine.Topology)
+		engine.State.Get("backend.handle").Enter()
+
+		spanCount := 0
+		var plans []SpanPlan
+		engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, &spanCount, DefaultMaxSpansPerTrace, false)
+
+		assert.Equal(t, 2, spanCount, "root span plus one rejected span")
+		assert.Len(t, plans, 2, "span count matches planned spans")
+	})
+}
+
+// TestPlanTraceAsyncConsumerKind pins that realtime planning marks async
+// callees as CONSUMER spans, mirroring walkTrace.
+func TestPlanTraceAsyncConsumerKind(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "api",
+				Operations: []OperationConfig{{
+					Name:     "submit",
+					Duration: "10ms",
+					Calls:    []CallConfig{{Target: "queue.publish", Async: true}},
+				}},
+			},
+			{
+				Name: "queue",
+				Operations: []OperationConfig{{
+					Name:     "publish",
+					Duration: "2ms",
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "10/s"},
+	}
+	engine, _, _ := newTestEngine(t, cfg)
+
+	var plans []SpanPlan
+	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false)
+
+	require.Len(t, plans, 2)
+	byOp := map[string]SpanPlan{}
+	for _, p := range plans {
+		byOp[p.Operation] = p
+	}
+	assert.Equal(t, trace.SpanKindServer, byOp["submit"].Kind)
+	assert.Equal(t, trace.SpanKindConsumer, byOp["publish"].Kind, "async callee is a CONSUMER span in realtime mode")
 }

--- a/pkg/synth/plan_test.go
+++ b/pkg/synth/plan_test.go
@@ -133,7 +133,7 @@ func TestPlanTraceMatchesWalkTrace(t *testing.T) {
 	var walkStats Stats
 	walkSpanCount := 0
 	walkEnd, walkErr := walkEngine.walkTrace(
-		context.Background(), walkEngine.Topology.Roots[0], now, 0, nil, nil,
+		context.Background(), walkEngine.Topology.Roots[0], nil, now, 0, nil, nil,
 		&walkStats, &walkSpanCount, DefaultMaxSpansPerTrace, false,
 	)
 	require.NoError(t, tp.ForceFlush(context.Background()))
@@ -289,7 +289,7 @@ func TestPlanTraceSequentialCalls(t *testing.T) {
 	walkEngine.Rng = rand.New(rand.NewPCG(seed[0], seed[1]))
 	var walkStats Stats
 	wsc := 0
-	walkEngine.walkTrace(context.Background(), walkEngine.Topology.Roots[0], now, 0, nil, nil,
+	walkEngine.walkTrace(context.Background(), walkEngine.Topology.Roots[0], nil, now, 0, nil, nil,
 		&walkStats, &wsc, DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
@@ -358,7 +358,7 @@ func TestPlanTraceRetries(t *testing.T) {
 	walkEngine.Rng = rand.New(rand.NewPCG(seed[0], seed[1]))
 	var walkStats Stats
 	wsc := 0
-	walkEngine.walkTrace(context.Background(), walkEngine.Topology.Roots[0], now, 0, nil, nil,
+	walkEngine.walkTrace(context.Background(), walkEngine.Topology.Roots[0], nil, now, 0, nil, nil,
 		&walkStats, &wsc, DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 

--- a/pkg/synth/property_test.go
+++ b/pkg/synth/property_test.go
@@ -591,7 +591,7 @@ func TestProperty_ResolveOverrides_DoesNotMutateInput(t *testing.T) {
 			scenarios[i] = Scenario{
 				Overrides: map[string]Override{
 					ref: {
-						Attributes: attrs,
+						Attributes: NewAttributes(attrs),
 						AddCalls:   []Call{{Operation: &Operation{Ref: fmt.Sprintf("target%d.op", i)}}},
 					},
 				},

--- a/pkg/synth/property_test.go
+++ b/pkg/synth/property_test.go
@@ -133,7 +133,7 @@ func walkOnce(t *rapid.T, cfg *Config) (*Topology, []tracetest.SpanStub, *Stats)
 	rootOp := topo.Roots[rng.IntN(len(topo.Roots))]
 	now := time.Now().Add(offset)
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 
 	if err := tp.ForceFlush(context.Background()); err != nil {
 		t.Fatalf("ForceFlush: %v", err)
@@ -722,7 +722,7 @@ func TestProperty_Engine_ScenarioOverrideApplied(t *testing.T) {
 		}
 
 		var stats Stats
-		engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 
 		if err := tp.ForceFlush(context.Background()); err != nil {
 			t.Fatalf("ForceFlush: %v", err)
@@ -779,7 +779,7 @@ func TestProperty_Engine_ScenarioErrorRateOverride(t *testing.T) {
 		}
 
 		var stats Stats
-		engine.walkTrace(context.Background(), topo.Roots[0], time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 
 		if err := tp.ForceFlush(context.Background()); err != nil {
 			t.Fatalf("ForceFlush: %v", err)

--- a/pkg/synth/scenario.go
+++ b/pkg/synth/scenario.go
@@ -26,7 +26,7 @@ type Override struct {
 	Duration     Distribution
 	ErrorRate    float64
 	HasErrorRate bool
-	Attributes   map[string]AttributeGenerator
+	Attributes   Attributes
 	AddCalls     []Call
 	RemoveCalls  map[string]bool
 	Metrics      map[string]FloatDistribution
@@ -79,14 +79,15 @@ func BuildScenarios(cfgs []ScenarioConfig, topo *Topology) ([]Scenario, error) {
 				o.HasErrorRate = true
 			}
 			if len(ov.Attributes) > 0 {
-				o.Attributes = make(map[string]AttributeGenerator, len(ov.Attributes))
+				gens := make(map[string]AttributeGenerator, len(ov.Attributes))
 				for attrName, attrCfg := range ov.Attributes {
 					gen, genErr := NewAttributeGenerator(attrCfg)
 					if genErr != nil {
 						return nil, fmt.Errorf("scenario %q override %q: attribute %q: %w", cfg.Name, ref, attrName, genErr)
 					}
-					o.Attributes[attrName] = gen
+					gens[attrName] = gen
 				}
+				o.Attributes = NewAttributes(gens)
 			}
 			for _, callCfg := range ov.AddCalls {
 				_, targetOp, resolveErr := resolveRef(topo, callCfg.Target)
@@ -289,10 +290,7 @@ func ResolveOverrides(active []Scenario) map[string]Override {
 				existing.HasErrorRate = true
 			}
 			if len(ov.Attributes) > 0 {
-				newAttrs := make(map[string]AttributeGenerator, len(existing.Attributes)+len(ov.Attributes))
-				maps.Copy(newAttrs, existing.Attributes)
-				maps.Copy(newAttrs, ov.Attributes)
-				existing.Attributes = newAttrs
+				existing.Attributes = existing.Attributes.Merge(ov.Attributes)
 			}
 			if len(ov.AddCalls) > 0 {
 				existing.AddCalls = append(slices.Clone(existing.AddCalls), ov.AddCalls...)

--- a/pkg/synth/scenario_test.go
+++ b/pkg/synth/scenario_test.go
@@ -276,7 +276,7 @@ func TestBuildScenariosWithAttributes(t *testing.T) {
 	require.Len(t, scenarios, 1)
 	require.Contains(t, scenarios[0].Overrides, "svc.op")
 	require.NotNil(t, scenarios[0].Overrides["svc.op"].Attributes)
-	assert.Contains(t, scenarios[0].Overrides["svc.op"].Attributes, "http.status")
+	assert.NotNil(t, scenarios[0].Overrides["svc.op"].Attributes.Get("http.status"))
 }
 
 func TestBuildScenariosInvalidAttribute(t *testing.T) {
@@ -311,20 +311,20 @@ func TestResolveOverridesMergesAttributes(t *testing.T) {
 		{
 			Overrides: map[string]Override{
 				"svc.op": {
-					Attributes: map[string]AttributeGenerator{
+					Attributes: NewAttributes(map[string]AttributeGenerator{
 						"keep":    gen1,
 						"replace": gen1,
-					},
+					}),
 				},
 			},
 		},
 		{
 			Overrides: map[string]Override{
 				"svc.op": {
-					Attributes: map[string]AttributeGenerator{
+					Attributes: NewAttributes(map[string]AttributeGenerator{
 						"replace": gen2,
 						"new":     gen3,
-					},
+					}),
 				},
 			},
 		},
@@ -334,9 +334,9 @@ func TestResolveOverridesMergesAttributes(t *testing.T) {
 	require.Contains(t, overrides, "svc.op")
 	attrs := overrides["svc.op"].Attributes
 	require.Len(t, attrs, 3)
-	assert.Equal(t, gen1, attrs["keep"], "untouched attribute preserved")
-	assert.Equal(t, gen2, attrs["replace"], "overridden attribute replaced")
-	assert.Equal(t, gen3, attrs["new"], "new attribute added")
+	assert.Equal(t, gen1, attrs.Get("keep"), "untouched attribute preserved")
+	assert.Equal(t, gen2, attrs.Get("replace"), "overridden attribute replaced")
+	assert.Equal(t, gen3, attrs.Get("new"), "new attribute added")
 }
 
 func TestResolveOverridesDoesNotMutateOriginal(t *testing.T) {
@@ -348,12 +348,12 @@ func TestResolveOverridesDoesNotMutateOriginal(t *testing.T) {
 	scenarios := []Scenario{
 		{
 			Overrides: map[string]Override{
-				"svc.op": {Attributes: map[string]AttributeGenerator{"a": original}},
+				"svc.op": {Attributes: NewAttributes(map[string]AttributeGenerator{"a": original})},
 			},
 		},
 		{
 			Overrides: map[string]Override{
-				"svc.op": {Attributes: map[string]AttributeGenerator{"b": override}},
+				"svc.op": {Attributes: NewAttributes(map[string]AttributeGenerator{"b": override})},
 			},
 		},
 	}
@@ -374,7 +374,7 @@ func TestResolveOverridesNoAttributesIsNoop(t *testing.T) {
 	scenarios := []Scenario{
 		{
 			Overrides: map[string]Override{
-				"svc.op": {Attributes: map[string]AttributeGenerator{"a": gen}},
+				"svc.op": {Attributes: NewAttributes(map[string]AttributeGenerator{"a": gen})},
 			},
 		},
 		{
@@ -387,7 +387,7 @@ func TestResolveOverridesNoAttributesIsNoop(t *testing.T) {
 	overrides := ResolveOverrides(scenarios)
 	attrs := overrides["svc.op"].Attributes
 	require.Len(t, attrs, 1)
-	assert.Equal(t, gen, attrs["a"], "earlier attributes preserved when later has none")
+	assert.Equal(t, gen, attrs.Get("a"), "earlier attributes preserved when later has none")
 }
 
 func TestResolveOverrides(t *testing.T) {

--- a/pkg/synth/state_test.go
+++ b/pkg/synth/state_test.go
@@ -297,7 +297,7 @@ func TestEngineQueueDepthRejection(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -351,14 +351,14 @@ func TestEngineCircuitBreakerIntegration(t *testing.T) {
 	require.NotNil(t, opState)
 
 	for range opState.FailureThreshold {
-		engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	}
 
 	assert.Equal(t, CircuitOpen, opState.Circuit, "circuit should be open after threshold failures")
 
 	// Third call should be rejected (circuit is open)
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, time.Now(), time.Second, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), time.Second, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	assert.Equal(t, int64(1), stats.CircuitBreakerTrips)
@@ -400,7 +400,7 @@ func TestEngineBackpressureIntegration(t *testing.T) {
 	rootOp := engine.Topology.Roots[0]
 
 	// First call: 10ms duration > 5ms threshold → backpressure activates
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans1 := exporter.GetSpans()
@@ -409,7 +409,7 @@ func TestEngineBackpressureIntegration(t *testing.T) {
 
 	// Second call: backpressure should be active, amplifying duration
 	exporter.Reset()
-	engine.walkTrace(context.Background(), rootOp, time.Now(), time.Second, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), time.Second, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans2 := exporter.GetSpans()
@@ -440,7 +440,7 @@ func TestEngineStateNotCreatedWithoutConfig(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -27,7 +27,7 @@ type MetricDefinition struct {
 	Min        *float64      // optional lower bound for gauge values
 	Max        *float64      // optional upper bound for gauge values
 	ErrorsOnly bool
-	Attributes map[string]AttributeGenerator
+	Attributes Attributes
 }
 
 // LogDefinition is a resolved log record template.
@@ -38,7 +38,7 @@ type LogDefinition struct {
 	Probability float64
 	AtEnd       bool
 	Delay       time.Duration
-	Attributes  map[string]AttributeGenerator
+	Attributes  Attributes
 }
 
 // Service represents a resolved service node in the topology graph.
@@ -69,7 +69,7 @@ type ResolvedCircuitBreaker struct {
 type Event struct {
 	Name       string
 	Delay      time.Duration
-	Attributes map[string]AttributeGenerator
+	Attributes Attributes
 }
 
 // Operation represents a resolved operation with pointers to downstream calls.
@@ -81,7 +81,7 @@ type Operation struct {
 	ErrorRate      float64
 	Calls          []Call
 	CallStyle      string
-	Attributes     map[string]AttributeGenerator
+	Attributes     Attributes
 	Events         []Event
 	Links          []*Operation
 	Metrics        []MetricDefinition
@@ -185,7 +185,7 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 				Duration:   dist,
 				ErrorRate:  errorRate,
 				CallStyle:  opCfg.CallStyle,
-				Attributes: attrs,
+				Attributes: NewAttributes(attrs),
 				QueueDepth: opCfg.QueueDepth,
 			}
 			if len(opCfg.Metrics) > 0 {
@@ -235,14 +235,15 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 						}
 					}
 					if len(evtCfg.Attributes) > 0 {
-						evt.Attributes = make(map[string]AttributeGenerator, len(evtCfg.Attributes))
+						gens := make(map[string]AttributeGenerator, len(evtCfg.Attributes))
 						for name, acfg := range evtCfg.Attributes {
 							gen, err := NewAttributeGenerator(acfg)
 							if err != nil {
 								return nil, fmt.Errorf("service %q operation %q event %q attribute %q: %w", svcCfg.Name, opCfg.Name, evtCfg.Name, name, err)
 							}
-							evt.Attributes[name] = gen
+							gens[name] = gen
 						}
+						evt.Attributes = NewAttributes(gens)
 					}
 					op.Events[i] = evt
 				}
@@ -358,7 +359,7 @@ func resolveMetrics(configs []MetricConfig, svcName, opName string) ([]MetricDef
 			return nil, fmt.Errorf("%s: metric %q: gauge requires a value", ctx, mc.Name)
 		}
 		if len(mc.Attributes) > 0 {
-			def.Attributes = make(map[string]AttributeGenerator, len(mc.Attributes))
+			gens := make(map[string]AttributeGenerator, len(mc.Attributes))
 			for name, acfg := range mc.Attributes {
 				gen, err := NewAttributeGenerator(acfg)
 				if err != nil {
@@ -368,8 +369,9 @@ func resolveMetrics(configs []MetricConfig, svcName, opName string) ([]MetricDef
 					}
 					return nil, fmt.Errorf("%s: metric %q attribute %q: %w", ctx, mc.Name, name, err)
 				}
-				def.Attributes[name] = gen
+				gens[name] = gen
 			}
+			def.Attributes = NewAttributes(gens)
 		}
 		defs[i] = def
 	}
@@ -403,14 +405,15 @@ func resolveLogs(configs []LogConfig, errCtx string) ([]LogDefinition, error) {
 			def.Delay = d
 		}
 		if len(lc.Attributes) > 0 {
-			def.Attributes = make(map[string]AttributeGenerator, len(lc.Attributes))
+			gens := make(map[string]AttributeGenerator, len(lc.Attributes))
 			for name, acfg := range lc.Attributes {
 				gen, err := NewAttributeGenerator(acfg)
 				if err != nil {
 					return nil, fmt.Errorf("%s: log[%d] attribute %q: %w", errCtx, i, name, err)
 				}
-				def.Attributes[name] = gen
+				gens[name] = gen
 			}
+			def.Attributes = NewAttributes(gens)
 		}
 		defs[i] = def
 	}

--- a/pkg/synth/topology_test.go
+++ b/pkg/synth/topology_test.go
@@ -181,9 +181,9 @@ func TestBuildTopology(t *testing.T) {
 		require.NoError(t, err)
 		op := topo.Services["svc"].Operations["op"]
 		require.Len(t, op.Attributes, 3)
-		assert.IsType(t, &StaticValue{}, op.Attributes["http.route"])
-		assert.IsType(t, &WeightedChoice{}, op.Attributes["status"])
-		assert.IsType(t, &SequenceValue{}, op.Attributes["req.id"])
+		assert.IsType(t, &StaticValue{}, op.Attributes.Get("http.route"))
+		assert.IsType(t, &WeightedChoice{}, op.Attributes.Get("status"))
+		assert.IsType(t, &SequenceValue{}, op.Attributes.Get("req.id"))
 	})
 
 	t.Run("resolves call_style", func(t *testing.T) {
@@ -253,8 +253,8 @@ func TestBuildTopology(t *testing.T) {
 		require.NoError(t, err)
 		op := topo.Services["svc"].Operations["op"]
 		require.Len(t, op.Attributes, 2)
-		assert.Equal(t, "GET", op.Attributes["http.method"].Generate(nil))
-		assert.Equal(t, "/default", op.Attributes["http.route"].Generate(nil))
+		assert.Equal(t, "GET", op.Attributes.Get("http.method").Generate(nil))
+		assert.Equal(t, "/default", op.Attributes.Get("http.route").Generate(nil))
 	})
 
 	t.Run("user attributes override domain defaults", func(t *testing.T) {
@@ -282,7 +282,7 @@ func TestBuildTopology(t *testing.T) {
 		topo, err := BuildTopology(cfg, resolver)
 		require.NoError(t, err)
 		op := topo.Services["svc"].Operations["op"]
-		assert.Equal(t, "/api/v1/users", op.Attributes["http.route"].Generate(nil))
+		assert.Equal(t, "/api/v1/users", op.Attributes.Get("http.route").Generate(nil))
 	})
 
 	t.Run("domain with no resolver returns error", func(t *testing.T) {
@@ -353,8 +353,8 @@ func TestBuildTopology(t *testing.T) {
 		require.NoError(t, err)
 		op := topo.Services["svc"].Operations["op"]
 		require.Len(t, op.Attributes, 2)
-		assert.Equal(t, "GET", op.Attributes["http.method"].Generate(nil))
-		assert.Equal(t, "/api/v1/users", op.Attributes["http.route"].Generate(nil))
+		assert.Equal(t, "GET", op.Attributes.Get("http.method").Generate(nil))
+		assert.Equal(t, "/api/v1/users", op.Attributes.Get("http.route").Generate(nil))
 	})
 
 	t.Run("no domain ignores resolver", func(t *testing.T) {
@@ -530,7 +530,7 @@ func TestBuildTopologyLogs(t *testing.T) {
 		assert.InDelta(t, 0.25, opLogs[0].Probability, 1e-9)
 		assert.True(t, opLogs[0].AtEnd)
 		assert.Equal(t, 5*time.Millisecond, opLogs[0].Delay)
-		require.Contains(t, opLogs[0].Attributes, "error.type")
+		require.NotNil(t, opLogs[0].Attributes.Get("error.type"))
 	})
 
 	t.Run("rejects invalid delay", func(t *testing.T) {


### PR DESCRIPTION
Extracts the engine-level improvements from the visualisation spike (PR 165) into a standalone, mergeable change. No visualisation code is included; these three commits are useful to any observer or seeded workflow independent of how the graph work proceeds.

## Changes

**Span parentage and plan-phase events for observers.** `SpanInfo` gains `ParentService`/`ParentOperation`, threaded through both the walk path and the realtime plan/emit path (derived from the existing `SpanPlan.ParentIndex`), so observers can attribute spans to their calling operation. A new `PlanEventObserver` interface surfaces timeouts, retries, queue rejections, and circuit breaker trips as timestamped events — simulation ground truth that was previously only visible as aggregate counters in `Stats`.

**Deterministic attribute iteration.** Resolved topology and override attributes change from `map[string]AttributeGenerator` to `Attributes`, a key-sorted pair slice built once at topology construction. Map iteration order previously randomised RNG consumption during attribute generation: with a normal-distribution generator (variable draw count via ziggurat sampling) alongside other consuming generators, seeded runs could diverge structurally, and generated attribute values were never reproducible. This is a correctness fix for any seeded use, including `motel check`. The log observer's hand-rolled sorted-key workaround is removed — the type now guarantees what that code enforced locally. Pinned by a determinism test verified to fail under map iteration.

**`motel run --seed`.** A non-zero seed makes engine, metric, and log observer RNGs deterministic, each on a fixed PCG stream of the same seed so enabling one signal does not perturb the others. A seeded topology plus motel version reproduces a run's decision sequence after the fact. Determinism is best-effort: not guaranteed across motel versions, and wall-clock pacing in `--realtime` mode remains nondeterministic.

## Verification

`make test` and `make lint` pass. New tests cover parent attribution on both engine paths, plan-event observation, `Attributes` ordering/merge/lookup semantics, per-stream RNG separation, and full structural-plus-value determinism of seeded runs.

https://claude.ai/code/session_01P53wZUbnoSxTDMftXxrFLi

---
_Generated by [Claude Code](https://claude.ai/code/session_01P53wZUbnoSxTDMftXxrFLi)_