### PR TITLE
Fix telemetry lifecycle and stability issues

### DIFF
--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -42,6 +42,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	otelsc "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 var (
@@ -255,6 +256,11 @@ func emitCmd() *cobra.Command {
 			}
 			defer shutdownTraces()
 
+			tracers, err := tracerSource(topo, traceProviders)
+			if err != nil {
+				return err
+			}
+
 			engineDuration := unlimitedDuration
 			maxTraces := count
 			if duration > 0 {
@@ -265,21 +271,9 @@ func emitCmd() *cobra.Command {
 			}
 
 			engine := &synth.Engine{
-				Topology: topo,
-				Traffic:  traffic,
-				Tracers: func(name string) trace.Tracer {
-					tp := traceProviders[name]
-					if tp == nil {
-						panic(fmt.Sprintf("BUG: no tracer provider for service %q", name))
-					}
-					return tp.Tracer("github.com/andrewh/motel",
-						trace.WithInstrumentationVersion(version),
-						trace.WithSchemaURL(otelsc.SchemaURL),
-						trace.WithInstrumentationAttributes(
-							attribute.Bool("motel.synthetic", true),
-						),
-					)
-				},
+				Topology:  topo,
+				Traffic:   traffic,
+				Tracers:   tracers,
 				Rng:       rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())), //nolint:gosec // synthetic data, not security-sensitive
 				Duration:  engineDuration,
 				MaxTraces: maxTraces,
@@ -554,10 +548,23 @@ func checkEndpoint(endpoint, protocol, configPath string) error {
 
 func runGenerate(ctx context.Context, configPath string, opts runOptions) error {
 	if opts.pprofAddr != "" {
+		pprofListener, listenErr := net.Listen("tcp", opts.pprofAddr)
+		if listenErr != nil {
+			return fmt.Errorf("starting pprof server: %w", listenErr)
+		}
+
+		pprofServer := &http.Server{Addr: opts.pprofAddr, Handler: http.DefaultServeMux}
 		go func() {
-			fmt.Fprintf(os.Stderr, "pprof server listening on %s\n", opts.pprofAddr)
-			if err := http.ListenAndServe(opts.pprofAddr, nil); err != nil { //nolint:gosec // pprof server is opt-in via flag
+			fmt.Fprintf(os.Stderr, "pprof server listening on %s\n", pprofListener.Addr())
+			if err := pprofServer.Serve(pprofListener); err != nil && err != http.ErrServerClosed { //nolint:gosec // pprof server is opt-in via flag
 				fmt.Fprintf(os.Stderr, "pprof server error: %v\n", err)
+			}
+		}()
+		defer func() {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+			defer cancel()
+			if err := pprofServer.Shutdown(shutdownCtx); err != nil {
+				fmt.Fprintf(os.Stderr, "pprof server shutdown error: %v\n", err)
 			}
 		}()
 	}
@@ -631,6 +638,11 @@ func runGenerate(ctx context.Context, configPath string, opts runOptions) error 
 	}
 	defer shutdownTraces()
 
+	tracers, err := tracerSource(topo, traceProviders)
+	if err != nil {
+		return err
+	}
+
 	var observers []synth.SpanObserver
 
 	if enabledSignals["metrics"] {
@@ -670,22 +682,10 @@ func runGenerate(ctx context.Context, configPath string, opts runOptions) error 
 	}
 
 	engine := &synth.Engine{
-		Topology:  topo,
-		Traffic:   traffic,
-		Scenarios: scenarios,
-		Tracers: func(name string) trace.Tracer {
-			tp := traceProviders[name]
-			if tp == nil {
-				panic(fmt.Sprintf("BUG: no tracer provider for service %q", name))
-			}
-			return tp.Tracer("github.com/andrewh/motel",
-				trace.WithInstrumentationVersion(version),
-				trace.WithSchemaURL(otelsc.SchemaURL),
-				trace.WithInstrumentationAttributes(
-					attribute.Bool("motel.synthetic", true),
-				),
-			)
-		},
+		Topology:         topo,
+		Traffic:          traffic,
+		Scenarios:        scenarios,
+		Tracers:          tracers,
 		Rng:              newRunRng(opts.seed, rngStreamEngine),
 		Duration:         duration,
 		Observers:        observers,
@@ -706,6 +706,30 @@ func runGenerate(ctx context.Context, configPath string, opts runOptions) error 
 	}
 
 	return json.NewEncoder(os.Stderr).Encode(stats)
+}
+
+func tracerSource(topo *synth.Topology, providers map[string]*sdktrace.TracerProvider) (synth.TracerSource, error) {
+	for name := range topo.Services {
+		if providers[name] == nil {
+			return nil, fmt.Errorf("missing tracer provider for service %q", name)
+		}
+	}
+
+	missingProvider := noop.NewTracerProvider()
+	return func(name string) trace.Tracer {
+		provider := providers[name]
+		if provider == nil {
+			return missingProvider.Tracer("github.com/andrewh/motel")
+		}
+
+		return provider.Tracer("github.com/andrewh/motel",
+			trace.WithInstrumentationVersion(version),
+			trace.WithSchemaURL(otelsc.SchemaURL),
+			trace.WithInstrumentationAttributes(
+				attribute.Bool("motel.synthetic", true),
+			),
+		)
+	}, nil
 }
 
 // createTraceProviders creates one TracerProvider per service sharing a single exporter

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/andrewh/motel/pkg/synth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func writeTestConfig(t *testing.T, content string) string {
@@ -47,6 +48,33 @@ services:
 traffic:
   rate: 100/s
 `
+
+func TestTracerSourceMissingProvider(t *testing.T) {
+	t.Parallel()
+
+	topo := &synth.Topology{Services: map[string]*synth.Service{
+		"gateway": {Name: "gateway"},
+	}}
+
+	_, err := tracerSource(topo, map[string]*sdktrace.TracerProvider{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing tracer provider")
+	assert.Contains(t, err.Error(), "gateway")
+}
+
+func TestTracerSourceReturnsTracer(t *testing.T) {
+	t.Parallel()
+
+	tp := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { require.NoError(t, tp.Shutdown(context.Background())) })
+	topo := &synth.Topology{Services: map[string]*synth.Service{
+		"gateway": {Name: "gateway"},
+	}}
+
+	tracers, err := tracerSource(topo, map[string]*sdktrace.TracerProvider{"gateway": tp})
+	require.NoError(t, err)
+	assert.NotNil(t, tracers("gateway"))
+}
 
 func TestValidateCommand(t *testing.T) {
 	t.Parallel()

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -19,6 +19,8 @@ import (
 // DefaultMaxSpansPerTrace is the safety bound for span generation per trace.
 const DefaultMaxSpansPerTrace = 10_000
 
+const zeroRateIdleInterval = 10 * time.Millisecond
+
 // spanContextRegistry stores the most recent span context for each operation ref.
 // Used to attach cross-trace span links from consumer operations to producer operations.
 // Concurrent Store calls produce last-writer-wins semantics — "most recent" is
@@ -172,7 +174,10 @@ func (e *Engine) Run(ctx context.Context) (*Stats, error) {
 
 		rate := trafficPattern.Rate(elapsed)
 		if rate <= 0 {
-			time.Sleep(10 * time.Millisecond)
+			if waitZeroRate(ctx) {
+				e.finaliseStats(&stats, startTime)
+				return &stats, nil
+			}
 			continue
 		}
 
@@ -206,6 +211,18 @@ func (e *Engine) Run(ctx context.Context) (*Stats, error) {
 			return &stats, nil
 		case <-time.After(interval):
 		}
+	}
+}
+
+func waitZeroRate(ctx context.Context) bool {
+	timer := time.NewTimer(zeroRateIdleInterval)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return true
+	case <-timer.C:
+		return false
 	}
 }
 
@@ -302,7 +319,12 @@ func (e *Engine) runRealtime(ctx context.Context) (*Stats, error) {
 
 		rate := trafficPattern.Rate(elapsed)
 		if rate <= 0 {
-			time.Sleep(10 * time.Millisecond)
+			if waitZeroRate(ctx) {
+				wg.Wait()
+				e.mergeRealtimeStats(&stats, &rstats)
+				e.finaliseStats(&stats, startTime)
+				return &stats, nil
+			}
 			continue
 		}
 

--- a/pkg/synth/metricoffset_test.go
+++ b/pkg/synth/metricoffset_test.go
@@ -4,6 +4,7 @@ package synth
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 
 // captureMetricExporter records the last exported ResourceMetrics.
 type captureMetricExporter struct {
+	mu       sync.Mutex
 	exported *metricdata.ResourceMetrics
 }
 
@@ -27,8 +29,19 @@ func (e *captureMetricExporter) Aggregation(k sdkmetric.InstrumentKind) sdkmetri
 }
 
 func (e *captureMetricExporter) Export(_ context.Context, rm *metricdata.ResourceMetrics) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.exported = rm
 	return nil
+}
+
+func (e *captureMetricExporter) findMetric(name string) *metricdata.Metrics {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.exported == nil {
+		return nil
+	}
+	return findMetric(*e.exported, name)
 }
 
 func (e *captureMetricExporter) ForceFlush(context.Context) error { return nil }
@@ -149,7 +162,7 @@ func TestTimeOffsetMetricExporterEndToEnd(t *testing.T) {
 
 	offset := -24 * time.Hour
 	capture := &captureMetricExporter{}
-	reader := sdkmetric.NewPeriodicReader(NewTimeOffsetMetricExporter(capture, offset))
+	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	defer func() { require.NoError(t, mp.Shutdown(context.Background())) }()
 
@@ -158,11 +171,12 @@ func TestTimeOffsetMetricExporterEndToEnd(t *testing.T) {
 
 	before := time.Now()
 	counter.Add(context.Background(), 1)
-	require.NoError(t, reader.ForceFlush(context.Background()))
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	require.NoError(t, NewTimeOffsetMetricExporter(capture, offset).Export(context.Background(), &rm))
 	after := time.Now()
 
-	require.NotNil(t, capture.exported)
-	m := findMetric(*capture.exported, "requests.count")
+	m := capture.findMetric("requests.count")
 	require.NotNil(t, m)
 	sum, ok := m.Data.(metricdata.Sum[int64])
 	require.True(t, ok)

--- a/tools/dgg2motel/test_corpus.sh
+++ b/tools/dgg2motel/test_corpus.sh
@@ -22,8 +22,9 @@ if [ ! -x "$MOTEL" ]; then
 fi
 
 temp_topo=""
-cleanup() { [ -n "$temp_topo" ] && rm -f "$temp_topo"; true; }
-trap cleanup EXIT INT TERM
+cleanup() { [ -n "$temp_topo" ] && rm -f "$temp_topo"; temp_topo=""; true; }
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT TERM
 
 check_pass=0
 check_fail=0
@@ -56,18 +57,15 @@ for f in "${files[@]}"; do
     # motel run
     topo="$f"
     if [ -n "$RATE" ]; then
-        temp_topo=$(mktemp /tmp/dgg-topo-XXXXXX.yaml)
+        temp_topo=$(mktemp "${TMPDIR:-/tmp}/dgg-topo-XXXXXX.yaml")
         sed "s|rate: .*|rate: $RATE|" "$f" > "$temp_topo"
         topo="$temp_topo"
     fi
 
+    rc=0
     output=$(timeout 10 "$MOTEL" run --stdout --duration "$DURATION" "$topo" 2>&1) || rc=$?
-    rc=${rc:-0}
 
-    if [ -n "$temp_topo" ]; then
-        rm -f "$temp_topo"
-        temp_topo=""
-    fi
+    cleanup
 
     if [ "$rc" -eq 124 ]; then
         echo "RUN TIMEOUT: $rel"


### PR DESCRIPTION
## Summary

- Rework pprof startup to bind before launching the server, surface listener errors, and shut the server down on exit.
- Validate tracer providers up front and add a defensive no-op tracer fallback for unexpected service names.
- Make zero-rate waits context-aware while preserving realtime stats merging before finalization.
- Stabilize the metric time-offset end-to-end test with deterministic manual collection.
- Harden the dgg2motel corpus test script cleanup and per-run exit-code handling.

## Impact

This removes lifecycle and stability edge cases in trace generation, realtime shutdown, metric testing, and corpus replay tooling. Failures that previously could panic or surface late now return clearer errors.

## Validation

- `make test`
- `make lint`
- `make build`