### PR TITLE
feat(traceimport): add Jaeger JSON import for Grafana Explore Tempo downloads

### DIFF
--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -422,7 +422,7 @@ func importCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&format, "format", "auto", "input format: auto, stdouttrace, otlp, or jaeger (Jaeger JSON, also used by Grafana Tempo exports)")
+	cmd.Flags().StringVar(&format, "format", "auto", "input format: auto, stdouttrace, otlp, or jaeger (Jaeger JSON, including Grafana Explore Tempo downloads)")
 	cmd.Flags().IntVar(&minTraces, "min-traces", 1, "minimum traces for statistical accuracy (warns if fewer)")
 
 	return cmd

--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -392,7 +392,7 @@ func importCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import [file]",
 		Short: "Import a topology config from trace data",
-		Long:  "Reads trace spans (stdouttrace or OTLP JSON) and generates a synth YAML topology config.",
+		Long:  "Reads trace spans (stdouttrace, OTLP JSON, or Grafana Tempo/Jaeger JSON) and generates a synth YAML topology config.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var r io.Reader = os.Stdin
@@ -422,7 +422,7 @@ func importCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&format, "format", "auto", "input format: auto, stdouttrace, or otlp")
+	cmd.Flags().StringVar(&format, "format", "auto", "input format: auto, stdouttrace, otlp, or tempo")
 	cmd.Flags().IntVar(&minTraces, "min-traces", 1, "minimum traces for statistical accuracy (warns if fewer)")
 
 	return cmd

--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -392,7 +392,7 @@ func importCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import [file]",
 		Short: "Import a topology config from trace data",
-		Long:  "Reads trace spans (stdouttrace, OTLP JSON, or Grafana Tempo/Jaeger JSON) and generates a synth YAML topology config.",
+		Long:  "Reads trace spans (stdouttrace, OTLP JSON, or Jaeger JSON) and generates a synth YAML topology config.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var r io.Reader = os.Stdin
@@ -422,7 +422,7 @@ func importCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&format, "format", "auto", "input format: auto, stdouttrace, otlp, or tempo")
+	cmd.Flags().StringVar(&format, "format", "auto", "input format: auto, stdouttrace, otlp, or jaeger (Jaeger JSON, also used by Grafana Tempo exports)")
 	cmd.Flags().IntVar(&minTraces, "min-traces", 1, "minimum traces for statistical accuracy (warns if fewer)")
 
 	return cmd

--- a/docs/demos/demo-import.md
+++ b/docs/demos/demo-import.md
@@ -10,7 +10,7 @@ For a detailed walkthrough of how each pipeline stage processes real trace data,
 
 The import pipeline analyses trace data in stages:
 
-1. **Parse spans** -- reads stdouttrace (line-delimited JSON) or OTLP protobuf JSON, normalising both into a common span representation
+1. **Parse spans** -- reads stdouttrace (line-delimited JSON), OTLP protobuf JSON, or Jaeger JSON, normalising them into a common span representation
 2. **Build trace trees** -- links parent and child spans by span ID, reconstructing the call graph per trace
 3. **Collect statistics** -- for each (service, operation) pair: duration mean and standard deviation, error rate, and which downstream operations are called
 4. **Infer call style** -- when an operation has multiple children, votes parallel (children start within 1ms of each other) or sequential (each child starts after the previous ends)
@@ -87,7 +87,7 @@ Configuration valid: 5 services, 2 root operations
 
 ## Explicit format selection
 
-By default, `import` auto-detects the input format by inspecting the JSON structure. You can also specify `--format stdouttrace` or `--format otlp` to skip detection.
+By default, `import` auto-detects the input format by inspecting the JSON structure. You can also specify `--format stdouttrace`, `--format otlp`, or `--format jaeger` to skip detection.
 
 ```bash
 motel run --stdout --duration 500ms docs/examples/basic-topology.yaml 2>/dev/null | motel import --format stdouttrace 2>/dev/null | grep -c "^version:"

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -147,10 +147,10 @@ Reads trace spans and generates a YAML topology. If no file is given, reads from
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--format` | string | `auto` | Input format: `auto`, `stdouttrace`, or `otlp` |
+| `--format` | string | `auto` | Input format: `auto`, `stdouttrace`, `otlp`, or `jaeger` |
 | `--min-traces` | int | 1 | Minimum traces for statistical accuracy (warns if fewer) |
 
-The `auto` format detector examines the first line to determine whether the input is stdouttrace JSON (one span per line) or OTLP JSON (batched export format).
+The `auto` format detector examines the JSON structure to determine whether the input is stdouttrace JSON (one span per line), OTLP JSON (batched export format), or Jaeger JSON such as Grafana Explore Tempo downloads.
 
 Output is written to stdout as a YAML topology with a commented header noting how many traces and spans were analysed.
 

--- a/pkg/synth/metricoffset_test.go
+++ b/pkg/synth/metricoffset_test.go
@@ -4,6 +4,7 @@ package synth
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 
 // captureMetricExporter records the last exported ResourceMetrics.
 type captureMetricExporter struct {
+	mu       sync.Mutex
 	exported *metricdata.ResourceMetrics
 }
 
@@ -27,6 +29,8 @@ func (e *captureMetricExporter) Aggregation(k sdkmetric.InstrumentKind) sdkmetri
 }
 
 func (e *captureMetricExporter) Export(_ context.Context, rm *metricdata.ResourceMetrics) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.exported = rm
 	return nil
 }
@@ -34,6 +38,12 @@ func (e *captureMetricExporter) Export(_ context.Context, rm *metricdata.Resourc
 func (e *captureMetricExporter) ForceFlush(context.Context) error { return nil }
 
 func (e *captureMetricExporter) Shutdown(context.Context) error { return nil }
+
+func (e *captureMetricExporter) LastExported() *metricdata.ResourceMetrics {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.exported
+}
 
 func TestNewTimeOffsetMetricExporterZeroOffset(t *testing.T) {
 	t.Parallel()
@@ -100,13 +110,14 @@ func TestTimeOffsetMetricExporterShiftsAllDataPointTypes(t *testing.T) {
 	capture := &captureMetricExporter{}
 	exporter := NewTimeOffsetMetricExporter(capture, offset)
 	require.NoError(t, exporter.Export(context.Background(), rm))
-	require.NotNil(t, capture.exported)
+	exported := capture.LastExported()
+	require.NotNil(t, exported)
 
 	wantStart := start.Add(offset)
 	wantEnd := end.Add(offset)
 	wantExemplar := exemplarTime.Add(offset)
 
-	for _, m := range capture.exported.ScopeMetrics[0].Metrics {
+	for _, m := range exported.ScopeMetrics[0].Metrics {
 		switch data := m.Data.(type) {
 		case metricdata.Gauge[int64]:
 			assert.Equal(t, wantStart, data.DataPoints[0].StartTime, m.Name)
@@ -149,7 +160,7 @@ func TestTimeOffsetMetricExporterEndToEnd(t *testing.T) {
 
 	offset := -24 * time.Hour
 	capture := &captureMetricExporter{}
-	reader := sdkmetric.NewPeriodicReader(NewTimeOffsetMetricExporter(capture, offset))
+	reader := sdkmetric.NewPeriodicReader(NewTimeOffsetMetricExporter(capture, offset), sdkmetric.WithInterval(10*time.Millisecond))
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	defer func() { require.NoError(t, mp.Shutdown(context.Background())) }()
 
@@ -158,13 +169,21 @@ func TestTimeOffsetMetricExporterEndToEnd(t *testing.T) {
 
 	before := time.Now()
 	counter.Add(context.Background(), 1)
-	require.NoError(t, reader.ForceFlush(context.Background()))
+
+	var matched metricdata.Metrics
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rm := capture.LastExported()
+		if !assert.NotNil(c, rm) {
+			return
+		}
+		m := findMetric(*rm, "requests.count")
+		if assert.NotNil(c, m) {
+			matched = *m
+		}
+	}, time.Second, 10*time.Millisecond)
 	after := time.Now()
 
-	require.NotNil(t, capture.exported)
-	m := findMetric(*capture.exported, "requests.count")
-	require.NotNil(t, m)
-	sum, ok := m.Data.(metricdata.Sum[int64])
+	sum, ok := matched.Data.(metricdata.Sum[int64])
 	require.True(t, ok)
 	require.Len(t, sum.DataPoints, 1)
 

--- a/pkg/synth/traceimport/fuzz_test.go
+++ b/pkg/synth/traceimport/fuzz_test.go
@@ -28,7 +28,7 @@ func FuzzParseSpans(f *testing.F) {
 		// Test explicit formats
 		_, _ = ParseSpans(bytes.NewReader(data), FormatStdouttrace)
 		_, _ = ParseSpans(bytes.NewReader(data), FormatOTLP)
-		_, _ = ParseSpans(bytes.NewReader(data), FormatTempo)
+		_, _ = ParseSpans(bytes.NewReader(data), FormatJaeger)
 	})
 }
 

--- a/pkg/synth/traceimport/fuzz_test.go
+++ b/pkg/synth/traceimport/fuzz_test.go
@@ -18,6 +18,7 @@ func FuzzParseSpans(f *testing.F) {
 	// Seed with valid inputs for each format
 	f.Add([]byte(`{"Name":"op","SpanContext":{"TraceID":"aaa","SpanID":"bbb"},"Parent":{"TraceID":"aaa","SpanID":"0000000000000000"},"StartTime":"2024-01-01T00:00:00Z","EndTime":"2024-01-01T00:00:01Z","Attributes":[],"Status":{"Code":"Unset"},"InstrumentationScope":{"Name":"svc"}}`))
 	f.Add([]byte(`{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"api"}}]},"scopeSpans":[{"scope":{"name":"api"},"spans":[{"traceId":"AQIDBAUGBwgJCgsMDQ4PEA==","spanId":"AQIDBAUGBwg=","name":"op","startTimeUnixNano":"1700000000000000000","endTimeUnixNano":"1700000000030000000","status":{},"attributes":[{"key":"http.method","value":{"stringValue":"GET"}},{"key":"count","value":{"intValue":"42"}},{"key":"ok","value":{"boolValue":true}}]}]}]}]}`))
+	f.Add([]byte(`{"data":[{"traceID":"abc","spans":[{"traceID":"abc","spanID":"def","operationName":"op","references":[],"startTime":1700000000000000,"duration":30000,"tags":[{"key":"http.method","value":"GET"}],"processID":"p1","process":{"serviceName":"api"}}],"processes":{"p1":{"serviceName":"api"}}}]}`))
 	f.Add([]byte(`not json at all`))
 	f.Add([]byte(`{"something":"else"}`))
 	f.Add([]byte{})
@@ -27,6 +28,7 @@ func FuzzParseSpans(f *testing.F) {
 		// Test explicit formats
 		_, _ = ParseSpans(bytes.NewReader(data), FormatStdouttrace)
 		_, _ = ParseSpans(bytes.NewReader(data), FormatOTLP)
+		_, _ = ParseSpans(bytes.NewReader(data), FormatTempo)
 	})
 }
 

--- a/pkg/synth/traceimport/span.go
+++ b/pkg/synth/traceimport/span.go
@@ -38,7 +38,7 @@ const (
 	FormatAuto        Format = "auto"        // Detects the format from the input.
 	FormatStdouttrace Format = "stdouttrace" // Line-delimited JSON from the OTel stdout exporter.
 	FormatOTLP        Format = "otlp"        // OTLP protobuf JSON.
-	FormatTempo       Format = "tempo"       // Grafana Tempo / Jaeger JSON export format.
+	FormatJaeger      Format = "jaeger"      // Jaeger JSON export format (also used by Grafana Tempo).
 )
 
 // maxInputSize is the maximum input size to prevent OOM on large trace exports.
@@ -72,10 +72,10 @@ func ParseSpans(r io.Reader, format Format) ([]Span, error) {
 		return parseStdouttrace(data)
 	case FormatOTLP:
 		return parseOTLP(data)
-	case FormatTempo:
-		return parseTempo(data)
+	case FormatJaeger:
+		return parseJaeger(data)
 	default:
-		return nil, fmt.Errorf("unknown format %q, valid formats: auto, stdouttrace, otlp, tempo", format)
+		return nil, fmt.Errorf("unknown format %q, valid formats: auto, stdouttrace, otlp, jaeger", format)
 	}
 }
 
@@ -94,12 +94,12 @@ func detectFormat(data []byte) (Format, error) {
 		if _, ok := probe["resourceSpans"]; ok {
 			return FormatOTLP, nil
 		}
-		if isTempoData(probe["data"]) {
-			return FormatTempo, nil
+		if isJaegerData(probe["data"]) {
+			return FormatJaeger, nil
 		}
 	}
 
-	// First line wasn't a complete JSON object (e.g. pretty-printed OTLP or Tempo).
+	// First line wasn't a complete JSON object (e.g. pretty-printed OTLP or Jaeger).
 	// Try the full input as a single JSON document.
 	if hasMore {
 		if err := json.Unmarshal(data, &probe); err == nil {
@@ -109,13 +109,13 @@ func detectFormat(data []byte) (Format, error) {
 			if _, ok := probe["SpanContext"]; ok {
 				return FormatStdouttrace, nil
 			}
-			if isTempoData(probe["data"]) {
-				return FormatTempo, nil
+			if isJaegerData(probe["data"]) {
+				return FormatJaeger, nil
 			}
 		}
 	}
 
-	return "", fmt.Errorf("cannot detect format: input has neither SpanContext (stdouttrace), resourceSpans (OTLP), nor data[].spans[].operationName (Tempo)")
+	return "", fmt.Errorf("cannot detect format: input has neither SpanContext (stdouttrace), resourceSpans (OTLP), nor data[].spans[].operationName (Jaeger/Tempo)")
 }
 
 // stdouttraceEvent mirrors the Go SDK's stdouttrace JSON output.
@@ -333,10 +333,10 @@ func isZeroID(id string) bool {
 	return len(id) > 0
 }
 
-// isTempoData returns true when raw is a JSON array whose first element contains
+// isJaegerData returns true when raw is a JSON array whose first element contains
 // both "spans" and within it "operationName" — the distinguishing marks of a
-// Grafana Tempo / Jaeger JSON export.
-func isTempoData(raw json.RawMessage) bool {
+// Jaeger JSON export (also produced by Grafana Tempo's UI download).
+func isJaegerData(raw json.RawMessage) bool {
 	if len(raw) == 0 {
 		return false
 	}
@@ -354,7 +354,7 @@ func isTempoData(raw json.RawMessage) bool {
 	return traces[0].Spans[0].OperationName != nil
 }
 
-// jaegerExport is the top-level structure of a Grafana Tempo / Jaeger JSON export.
+// jaegerExport is the top-level structure of a Jaeger JSON export.
 type jaegerExport struct {
 	Data []jaegerTrace `json:"data"`
 }
@@ -390,16 +390,16 @@ type jaegerTag struct {
 	Value json.RawMessage `json:"value"`
 }
 
-func parseTempo(data []byte) ([]Span, error) {
+func parseJaeger(data []byte) ([]Span, error) {
 	var export jaegerExport
 	if err := json.Unmarshal(data, &export); err != nil {
-		return nil, fmt.Errorf("parsing Tempo/Jaeger JSON: %w", err)
+		return nil, fmt.Errorf("parsing Jaeger JSON: %w", err)
 	}
 
 	var spans []Span
 	for _, trace := range export.Data {
 		for _, js := range trace.Spans {
-			service := tempoService(js, trace.Processes)
+			service := jaegerService(js, trace.Processes)
 
 			parentID := ""
 			for _, ref := range js.References {
@@ -415,7 +415,7 @@ func parseTempo(data []byte) ([]Span, error) {
 			attrs := make(map[string]string)
 			isError := false
 			for _, tag := range js.Tags {
-				val := tempoTagString(tag.Value)
+				val := jaegerTagString(tag.Value)
 				if tag.Key == "error" && val == "true" {
 					isError = true
 				}
@@ -442,9 +442,9 @@ func parseTempo(data []byte) ([]Span, error) {
 	return spans, nil
 }
 
-// tempoService resolves the service name for a span: prefers the embedded
-// process field, falls back to the trace-level processes map.
-func tempoService(js jaegerSpan, processes map[string]*jaegerProcess) string {
+// jaegerService resolves the service name: prefers the span's inline process
+// field, falls back to the trace-level processes map.
+func jaegerService(js jaegerSpan, processes map[string]*jaegerProcess) string {
 	if js.Process != nil && js.Process.ServiceName != "" {
 		return js.Process.ServiceName
 	}
@@ -456,10 +456,10 @@ func tempoService(js jaegerSpan, processes map[string]*jaegerProcess) string {
 	return ""
 }
 
-// tempoTagString converts a raw Jaeger tag value to a string.
+// jaegerTagString converts a raw Jaeger tag JSON value to a string.
 // Strings are unquoted; other JSON scalars (numbers, booleans) use their
 // literal representation so callers can match against "true"/"false"/etc.
-func tempoTagString(raw json.RawMessage) string {
+func jaegerTagString(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return ""
 	}

--- a/pkg/synth/traceimport/span.go
+++ b/pkg/synth/traceimport/span.go
@@ -1,5 +1,5 @@
 // Normalised span type and format-specific parsers for trace inference
-// Handles both stdouttrace (line-delimited JSON) and OTLP protobuf JSON formats
+// Handles stdouttrace, OTLP protobuf JSON, and Jaeger JSON formats
 package traceimport
 
 import (
@@ -81,7 +81,7 @@ func ParseSpans(r io.Reader, format Format) ([]Span, error) {
 
 // detectFormat examines the input to determine the format.
 // Tries the first line (for line-delimited stdouttrace), then the full data
-// (for pretty-printed OTLP JSON).
+// (for pretty-printed OTLP or Jaeger JSON).
 func detectFormat(data []byte) (Format, error) {
 	firstLine, _, hasMore := bytes.Cut(data, []byte{'\n'})
 	firstLine = bytes.TrimSpace(firstLine)
@@ -335,7 +335,7 @@ func isZeroID(id string) bool {
 
 // isJaegerData returns true when raw is a JSON array whose first element contains
 // both "spans" and within it "operationName" — the distinguishing marks of a
-// Jaeger JSON export (also produced by Grafana Tempo's UI download).
+// Jaeger JSON export (also produced by Grafana Explore Tempo downloads).
 func isJaegerData(raw json.RawMessage) bool {
 	if len(raw) == 0 {
 		return false
@@ -360,8 +360,8 @@ type jaegerExport struct {
 }
 
 type jaegerTrace struct {
-	Spans     []jaegerSpan               `json:"spans"`
-	Processes map[string]*jaegerProcess  `json:"processes"`
+	Spans     []jaegerSpan              `json:"spans"`
+	Processes map[string]*jaegerProcess `json:"processes"`
 }
 
 type jaegerSpan struct {

--- a/pkg/synth/traceimport/span.go
+++ b/pkg/synth/traceimport/span.go
@@ -38,6 +38,7 @@ const (
 	FormatAuto        Format = "auto"        // Detects the format from the input.
 	FormatStdouttrace Format = "stdouttrace" // Line-delimited JSON from the OTel stdout exporter.
 	FormatOTLP        Format = "otlp"        // OTLP protobuf JSON.
+	FormatTempo       Format = "tempo"       // Grafana Tempo / Jaeger JSON export format.
 )
 
 // maxInputSize is the maximum input size to prevent OOM on large trace exports.
@@ -71,8 +72,10 @@ func ParseSpans(r io.Reader, format Format) ([]Span, error) {
 		return parseStdouttrace(data)
 	case FormatOTLP:
 		return parseOTLP(data)
+	case FormatTempo:
+		return parseTempo(data)
 	default:
-		return nil, fmt.Errorf("unknown format %q, valid formats: auto, stdouttrace, otlp", format)
+		return nil, fmt.Errorf("unknown format %q, valid formats: auto, stdouttrace, otlp, tempo", format)
 	}
 }
 
@@ -91,9 +94,12 @@ func detectFormat(data []byte) (Format, error) {
 		if _, ok := probe["resourceSpans"]; ok {
 			return FormatOTLP, nil
 		}
+		if isTempoData(probe["data"]) {
+			return FormatTempo, nil
+		}
 	}
 
-	// First line wasn't a complete JSON object (e.g. pretty-printed OTLP).
+	// First line wasn't a complete JSON object (e.g. pretty-printed OTLP or Tempo).
 	// Try the full input as a single JSON document.
 	if hasMore {
 		if err := json.Unmarshal(data, &probe); err == nil {
@@ -103,10 +109,13 @@ func detectFormat(data []byte) (Format, error) {
 			if _, ok := probe["SpanContext"]; ok {
 				return FormatStdouttrace, nil
 			}
+			if isTempoData(probe["data"]) {
+				return FormatTempo, nil
+			}
 		}
 	}
 
-	return "", fmt.Errorf("cannot detect format: input has neither SpanContext (stdouttrace) nor resourceSpans (OTLP)")
+	return "", fmt.Errorf("cannot detect format: input has neither SpanContext (stdouttrace), resourceSpans (OTLP), nor data[].spans[].operationName (Tempo)")
 }
 
 // stdouttraceEvent mirrors the Go SDK's stdouttrace JSON output.
@@ -322,6 +331,143 @@ func isZeroID(id string) bool {
 		}
 	}
 	return len(id) > 0
+}
+
+// isTempoData returns true when raw is a JSON array whose first element contains
+// both "spans" and within it "operationName" — the distinguishing marks of a
+// Grafana Tempo / Jaeger JSON export.
+func isTempoData(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var traces []struct {
+		Spans []struct {
+			OperationName *json.RawMessage `json:"operationName"`
+		} `json:"spans"`
+	}
+	if err := json.Unmarshal(raw, &traces); err != nil || len(traces) == 0 {
+		return false
+	}
+	if len(traces[0].Spans) == 0 {
+		return false
+	}
+	return traces[0].Spans[0].OperationName != nil
+}
+
+// jaegerExport is the top-level structure of a Grafana Tempo / Jaeger JSON export.
+type jaegerExport struct {
+	Data []jaegerTrace `json:"data"`
+}
+
+type jaegerTrace struct {
+	Spans     []jaegerSpan               `json:"spans"`
+	Processes map[string]*jaegerProcess  `json:"processes"`
+}
+
+type jaegerSpan struct {
+	TraceID       string         `json:"traceID"`
+	SpanID        string         `json:"spanID"`
+	OperationName string         `json:"operationName"`
+	References    []jaegerRef    `json:"references"`
+	StartTime     int64          `json:"startTime"` // microseconds since epoch
+	Duration      int64          `json:"duration"`  // microseconds
+	Tags          []jaegerTag    `json:"tags"`
+	ProcessID     string         `json:"processID"`
+	Process       *jaegerProcess `json:"process"`
+}
+
+type jaegerRef struct {
+	RefType string `json:"refType"`
+	SpanID  string `json:"spanID"`
+}
+
+type jaegerProcess struct {
+	ServiceName string `json:"serviceName"`
+}
+
+type jaegerTag struct {
+	Key   string          `json:"key"`
+	Value json.RawMessage `json:"value"`
+}
+
+func parseTempo(data []byte) ([]Span, error) {
+	var export jaegerExport
+	if err := json.Unmarshal(data, &export); err != nil {
+		return nil, fmt.Errorf("parsing Tempo/Jaeger JSON: %w", err)
+	}
+
+	var spans []Span
+	for _, trace := range export.Data {
+		for _, js := range trace.Spans {
+			service := tempoService(js, trace.Processes)
+
+			parentID := ""
+			for _, ref := range js.References {
+				if ref.RefType == "CHILD_OF" {
+					parentID = ref.SpanID
+					break
+				}
+			}
+
+			startTime := time.UnixMicro(js.StartTime)
+			endTime := time.UnixMicro(js.StartTime + js.Duration)
+
+			attrs := make(map[string]string)
+			isError := false
+			for _, tag := range js.Tags {
+				val := tempoTagString(tag.Value)
+				if tag.Key == "error" && val == "true" {
+					isError = true
+				}
+				attrs[tag.Key] = val
+			}
+
+			spans = append(spans, Span{
+				TraceID:    js.TraceID,
+				SpanID:     js.SpanID,
+				ParentID:   parentID,
+				Service:    service,
+				Operation:  js.OperationName,
+				StartTime:  startTime,
+				EndTime:    endTime,
+				IsError:    isError,
+				Attributes: attrs,
+			})
+		}
+	}
+
+	if len(spans) == 0 {
+		return nil, fmt.Errorf("no spans found in input")
+	}
+	return spans, nil
+}
+
+// tempoService resolves the service name for a span: prefers the embedded
+// process field, falls back to the trace-level processes map.
+func tempoService(js jaegerSpan, processes map[string]*jaegerProcess) string {
+	if js.Process != nil && js.Process.ServiceName != "" {
+		return js.Process.ServiceName
+	}
+	if js.ProcessID != "" && processes != nil {
+		if p := processes[js.ProcessID]; p != nil {
+			return p.ServiceName
+		}
+	}
+	return ""
+}
+
+// tempoTagString converts a raw Jaeger tag value to a string.
+// Strings are unquoted; other JSON scalars (numbers, booleans) use their
+// literal representation so callers can match against "true"/"false"/etc.
+func tempoTagString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return string(raw)
 }
 
 // attrValueString extracts a string representation from an OTLP AnyValue.

--- a/pkg/synth/traceimport/span_test.go
+++ b/pkg/synth/traceimport/span_test.go
@@ -235,21 +235,21 @@ func TestParseStdouttrace_BlankLinesOnly(t *testing.T) {
 	assert.Contains(t, err.Error(), "no spans found")
 }
 
-func TestDetectFormat_Tempo(t *testing.T) {
+func TestDetectFormat_Jaeger(t *testing.T) {
 	input := `{"data":[{"traceID":"abc","spans":[{"traceID":"abc","spanID":"def","operationName":"op","references":[],"startTime":1700000000000000,"duration":30000,"tags":[],"processID":"p1","process":{"serviceName":"api"}}],"processes":{"p1":{"serviceName":"api"}}}]}`
 	format, err := detectFormat([]byte(input))
 	require.NoError(t, err)
-	assert.Equal(t, FormatTempo, format)
+	assert.Equal(t, FormatJaeger, format)
 }
 
-func TestDetectFormat_PrettyPrintedTempo(t *testing.T) {
+func TestDetectFormat_PrettyPrintedJaeger(t *testing.T) {
 	input := "{\n  \"data\": [{\"spans\":[{\"operationName\":\"op\"}]}]\n}"
 	format, err := detectFormat([]byte(input))
 	require.NoError(t, err)
-	assert.Equal(t, FormatTempo, format)
+	assert.Equal(t, FormatJaeger, format)
 }
 
-func TestParseTempo_Basic(t *testing.T) {
+func TestParseJaeger_Basic(t *testing.T) {
 	input := `{
 		"data": [{
 			"traceID": "abc123",
@@ -268,7 +268,7 @@ func TestParseTempo_Basic(t *testing.T) {
 		}]
 	}`
 
-	spans, err := ParseSpans(strings.NewReader(input), FormatTempo)
+	spans, err := ParseSpans(strings.NewReader(input), FormatJaeger)
 	require.NoError(t, err)
 	require.Len(t, spans, 1)
 
@@ -285,7 +285,7 @@ func TestParseTempo_Basic(t *testing.T) {
 	assert.Equal(t, int64(1700000000000000+30000), s.EndTime.UnixMicro())
 }
 
-func TestParseTempo_ParentRef(t *testing.T) {
+func TestParseJaeger_ParentRef(t *testing.T) {
 	input := `{
 		"data": [{
 			"spans": [
@@ -310,7 +310,7 @@ func TestParseTempo_ParentRef(t *testing.T) {
 		}]
 	}`
 
-	spans, err := ParseSpans(strings.NewReader(input), FormatTempo)
+	spans, err := ParseSpans(strings.NewReader(input), FormatJaeger)
 	require.NoError(t, err)
 	require.Len(t, spans, 2)
 
@@ -322,7 +322,7 @@ func TestParseTempo_ParentRef(t *testing.T) {
 	assert.Equal(t, "backend", child.Service)
 }
 
-func TestParseTempo_ErrorTag(t *testing.T) {
+func TestParseJaeger_ErrorTag(t *testing.T) {
 	input := `{
 		"data": [{
 			"spans": [{
@@ -337,13 +337,13 @@ func TestParseTempo_ErrorTag(t *testing.T) {
 		}]
 	}`
 
-	spans, err := ParseSpans(strings.NewReader(input), FormatTempo)
+	spans, err := ParseSpans(strings.NewReader(input), FormatJaeger)
 	require.NoError(t, err)
 	require.Len(t, spans, 1)
 	assert.True(t, spans[0].IsError)
 }
 
-func TestParseTempo_ServiceFromProcessesMap(t *testing.T) {
+func TestParseJaeger_ServiceFromProcessesMap(t *testing.T) {
 	// No inline process field; service resolved from processes map via processID.
 	input := `{
 		"data": [{
@@ -362,13 +362,13 @@ func TestParseTempo_ServiceFromProcessesMap(t *testing.T) {
 		}]
 	}`
 
-	spans, err := ParseSpans(strings.NewReader(input), FormatTempo)
+	spans, err := ParseSpans(strings.NewReader(input), FormatJaeger)
 	require.NoError(t, err)
 	require.Len(t, spans, 1)
 	assert.Equal(t, "target-service", spans[0].Service)
 }
 
-func TestParseTempo_MultipleTraces(t *testing.T) {
+func TestParseJaeger_MultipleTraces(t *testing.T) {
 	input := `{
 		"data": [
 			{
@@ -382,20 +382,20 @@ func TestParseTempo_MultipleTraces(t *testing.T) {
 		]
 	}`
 
-	spans, err := ParseSpans(strings.NewReader(input), FormatTempo)
+	spans, err := ParseSpans(strings.NewReader(input), FormatJaeger)
 	require.NoError(t, err)
 	require.Len(t, spans, 2)
 	assert.Equal(t, "t1", spans[0].TraceID)
 	assert.Equal(t, "t2", spans[1].TraceID)
 }
 
-func TestParseTempo_EmptyData(t *testing.T) {
-	_, err := ParseSpans(strings.NewReader(`{"data":[]}`), FormatTempo)
+func TestParseJaeger_EmptyData(t *testing.T) {
+	_, err := ParseSpans(strings.NewReader(`{"data":[]}`), FormatJaeger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no spans found")
 }
 
-func TestParseTempo_AutoDetect(t *testing.T) {
+func TestParseJaeger_AutoDetect(t *testing.T) {
 	input := `{"data":[{"spans":[{"traceID":"t1","spanID":"s1","operationName":"op","references":[],"startTime":1700000000000000,"duration":1000,"tags":[],"process":{"serviceName":"svc"}}],"processes":{}}]}`
 	spans, err := ParseSpans(strings.NewReader(input), FormatAuto)
 	require.NoError(t, err)

--- a/pkg/synth/traceimport/span_test.go
+++ b/pkg/synth/traceimport/span_test.go
@@ -1,4 +1,4 @@
-// Unit tests for span parsing across stdouttrace and OTLP formats
+// Unit tests for span parsing across supported trace import formats
 // Covers format detection, field extraction, and error handling
 package traceimport
 

--- a/pkg/synth/traceimport/span_test.go
+++ b/pkg/synth/traceimport/span_test.go
@@ -235,6 +235,174 @@ func TestParseStdouttrace_BlankLinesOnly(t *testing.T) {
 	assert.Contains(t, err.Error(), "no spans found")
 }
 
+func TestDetectFormat_Tempo(t *testing.T) {
+	input := `{"data":[{"traceID":"abc","spans":[{"traceID":"abc","spanID":"def","operationName":"op","references":[],"startTime":1700000000000000,"duration":30000,"tags":[],"processID":"p1","process":{"serviceName":"api"}}],"processes":{"p1":{"serviceName":"api"}}}]}`
+	format, err := detectFormat([]byte(input))
+	require.NoError(t, err)
+	assert.Equal(t, FormatTempo, format)
+}
+
+func TestDetectFormat_PrettyPrintedTempo(t *testing.T) {
+	input := "{\n  \"data\": [{\"spans\":[{\"operationName\":\"op\"}]}]\n}"
+	format, err := detectFormat([]byte(input))
+	require.NoError(t, err)
+	assert.Equal(t, FormatTempo, format)
+}
+
+func TestParseTempo_Basic(t *testing.T) {
+	input := `{
+		"data": [{
+			"traceID": "abc123",
+			"spans": [{
+				"traceID": "abc123",
+				"spanID": "def456",
+				"operationName": "HTTP GET /users",
+				"references": [],
+				"startTime": 1700000000000000,
+				"duration": 30000,
+				"tags": [{"key": "http.method", "value": "GET"}],
+				"processID": "p1",
+				"process": {"serviceName": "api-gateway"}
+			}],
+			"processes": {"p1": {"serviceName": "api-gateway"}}
+		}]
+	}`
+
+	spans, err := ParseSpans(strings.NewReader(input), FormatTempo)
+	require.NoError(t, err)
+	require.Len(t, spans, 1)
+
+	s := spans[0]
+	assert.Equal(t, "abc123", s.TraceID)
+	assert.Equal(t, "def456", s.SpanID)
+	assert.Empty(t, s.ParentID)
+	assert.Equal(t, "api-gateway", s.Service)
+	assert.Equal(t, "HTTP GET /users", s.Operation)
+	assert.False(t, s.IsError)
+	assert.Equal(t, "GET", s.Attributes["http.method"])
+	// startTime 1700000000000000 µs = 1700000000 s
+	assert.Equal(t, int64(1700000000), s.StartTime.Unix())
+	assert.Equal(t, int64(1700000000000000+30000), s.EndTime.UnixMicro())
+}
+
+func TestParseTempo_ParentRef(t *testing.T) {
+	input := `{
+		"data": [{
+			"spans": [
+				{
+					"traceID": "t1", "spanID": "root",
+					"operationName": "root-op",
+					"references": [],
+					"startTime": 1700000000000000, "duration": 50000,
+					"tags": [],
+					"process": {"serviceName": "frontend"}
+				},
+				{
+					"traceID": "t1", "spanID": "child",
+					"operationName": "child-op",
+					"references": [{"refType": "CHILD_OF", "traceID": "t1", "spanID": "root"}],
+					"startTime": 1700000000010000, "duration": 20000,
+					"tags": [],
+					"process": {"serviceName": "backend"}
+				}
+			],
+			"processes": {}
+		}]
+	}`
+
+	spans, err := ParseSpans(strings.NewReader(input), FormatTempo)
+	require.NoError(t, err)
+	require.Len(t, spans, 2)
+
+	root := spans[0]
+	child := spans[1]
+	assert.Empty(t, root.ParentID)
+	assert.Equal(t, "root", child.ParentID)
+	assert.Equal(t, "frontend", root.Service)
+	assert.Equal(t, "backend", child.Service)
+}
+
+func TestParseTempo_ErrorTag(t *testing.T) {
+	input := `{
+		"data": [{
+			"spans": [{
+				"traceID": "t1", "spanID": "s1",
+				"operationName": "fail",
+				"references": [],
+				"startTime": 1700000000000000, "duration": 5000,
+				"tags": [{"key": "error", "value": true}],
+				"process": {"serviceName": "svc"}
+			}],
+			"processes": {}
+		}]
+	}`
+
+	spans, err := ParseSpans(strings.NewReader(input), FormatTempo)
+	require.NoError(t, err)
+	require.Len(t, spans, 1)
+	assert.True(t, spans[0].IsError)
+}
+
+func TestParseTempo_ServiceFromProcessesMap(t *testing.T) {
+	// No inline process field; service resolved from processes map via processID.
+	input := `{
+		"data": [{
+			"spans": [{
+				"traceID": "t1", "spanID": "s1",
+				"operationName": "op",
+				"references": [],
+				"startTime": 1700000000000000, "duration": 1000,
+				"tags": [],
+				"processID": "p2"
+			}],
+			"processes": {
+				"p1": {"serviceName": "other"},
+				"p2": {"serviceName": "target-service"}
+			}
+		}]
+	}`
+
+	spans, err := ParseSpans(strings.NewReader(input), FormatTempo)
+	require.NoError(t, err)
+	require.Len(t, spans, 1)
+	assert.Equal(t, "target-service", spans[0].Service)
+}
+
+func TestParseTempo_MultipleTraces(t *testing.T) {
+	input := `{
+		"data": [
+			{
+				"spans": [{"traceID":"t1","spanID":"s1","operationName":"op1","references":[],"startTime":1700000000000000,"duration":1000,"tags":[],"process":{"serviceName":"svc"}}],
+				"processes": {}
+			},
+			{
+				"spans": [{"traceID":"t2","spanID":"s2","operationName":"op2","references":[],"startTime":1700000001000000,"duration":1000,"tags":[],"process":{"serviceName":"svc"}}],
+				"processes": {}
+			}
+		]
+	}`
+
+	spans, err := ParseSpans(strings.NewReader(input), FormatTempo)
+	require.NoError(t, err)
+	require.Len(t, spans, 2)
+	assert.Equal(t, "t1", spans[0].TraceID)
+	assert.Equal(t, "t2", spans[1].TraceID)
+}
+
+func TestParseTempo_EmptyData(t *testing.T) {
+	_, err := ParseSpans(strings.NewReader(`{"data":[]}`), FormatTempo)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no spans found")
+}
+
+func TestParseTempo_AutoDetect(t *testing.T) {
+	input := `{"data":[{"spans":[{"traceID":"t1","spanID":"s1","operationName":"op","references":[],"startTime":1700000000000000,"duration":1000,"tags":[],"process":{"serviceName":"svc"}}],"processes":{}}]}`
+	spans, err := ParseSpans(strings.NewReader(input), FormatAuto)
+	require.NoError(t, err)
+	require.Len(t, spans, 1)
+	assert.Equal(t, "op", spans[0].Operation)
+}
+
 func TestIsZeroID(t *testing.T) {
 	assert.True(t, isZeroID("0000000000000000"))
 	assert.True(t, isZeroID("00"))


### PR DESCRIPTION
Adds a new `jaeger` format to `motel import` that parses Jaeger JSON exports, including the Jaeger-shaped JSON downloaded from Grafana Explore when viewing Tempo traces.

This intentionally scopes the new parser to Jaeger export JSON. It does not add a separate Tempo HTTP API parser; OTLP-shaped JSON remains handled by the existing `otlp` parser.

Key changes:
- `FormatJaeger` constant and `parseJaeger` parser in `pkg/synth/traceimport`
- `detectFormat` recognizes Jaeger-style `data[].spans[].operationName` payloads so `--format auto` works
- Service name resolved from the inline `process` field first, then the trace-level `processes` map
- Error detection from the `error: true` boolean tag
- Timestamps converted from Jaeger microseconds to `time.Time`
- CLI `--format` flag description and import help updated
- Unit tests plus a Jaeger JSON seed added to the fuzz corpus

Closes https://github.com/andrewh/motel/issues/169