### PR TITLE
[codex] Stabilize metric offset exporter test

### DIFF
--- a/pkg/synth/metricoffset_test.go
+++ b/pkg/synth/metricoffset_test.go
@@ -169,7 +169,8 @@ func TestTimeOffsetMetricExporterEndToEnd(t *testing.T) {
 
 	offset := -24 * time.Hour
 	capture := &captureMetricExporter{}
-	reader := sdkmetric.NewPeriodicReader(NewTimeOffsetMetricExporter(capture, offset), sdkmetric.WithInterval(10*time.Millisecond))
+	exporter := NewTimeOffsetMetricExporter(capture, offset)
+	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	defer func() { require.NoError(t, mp.Shutdown(context.Background())) }()
 
@@ -179,18 +180,14 @@ func TestTimeOffsetMetricExporterEndToEnd(t *testing.T) {
 	before := time.Now()
 	counter.Add(context.Background(), 1)
 
-	var matched metricdata.Metrics
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		rm := capture.LastExported()
-		if !assert.NotNil(c, rm) {
-			return
-		}
-		m := findMetric(*rm, "requests.count")
-		if assert.NotNil(c, m) {
-			matched = *m
-		}
-	}, time.Second, 10*time.Millisecond)
+	// Manual collection avoids racing the periodic reader's background export.
+	rm := collectMetrics(t, reader)
+	require.NoError(t, exporter.Export(context.Background(), &rm))
 	after := time.Now()
+
+	m := capture.findMetric("requests.count")
+	require.NotNil(t, m)
+	matched := *m
 
 	sum, ok := matched.Data.(metricdata.Sum[int64])
 	require.True(t, ok)


### PR DESCRIPTION
## Summary

- Replace the periodic reader timing path in `TestTimeOffsetMetricExporterEndToEnd` with a manual reader collection.
- Export the collected metrics through `NewTimeOffsetMetricExporter` synchronously before asserting shifted timestamps.

## Root cause

The test depended on `NewPeriodicReader` exporting on a background interval before the assertion loop observed `requests.count`, which made the test timing-sensitive.

## Validation

- `go test ./pkg/synth -run TestTimeOffsetMetricExporterEndToEnd -count=100`
- `make test`
- `make lint`

Fixes issue 175.