### PR TITLE
Add checks file support

### DIFF
--- a/cmd/motel/check.go
+++ b/cmd/motel/check.go
@@ -17,6 +17,7 @@ func checkCmd() *cobra.Command {
 		samples          int
 		seed             uint64
 		semconvDir       string
+		checksPath       string
 		skipScenarios    bool
 	)
 
@@ -29,7 +30,9 @@ func checkCmd() *cobra.Command {
 			"Scenarios defined in the topology are explored automatically: every\n" +
 			"distinct combination of co-active scenarios is checked alongside the\n" +
 			"baseline, and each check reports the combination that produces the\n" +
-			"worst case. Use --skip-scenarios to check the baseline topology only.",
+			"worst case. Use --skip-scenarios to check the baseline topology only.\n\n" +
+			"Use --checks to load thresholds from a separate YAML checks file or URL.\n" +
+			"Explicit command-line limit flags override values from that file.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("missing topology file or URL\n\nUsage: motel check <topology.yaml | URL>")
@@ -39,6 +42,29 @@ func checkCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if maxDepth < 0 || maxFanOut < 0 || maxSpans < 0 || maxSpansPerTrace < 0 || samples < 0 {
 				return fmt.Errorf("limit and sample flags must be non-negative")
+			}
+
+			var assertions synth.CheckAssertions
+			if checksPath != "" {
+				loaded, err := synth.LoadCheckAssertions(checksPath)
+				if err != nil {
+					return err
+				}
+				assertions = *loaded
+				if assertions.Checks.HasPercentile() && samples == 0 {
+					return fmt.Errorf("percentile checks require --samples greater than 0")
+				}
+
+				flags := cmd.Flags()
+				if flags.Changed("max-depth") {
+					assertions.Checks.MaxDepth = checkLimitPtr(maxDepth)
+				}
+				if flags.Changed("max-fan-out") {
+					assertions.Checks.MaxFanOut = checkLimitPtr(maxFanOut)
+				}
+				if flags.Changed("max-spans") {
+					assertions.Checks.MaxSpans = checkLimitPtr(maxSpans)
+				}
 			}
 
 			cfg, err := synth.LoadConfig(args[0])
@@ -69,6 +95,7 @@ func checkCmd() *cobra.Command {
 				Samples:          samples,
 				Seed:             seed,
 				Scenarios:        scenarios,
+				Assertions:       assertions.Checks,
 			}
 
 			results := synth.Check(topo, opts)
@@ -83,17 +110,17 @@ func checkCmd() *cobra.Command {
 				}
 
 				switch r.Name {
-				case "max-depth":
+				case synth.CheckNameMaxDepth:
 					_, _ = fmt.Fprintf(w, "%s  %s: %d (limit: %d)\n", status, r.Name, r.Actual, r.Limit)
 					if len(r.Path) > 0 {
 						_, _ = fmt.Fprintf(w, "      path: %s\n", strings.Join(r.Path, " \u2192 "))
 					}
-				case "max-fan-out":
+				case synth.CheckNameMaxFanOut:
 					_, _ = fmt.Fprintf(w, "%s  %s: %d (limit: %d)\n", status, r.Name, r.Actual, r.Limit)
 					if r.Ref != "" {
 						_, _ = fmt.Fprintf(w, "      worst: %s\n", r.Ref)
 					}
-				case "max-spans":
+				case synth.CheckNameMaxSpans:
 					line := fmt.Sprintf("%s  %s: %d static worst-case", status, r.Name, r.Actual)
 					if r.Sampled != nil {
 						line += fmt.Sprintf(", %d observed/%d samples", *r.Sampled, r.SamplesRun)
@@ -129,7 +156,10 @@ func checkCmd() *cobra.Command {
 	cmd.Flags().Uint64Var(&seed, "seed", 0, "random seed for reproducibility (0 = random)")
 	cmd.Flags().IntVar(&maxSpansPerTrace, "max-spans-per-trace", 0, fmt.Sprintf("maximum spans per sampled trace (0 = default %d)", synth.DefaultMaxSpansPerTrace))
 	cmd.Flags().StringVar(&semconvDir, "semconv", "", "directory of additional semantic convention YAML files")
+	cmd.Flags().StringVar(&checksPath, "checks", "", "YAML checks file or URL with structural thresholds")
 	cmd.Flags().BoolVar(&skipScenarios, "skip-scenarios", false, "check the baseline topology only, ignoring scenarios")
 
 	return cmd
 }
+
+func checkLimitPtr(v int) *int { return &v }

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -23,9 +23,13 @@ import (
 )
 
 func writeTestConfig(t *testing.T, content string) string {
+	return writeTestFile(t, "config.yaml", content)
+}
+
+func writeTestFile(t *testing.T, name, content string) string {
 	t.Helper()
 	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
+	path := filepath.Join(dir, name)
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 	return path
 }
@@ -608,6 +612,104 @@ traffic:
 		assert.Contains(t, out.String(), "p95:")
 		assert.Contains(t, out.String(), "p99:")
 		assert.Contains(t, out.String(), "samples)")
+	})
+
+	t.Run("checks file thresholds pass", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, validConfig)
+		checksPath := writeTestFile(t, "checks.yaml", `
+version: 1
+checks:
+  max_depth: 1
+  max_fan_out: 1
+  max_spans: 2
+  p99_depth: 1
+  p95_spans: 2
+`)
+		root := rootCmd()
+		root.SetArgs([]string{"check", "--seed", "42", "--checks", checksPath, path})
+		var out bytes.Buffer
+		root.SetOut(&out)
+
+		err := root.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, out.String(), "PASS  max-depth: 1 (limit: 1)")
+		assert.Contains(t, out.String(), "PASS  max-fan-out: 1 (limit: 1)")
+		assert.Contains(t, out.String(), "PASS  max-spans: 2 static worst-case")
+		assert.Contains(t, out.String(), "PASS  p99-depth: 1 (limit: 1)")
+		assert.Contains(t, out.String(), "PASS  p95-spans: 2 (limit: 2)")
+	})
+
+	t.Run("checks file static threshold fails", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, validConfig)
+		checksPath := writeTestFile(t, "checks.yaml", `
+version: 1
+checks:
+  max_depth: 0
+`)
+		root := rootCmd()
+		root.SetArgs([]string{"check", "--checks", checksPath, path})
+		var out bytes.Buffer
+		root.SetOut(&out)
+
+		err := root.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "one or more checks failed")
+		assert.Contains(t, out.String(), "FAIL  max-depth: 1 (limit: 0)")
+	})
+
+	t.Run("checks file percentile threshold fails", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, validConfig)
+		checksPath := writeTestFile(t, "checks.yaml", `
+version: 1
+checks:
+  p99_depth: 0
+`)
+		root := rootCmd()
+		root.SetArgs([]string{"check", "--seed", "42", "--checks", checksPath, path})
+		var out bytes.Buffer
+		root.SetOut(&out)
+
+		err := root.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "one or more checks failed")
+		assert.Contains(t, out.String(), "FAIL  p99-depth: 1 (limit: 0)")
+	})
+
+	t.Run("limit flags override checks file", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, validConfig)
+		checksPath := writeTestFile(t, "checks.yaml", `
+version: 1
+checks:
+  max_depth: 0
+`)
+		root := rootCmd()
+		root.SetArgs([]string{"check", "--checks", checksPath, "--max-depth", "1", path})
+		var out bytes.Buffer
+		root.SetOut(&out)
+
+		err := root.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, out.String(), "PASS  max-depth: 1 (limit: 1)")
+	})
+
+	t.Run("percentile checks require sampling", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, validConfig)
+		checksPath := writeTestFile(t, "checks.yaml", `
+version: 1
+checks:
+  p95_depth: 1
+`)
+		root := rootCmd()
+		root.SetArgs([]string{"check", "--samples", "0", "--checks", checksPath, path})
+
+		err := root.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "percentile checks require --samples greater than 0")
 	})
 
 	t.Run("with seed for reproducibility", func(t *testing.T) {

--- a/docs/man/man1/motel.1
+++ b/docs/man/man1/motel.1
@@ -138,9 +138,20 @@ Set to 0 to skip sampling.
 \fIN\fR
 Random seed for reproducibility. When 0 (default), a random seed is used.
 .TP
+.B \-\-max\-spans\-per\-trace
+\fIN\fR
+Maximum spans per sampled trace; 0 means the default of 10000.
+.TP
 .B \-\-semconv
 \fIdir\fR
 Directory of additional semantic convention YAML files to load.
+.TP
+.B \-\-checks
+\fIfile\fR|\fIURL\fR
+YAML checks file or HTTP/HTTPS URL with structural thresholds.
+.TP
+.B \-\-skip\-scenarios
+Check the baseline topology only, ignoring scenarios.
 .SS preview
 Render the traffic rate over time as an SVG chart. Useful for visualising how
 traffic and scenarios interact before running a simulation.

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -131,9 +131,24 @@ Scenarios defined in the topology are explored automatically. Scenario windows a
 | `--seed` | uint | 0 | Random seed for reproducibility (0 = random) |
 | `--max-spans-per-trace` | int | 0 | Maximum spans per sampled trace; 0 means the default of 10000 |
 | `--semconv` | string | | Directory of additional semantic convention YAML files |
+| `--checks` | string | | YAML checks file or URL with structural thresholds |
 | `--skip-scenarios` | bool | false | Check the baseline topology only, ignoring scenarios |
 
 Output is one line per check showing PASS/FAIL, the measured value, and the limit. Depth checks include the worst-case path; fan-out checks identify the worst operation; span checks show both static worst-case and observed values from sampling. When a scenario combination produces the worst case, the check is annotated with `scenarios:` naming it.
+
+Use `--checks` to load project-specific thresholds from a separate YAML file or HTTP/HTTPS URL. Explicit command-line limit flags override matching values from the checks source.
+
+```yaml
+version: 1
+checks:
+  max_depth: 8
+  max_fan_out: 100
+  max_spans: 200
+  p95_depth: 6
+  p99_spans: 150
+```
+
+Static thresholds (`max_depth`, `max_fan_out`, `max_spans`) reuse the same checks as the matching flags. Percentile thresholds (`p50_*`, `p95_*`, `p99_*` for `depth`, `fan_out`, and `spans`) are evaluated from sampled traces, so they require sampling to be enabled.
 
 ### import
 

--- a/pkg/synth/check.go
+++ b/pkg/synth/check.go
@@ -15,6 +15,21 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	CheckNameMaxDepth  = "max-depth"
+	CheckNameMaxFanOut = "max-fan-out"
+	CheckNameMaxSpans  = "max-spans"
+	CheckNameP50Depth  = "p50-depth"
+	CheckNameP95Depth  = "p95-depth"
+	CheckNameP99Depth  = "p99-depth"
+	CheckNameP50FanOut = "p50-fan-out"
+	CheckNameP95FanOut = "p95-fan-out"
+	CheckNameP99FanOut = "p99-fan-out"
+	CheckNameP50Spans  = "p50-spans"
+	CheckNameP95Spans  = "p95-spans"
+	CheckNameP99Spans  = "p99-spans"
+)
+
 // CheckResult holds the outcome of a single structural check.
 // Scenarios names the scenario combination that produced the worst case;
 // empty means the baseline topology (no scenarios active).
@@ -88,6 +103,7 @@ type CheckOptions struct {
 	Samples          int
 	Seed             uint64
 	Scenarios        []Scenario
+	Assertions       CheckThresholds
 }
 
 // SampleResults holds empirical measurements from sampled trace generation.
@@ -437,6 +453,81 @@ type setEvaluation struct {
 	sampled   SampleResults
 }
 
+func appendPercentileCheckResults(results []CheckResult, evals []setEvaluation, thresholds CheckThresholds) []CheckResult {
+	type spec struct {
+		name       string
+		limit      *int
+		summary    func(setEvaluation) DistributionSummary
+		percentile func(DistributionSummary) int
+	}
+
+	for _, s := range []spec{
+		{CheckNameP50Depth, thresholds.P50Depth, func(e setEvaluation) DistributionSummary {
+			return summarise(e.sampled.Distribution.Depths)
+		}, func(d DistributionSummary) int { return d.P50 }},
+		{CheckNameP95Depth, thresholds.P95Depth, func(e setEvaluation) DistributionSummary {
+			return summarise(e.sampled.Distribution.Depths)
+		}, func(d DistributionSummary) int { return d.P95 }},
+		{CheckNameP99Depth, thresholds.P99Depth, func(e setEvaluation) DistributionSummary {
+			return summarise(e.sampled.Distribution.Depths)
+		}, func(d DistributionSummary) int { return d.P99 }},
+		{CheckNameP50FanOut, thresholds.P50FanOut, func(e setEvaluation) DistributionSummary {
+			return summarise(e.sampled.Distribution.FanOuts)
+		}, func(d DistributionSummary) int { return d.P50 }},
+		{CheckNameP95FanOut, thresholds.P95FanOut, func(e setEvaluation) DistributionSummary {
+			return summarise(e.sampled.Distribution.FanOuts)
+		}, func(d DistributionSummary) int { return d.P95 }},
+		{CheckNameP99FanOut, thresholds.P99FanOut, func(e setEvaluation) DistributionSummary {
+			return summarise(e.sampled.Distribution.FanOuts)
+		}, func(d DistributionSummary) int { return d.P99 }},
+		{CheckNameP50Spans, thresholds.P50Spans, func(e setEvaluation) DistributionSummary {
+			return summarise(e.sampled.Distribution.Spans)
+		}, func(d DistributionSummary) int { return d.P50 }},
+		{CheckNameP95Spans, thresholds.P95Spans, func(e setEvaluation) DistributionSummary {
+			return summarise(e.sampled.Distribution.Spans)
+		}, func(d DistributionSummary) int { return d.P95 }},
+		{CheckNameP99Spans, thresholds.P99Spans, func(e setEvaluation) DistributionSummary {
+			return summarise(e.sampled.Distribution.Spans)
+		}, func(d DistributionSummary) int { return d.P99 }},
+	} {
+		if s.limit == nil {
+			continue
+		}
+
+		best := evals[0]
+		bestDist := s.summary(best)
+		bestActual := s.percentile(bestDist)
+		for _, ev := range evals[1:] {
+			dist := s.summary(ev)
+			actual := s.percentile(dist)
+			if actual > bestActual || (actual == bestActual && dist.Max > bestDist.Max) {
+				best = ev
+				bestDist = dist
+				bestActual = actual
+			}
+		}
+
+		results = append(results, CheckResult{
+			Name:         s.name,
+			Pass:         bestActual <= *s.limit,
+			Limit:        *s.limit,
+			Actual:       bestActual,
+			SamplesRun:   best.sampled.TracesRun,
+			Scenarios:    best.names,
+			Distribution: &bestDist,
+		})
+	}
+
+	return results
+}
+
+func checkLimit(fallback int, assertion *int) int {
+	if assertion != nil {
+		return *assertion
+	}
+	return fallback
+}
+
 // Check runs structural analysis and sampled exploration, returning one result
 // per check. When opts.Scenarios is non-empty, the baseline topology and every
 // distinct combination of co-active scenarios are evaluated; each result
@@ -486,12 +577,16 @@ func Check(topo *Topology, opts CheckOptions) []CheckResult {
 		func(e setEvaluation) int { return e.spans },
 		func(e setEvaluation) int { return e.sampled.MaxSpans })
 
-	results := make([]CheckResult, 0, 3)
+	maxDepthLimit := checkLimit(opts.MaxDepth, opts.Assertions.MaxDepth)
+	maxFanOutLimit := checkLimit(opts.MaxFanOut, opts.Assertions.MaxFanOut)
+	maxSpansLimit := checkLimit(opts.MaxSpans, opts.Assertions.MaxSpans)
+
+	results := make([]CheckResult, 0, 3+opts.Assertions.percentileCount())
 
 	depthResult := CheckResult{
-		Name:       "max-depth",
-		Pass:       depthEval.depth <= opts.MaxDepth,
-		Limit:      opts.MaxDepth,
+		Name:       CheckNameMaxDepth,
+		Pass:       depthEval.depth <= maxDepthLimit,
+		Limit:      maxDepthLimit,
 		Actual:     depthEval.depth,
 		SamplesRun: depthEval.sampled.TracesRun,
 		Path:       depthEval.depthPath,
@@ -505,9 +600,9 @@ func Check(topo *Topology, opts CheckOptions) []CheckResult {
 	results = append(results, depthResult)
 
 	fanOutResult := CheckResult{
-		Name:       "max-fan-out",
-		Pass:       fanOutEval.fanOut <= opts.MaxFanOut,
-		Limit:      opts.MaxFanOut,
+		Name:       CheckNameMaxFanOut,
+		Pass:       fanOutEval.fanOut <= maxFanOutLimit,
+		Limit:      maxFanOutLimit,
 		Actual:     fanOutEval.fanOut,
 		SamplesRun: fanOutEval.sampled.TracesRun,
 		Ref:        fanOutEval.fanOutRef,
@@ -521,9 +616,9 @@ func Check(topo *Topology, opts CheckOptions) []CheckResult {
 	results = append(results, fanOutResult)
 
 	spansResult := CheckResult{
-		Name:       "max-spans",
-		Pass:       spansEval.spans <= opts.MaxSpans,
-		Limit:      opts.MaxSpans,
+		Name:       CheckNameMaxSpans,
+		Pass:       spansEval.spans <= maxSpansLimit,
+		Limit:      maxSpansLimit,
 		Actual:     spansEval.spans,
 		SamplesRun: spansEval.sampled.TracesRun,
 		Scenarios:  spansEval.names,
@@ -534,6 +629,10 @@ func Check(topo *Topology, opts CheckOptions) []CheckResult {
 		spansResult.Distribution = &sd
 	}
 	results = append(results, spansResult)
+
+	if opts.Samples > 0 && opts.Assertions.HasPercentile() {
+		results = appendPercentileCheckResults(results, evals, opts.Assertions)
+	}
 
 	return results
 }

--- a/pkg/synth/check_assertions.go
+++ b/pkg/synth/check_assertions.go
@@ -1,0 +1,134 @@
+package synth
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CheckAssertions is the user-facing YAML format consumed by motel check.
+type CheckAssertions struct {
+	Version int
+	Checks  CheckThresholds
+}
+
+type rawCheckAssertions struct {
+	Version *int             `yaml:"version"`
+	Checks  *CheckThresholds `yaml:"checks"`
+}
+
+// CheckThresholds contains structural limits users can load from a checks file.
+type CheckThresholds struct {
+	MaxDepth  *int `yaml:"max_depth,omitempty"`
+	MaxFanOut *int `yaml:"max_fan_out,omitempty"`
+	MaxSpans  *int `yaml:"max_spans,omitempty"`
+	P50Depth  *int `yaml:"p50_depth,omitempty"`
+	P95Depth  *int `yaml:"p95_depth,omitempty"`
+	P99Depth  *int `yaml:"p99_depth,omitempty"`
+	P50FanOut *int `yaml:"p50_fan_out,omitempty"`
+	P95FanOut *int `yaml:"p95_fan_out,omitempty"`
+	P99FanOut *int `yaml:"p99_fan_out,omitempty"`
+	P50Spans  *int `yaml:"p50_spans,omitempty"`
+	P95Spans  *int `yaml:"p95_spans,omitempty"`
+	P99Spans  *int `yaml:"p99_spans,omitempty"`
+}
+
+// LoadCheckAssertions reads and validates a YAML checks file from a file path or URL.
+func LoadCheckAssertions(source string) (*CheckAssertions, error) {
+	data, err := readSource(source)
+	if err != nil {
+		return nil, fmt.Errorf("reading checks: %w", err)
+	}
+
+	var raw rawCheckAssertions
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("parsing checks: %w", err)
+	}
+
+	if raw.Version == nil {
+		return nil, fmt.Errorf("missing required field: version (e.g. 'version: 1')")
+	}
+	if *raw.Version != CurrentVersion {
+		return nil, fmt.Errorf("unsupported checks version %d (supported: %d)", *raw.Version, CurrentVersion)
+	}
+	if raw.Checks == nil || !raw.Checks.HasAny() {
+		return nil, fmt.Errorf("checks section must define at least one threshold")
+	}
+	if err := raw.Checks.validate(); err != nil {
+		return nil, err
+	}
+
+	return &CheckAssertions{
+		Version: *raw.Version,
+		Checks:  *raw.Checks,
+	}, nil
+}
+
+// HasAny reports whether at least one threshold is configured.
+func (t CheckThresholds) HasAny() bool {
+	return t.MaxDepth != nil ||
+		t.MaxFanOut != nil ||
+		t.MaxSpans != nil ||
+		t.HasPercentile()
+}
+
+// HasPercentile reports whether sampled percentile thresholds are configured.
+func (t CheckThresholds) HasPercentile() bool {
+	return t.P50Depth != nil ||
+		t.P95Depth != nil ||
+		t.P99Depth != nil ||
+		t.P50FanOut != nil ||
+		t.P95FanOut != nil ||
+		t.P99FanOut != nil ||
+		t.P50Spans != nil ||
+		t.P95Spans != nil ||
+		t.P99Spans != nil
+}
+
+func (t CheckThresholds) percentileCount() int {
+	count := 0
+	for _, v := range []*int{
+		t.P50Depth,
+		t.P95Depth,
+		t.P99Depth,
+		t.P50FanOut,
+		t.P95FanOut,
+		t.P99FanOut,
+		t.P50Spans,
+		t.P95Spans,
+		t.P99Spans,
+	} {
+		if v != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func (t CheckThresholds) validate() error {
+	for _, threshold := range []struct {
+		name  string
+		value *int
+	}{
+		{"max_depth", t.MaxDepth},
+		{"max_fan_out", t.MaxFanOut},
+		{"max_spans", t.MaxSpans},
+		{"p50_depth", t.P50Depth},
+		{"p95_depth", t.P95Depth},
+		{"p99_depth", t.P99Depth},
+		{"p50_fan_out", t.P50FanOut},
+		{"p95_fan_out", t.P95FanOut},
+		{"p99_fan_out", t.P99FanOut},
+		{"p50_spans", t.P50Spans},
+		{"p95_spans", t.P95Spans},
+		{"p99_spans", t.P99Spans},
+	} {
+		if threshold.value != nil && *threshold.value < 0 {
+			return fmt.Errorf("checks.%s must be non-negative", threshold.name)
+		}
+	}
+	return nil
+}

--- a/pkg/synth/check_assertions_test.go
+++ b/pkg/synth/check_assertions_test.go
@@ -1,0 +1,117 @@
+package synth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCheckAssertions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid thresholds", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, `
+version: 1
+checks:
+  max_depth: 8
+  max_fan_out: 20
+  max_spans: 200
+  p95_depth: 6
+  p99_spans: 150
+`)
+
+		assertions, err := LoadCheckAssertions(path)
+		require.NoError(t, err)
+		assert.Equal(t, CurrentVersion, assertions.Version)
+		assert.Equal(t, 8, *assertions.Checks.MaxDepth)
+		assert.Equal(t, 20, *assertions.Checks.MaxFanOut)
+		assert.Equal(t, 200, *assertions.Checks.MaxSpans)
+		assert.Equal(t, 6, *assertions.Checks.P95Depth)
+		assert.Equal(t, 150, *assertions.Checks.P99Spans)
+		assert.True(t, assertions.Checks.HasAny())
+		assert.True(t, assertions.Checks.HasPercentile())
+	})
+
+	t.Run("from URL", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`
+version: 1
+checks:
+  max_depth: 8
+`))
+		}))
+		t.Cleanup(srv.Close)
+
+		assertions, err := LoadCheckAssertions(srv.URL + "/checks.yaml")
+		require.NoError(t, err)
+		assert.Equal(t, 8, *assertions.Checks.MaxDepth)
+	})
+
+	t.Run("missing version", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, `
+checks:
+  max_depth: 8
+`)
+
+		_, err := LoadCheckAssertions(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required field: version")
+	})
+
+	t.Run("unsupported version", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, `
+version: 99
+checks:
+  max_depth: 8
+`)
+
+		_, err := LoadCheckAssertions(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported checks version 99")
+	})
+
+	t.Run("empty checks", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, `
+version: 1
+checks: {}
+`)
+
+		_, err := LoadCheckAssertions(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "checks section must define at least one threshold")
+	})
+
+	t.Run("negative threshold", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, `
+version: 1
+checks:
+  p99_depth: -1
+`)
+
+		_, err := LoadCheckAssertions(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "checks.p99_depth must be non-negative")
+	})
+
+	t.Run("unknown threshold", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, `
+version: 1
+checks:
+  p99_dept: 8
+`)
+
+		_, err := LoadCheckAssertions(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field p99_dept not found")
+	})
+}

--- a/pkg/synth/check_test.go
+++ b/pkg/synth/check_test.go
@@ -932,6 +932,79 @@ func TestCheck_ScenarioProducesWorstCase(t *testing.T) {
 	}
 }
 
+func TestCheck_PercentileAssertionUsesWorstScenario(t *testing.T) {
+	topo, scenarios := scenarioCheckTopo(t)
+	limit := 1
+
+	results := Check(topo, CheckOptions{
+		MaxDepth:  10,
+		MaxFanOut: 100,
+		MaxSpans:  10000,
+		Samples:   100,
+		Seed:      42,
+		Scenarios: scenarios,
+		Assertions: CheckThresholds{
+			P99Depth: &limit,
+		},
+	})
+
+	var p99DepthResult *CheckResult
+	for i := range results {
+		if results[i].Name == CheckNameP99Depth {
+			p99DepthResult = &results[i]
+		}
+	}
+	if p99DepthResult == nil {
+		t.Fatal("missing p99-depth result")
+	}
+	if p99DepthResult.Pass {
+		t.Fatalf("p99 depth check should fail under scenario: actual=%d", p99DepthResult.Actual)
+	}
+	if p99DepthResult.Actual != 2 {
+		t.Fatalf("expected scenario p99 depth 2, got %d", p99DepthResult.Actual)
+	}
+	if len(p99DepthResult.Scenarios) != 1 || p99DepthResult.Scenarios[0] != "deepen" {
+		t.Fatalf("expected p99 worst case attributed to scenario %q, got %v", "deepen", p99DepthResult.Scenarios)
+	}
+	if p99DepthResult.Distribution == nil {
+		t.Fatal("expected p99 result to include supporting distribution")
+	}
+	if p99DepthResult.Distribution.P99 != 2 {
+		t.Fatalf("expected supporting distribution p99 2, got %d", p99DepthResult.Distribution.P99)
+	}
+}
+
+func TestCheck_StaticAssertionsProvideLimits(t *testing.T) {
+	topo, _ := scenarioCheckTopo(t)
+	maxDepth := 1
+	maxFanOut := 100
+	maxSpans := 10000
+
+	results := Check(topo, CheckOptions{
+		Assertions: CheckThresholds{
+			MaxDepth:  &maxDepth,
+			MaxFanOut: &maxFanOut,
+			MaxSpans:  &maxSpans,
+		},
+	})
+
+	var depthResult *CheckResult
+	for i := range results {
+		if results[i].Name == CheckNameMaxDepth {
+			depthResult = &results[i]
+		}
+	}
+	if depthResult == nil {
+		t.Fatal("missing max-depth result")
+	}
+	if !depthResult.Pass {
+		t.Fatalf("depth check should pass using assertion limit: actual=%d limit=%d", depthResult.Actual, depthResult.Limit)
+	}
+	if depthResult.Limit != maxDepth {
+		t.Fatalf("expected assertion depth limit %d, got %d", maxDepth, depthResult.Limit)
+	}
+}
+
 func TestCheck_BaselineWinsWithoutScenarios(t *testing.T) {
 	topo, _ := scenarioCheckTopo(t)
 


### PR DESCRIPTION
## Summary

- Add a separate YAML checks file format for `motel check --checks`
- Let checks files define static thresholds and sampled percentile thresholds
- Keep existing CLI limit flags working, with explicit flags overriding checks-file values
- Document the checks file shape in the CLI reference

## Validation

- `go test ./pkg/synth`
- `go test ./cmd/motel`
- `make test`
- `make lint`
- `make build`

Fixes #72
