### PR TITLE
Fix endpoint URL handling and errors_only docs

### DIFF
--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -380,7 +380,10 @@ metric data.
 | `interval`   | string | Emit on a timer instead of per span, e.g. `10s`. Requires `value`; not valid for gauges (see below) |
 | `walk`       | string | Gauge only: mean-reversion timescale for a random walk, e.g. `30s` (see below) |
 | `min`, `max` | float  | Gauge only: clamp observed values to these bounds |
+| `errors_only` | bool | Counter only: record only completed error spans |
 | `attributes` | map    | Per-measurement attribute generators — same syntax as span attributes |
+
+`errors_only` is valid only on counters and cannot be combined with `interval`.
 
 Metric names that match a known OTel semantic convention metric are checked
 by `motel validate`: a `type` or `unit` that disagrees with the convention
@@ -391,7 +394,7 @@ from the span being observed.
 
 | Type | Span-derived recording |
 |------|----------------------|
-| `counter` | `+1` per completed span |
+| `counter` | `+1` per completed span; with `errors_only: true`, only error spans increment the counter |
 | `updowncounter` | `+1` on span start, `−1` on span end — tracks active-span count |
 | `histogram` | span duration, converted to the configured `unit` |
 | `gauge` | not valid — gauge requires `value` |
@@ -401,7 +404,7 @@ normal distribution on each observation.
 
 | Type | Topology-defined recording |
 |------|---------------------------|
-| `counter` | sampled float added per completed span (clamped ≥ 0) |
+| `counter` | sampled float added per completed span (clamped ≥ 0); with `errors_only: true`, only error spans add a value |
 | `updowncounter` | sampled float added per completed span |
 | `histogram` | sampled float recorded per completed span |
 | `gauge` | sampled float reported on each collection cycle |
@@ -485,6 +488,7 @@ metrics:
     type: counter
   - name: motel.span.errors
     type: counter
+    errors_only: true
 ```
 
 ### logs

--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec // pprof endpoint is opt-in via --pprof flag
+	"net/url"
 	"os"
 	"os/signal"
 	"slices"
@@ -129,7 +130,7 @@ func runCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&endpoint, "endpoint", "", "OTLP endpoint (e.g. localhost:4318)")
+	cmd.Flags().StringVar(&endpoint, "endpoint", "", "OTLP endpoint (e.g. localhost:4318 or http://localhost:4318)")
 	cmd.Flags().BoolVar(&stdout, "stdout", false, "emit signals to stdout as JSON")
 	cmd.Flags().DurationVar(&duration, "duration", 0, "simulation duration, e.g. 10s, 5m, 1h (default 1m)")
 	cmd.Flags().StringVar(&protocol, "protocol", "http/protobuf", "OTLP protocol (http/protobuf or grpc)")
@@ -299,7 +300,7 @@ func emitCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&attrs, "attr", nil, "span attribute in key=value format (repeatable)")
 	cmd.Flags().IntVar(&count, "count", 1, "number of traces to emit")
 	cmd.Flags().StringVar(&rate, "rate", "10/s", "trace rate when count > 1 (e.g. 10/s, 100/m)")
-	cmd.Flags().StringVar(&endpoint, "endpoint", "", "OTLP endpoint (e.g. localhost:4318)")
+	cmd.Flags().StringVar(&endpoint, "endpoint", "", "OTLP endpoint (e.g. localhost:4318 or http://localhost:4318)")
 	cmd.Flags().BoolVar(&stdout, "stdout", false, "emit signals to stdout as JSON")
 	cmd.Flags().StringVar(&protocol, "protocol", "http/protobuf", "OTLP protocol (http/protobuf or grpc)")
 
@@ -509,28 +510,67 @@ const (
 	defaultGRPCPort     = "4317"
 )
 
-func resolveEndpoint(endpoint, protocol string) string {
-	if endpoint == "" {
-		endpoint = "localhost"
-	}
-	if _, _, err := net.SplitHostPort(endpoint); err == nil {
-		return endpoint
-	}
-	port := defaultHTTPPort
+type resolvedEndpoint struct {
+	hostPort    string
+	endpointURL string
+}
+
+func defaultPort(protocol string) string {
 	if protocol == "grpc" {
-		port = defaultGRPCPort
+		return defaultGRPCPort
 	}
-	return net.JoinHostPort(endpoint, port)
+	return defaultHTTPPort
+}
+
+func isEndpointURL(endpoint string) bool {
+	return strings.Contains(endpoint, "://")
+}
+
+func resolveEndpoint(endpoint, protocol string) (resolvedEndpoint, error) {
+	if endpoint == "" {
+		return resolvedEndpoint{hostPort: net.JoinHostPort("localhost", defaultPort(protocol))}, nil
+	}
+
+	if isEndpointURL(endpoint) {
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			return resolvedEndpoint{}, fmt.Errorf("invalid endpoint URL %q: %w", endpoint, err)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return resolvedEndpoint{}, fmt.Errorf("endpoint URL %q: scheme must be http or https", endpoint)
+		}
+		if u.Host == "" {
+			return resolvedEndpoint{}, fmt.Errorf("endpoint URL %q: host is required", endpoint)
+		}
+		hostPort := u.Host
+		if _, _, err := net.SplitHostPort(hostPort); err != nil {
+			host := u.Hostname()
+			if host == "" {
+				return resolvedEndpoint{}, fmt.Errorf("endpoint URL %q: host is required", endpoint)
+			}
+			hostPort = net.JoinHostPort(host, defaultPort(protocol))
+			u.Host = hostPort
+		}
+		return resolvedEndpoint{hostPort: hostPort, endpointURL: u.String()}, nil
+	}
+
+	if _, _, err := net.SplitHostPort(endpoint); err == nil {
+		return resolvedEndpoint{hostPort: endpoint}, nil
+	}
+	return resolvedEndpoint{hostPort: net.JoinHostPort(endpoint, defaultPort(protocol))}, nil
 }
 
 func dialEndpoint(endpoint, protocol string) (string, error) {
-	host := resolveEndpoint(endpoint, protocol)
-	conn, err := net.DialTimeout("tcp", host, connectCheckTimeout)
+	resolved, err := resolveEndpoint(endpoint, protocol)
 	if err != nil {
-		return host, err
+		return endpoint, err
+	}
+	conn, err := net.DialTimeout("tcp", resolved.hostPort, connectCheckTimeout)
+	if err != nil {
+		return resolved.hostPort, err
 	}
 	_ = conn.Close()
-	return host, nil
+	return resolved.hostPort, nil
 }
 
 func checkEndpoint(endpoint, protocol, configPath string) error {
@@ -779,17 +819,29 @@ func createTraceExporter(ctx context.Context, opts runOptions) (sdktrace.SpanExp
 	if opts.stdout {
 		return stdouttrace.New(stdouttrace.WithWriter(os.Stdout))
 	}
+	resolved, err := resolveEndpoint(opts.endpoint, opts.protocol)
+	if err != nil {
+		return nil, err
+	}
 	switch opts.protocol {
 	case "grpc":
 		var grpcOpts []otlptracegrpc.Option
 		if opts.endpoint != "" {
-			grpcOpts = append(grpcOpts, otlptracegrpc.WithEndpoint(opts.endpoint), otlptracegrpc.WithInsecure())
+			if resolved.endpointURL != "" {
+				grpcOpts = append(grpcOpts, otlptracegrpc.WithEndpointURL(resolved.endpointURL))
+			} else {
+				grpcOpts = append(grpcOpts, otlptracegrpc.WithEndpoint(resolved.hostPort), otlptracegrpc.WithInsecure())
+			}
 		}
 		return otlptracegrpc.New(ctx, grpcOpts...)
 	case "http/protobuf", "":
 		var httpOpts []otlptracehttp.Option
 		if opts.endpoint != "" {
-			httpOpts = append(httpOpts, otlptracehttp.WithEndpoint(opts.endpoint), otlptracehttp.WithInsecure())
+			if resolved.endpointURL != "" {
+				httpOpts = append(httpOpts, otlptracehttp.WithEndpointURL(resolved.endpointURL))
+			} else {
+				httpOpts = append(httpOpts, otlptracehttp.WithEndpoint(resolved.hostPort), otlptracehttp.WithInsecure())
+			}
 		}
 		return otlptracehttp.New(ctx, httpOpts...)
 	default:
@@ -843,17 +895,29 @@ func createMetricExporter(ctx context.Context, opts runOptions) (sdkmetric.Expor
 	if opts.stdout {
 		return stdoutmetric.New(stdoutmetric.WithWriter(os.Stdout))
 	}
+	resolved, err := resolveEndpoint(opts.endpoint, opts.protocol)
+	if err != nil {
+		return nil, err
+	}
 	switch opts.protocol {
 	case "grpc":
 		var grpcOpts []otlpmetricgrpc.Option
 		if opts.endpoint != "" {
-			grpcOpts = append(grpcOpts, otlpmetricgrpc.WithEndpoint(opts.endpoint), otlpmetricgrpc.WithInsecure())
+			if resolved.endpointURL != "" {
+				grpcOpts = append(grpcOpts, otlpmetricgrpc.WithEndpointURL(resolved.endpointURL))
+			} else {
+				grpcOpts = append(grpcOpts, otlpmetricgrpc.WithEndpoint(resolved.hostPort), otlpmetricgrpc.WithInsecure())
+			}
 		}
 		return otlpmetricgrpc.New(ctx, grpcOpts...)
 	case "http/protobuf", "":
 		var httpOpts []otlpmetrichttp.Option
 		if opts.endpoint != "" {
-			httpOpts = append(httpOpts, otlpmetrichttp.WithEndpoint(opts.endpoint), otlpmetrichttp.WithInsecure())
+			if resolved.endpointURL != "" {
+				httpOpts = append(httpOpts, otlpmetrichttp.WithEndpointURL(resolved.endpointURL))
+			} else {
+				httpOpts = append(httpOpts, otlpmetrichttp.WithEndpoint(resolved.hostPort), otlpmetrichttp.WithInsecure())
+			}
 		}
 		return otlpmetrichttp.New(ctx, httpOpts...)
 	default:
@@ -900,17 +964,29 @@ func createLogExporter(ctx context.Context, opts runOptions) (sdklog.Exporter, e
 	if opts.stdout {
 		return stdoutlog.New(stdoutlog.WithWriter(os.Stdout))
 	}
+	resolved, err := resolveEndpoint(opts.endpoint, opts.protocol)
+	if err != nil {
+		return nil, err
+	}
 	switch opts.protocol {
 	case "grpc":
 		var grpcOpts []otlploggrpc.Option
 		if opts.endpoint != "" {
-			grpcOpts = append(grpcOpts, otlploggrpc.WithEndpoint(opts.endpoint), otlploggrpc.WithInsecure())
+			if resolved.endpointURL != "" {
+				grpcOpts = append(grpcOpts, otlploggrpc.WithEndpointURL(resolved.endpointURL))
+			} else {
+				grpcOpts = append(grpcOpts, otlploggrpc.WithEndpoint(resolved.hostPort), otlploggrpc.WithInsecure())
+			}
 		}
 		return otlploggrpc.New(ctx, grpcOpts...)
 	case "http/protobuf", "":
 		var httpOpts []otlploghttp.Option
 		if opts.endpoint != "" {
-			httpOpts = append(httpOpts, otlploghttp.WithEndpoint(opts.endpoint), otlploghttp.WithInsecure())
+			if resolved.endpointURL != "" {
+				httpOpts = append(httpOpts, otlploghttp.WithEndpointURL(resolved.endpointURL))
+			} else {
+				httpOpts = append(httpOpts, otlploghttp.WithEndpoint(resolved.hostPort), otlploghttp.WithInsecure())
+			}
 		}
 		return otlploghttp.New(ctx, httpOpts...)
 	default:

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -487,11 +487,36 @@ func TestCheckEndpoint(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("reachable URL endpoint succeeds", func(t *testing.T) {
+		t.Parallel()
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer ln.Close() //nolint:errcheck // best-effort close in test
+
+		err = checkEndpoint("http://"+ln.Addr().String()+"/v1/traces", "http/protobuf", "test.yaml")
+		require.NoError(t, err)
+	})
+
 	t.Run("endpoint without port gets default", func(t *testing.T) {
 		t.Parallel()
 		err := checkEndpoint("192.0.2.1", "http/protobuf", "test.yaml")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "192.0.2.1:4318")
+	})
+
+	t.Run("URL endpoint without port gets default", func(t *testing.T) {
+		t.Parallel()
+		got, err := resolveEndpoint("https://collector.example.com/custom", "http/protobuf")
+		require.NoError(t, err)
+		assert.Equal(t, "collector.example.com:4318", got.hostPort)
+		assert.Equal(t, "https://collector.example.com:4318/custom", got.endpointURL)
+	})
+
+	t.Run("unsupported URL scheme is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := resolveEndpoint("ftp://collector.example.com:4318", "http/protobuf")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scheme must be http or https")
 	})
 
 	t.Run("run command fails fast without collector", func(t *testing.T) {

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -52,7 +52,7 @@ motel run <topology.yaml | URL> [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--duration` | duration | `1m` | Simulation duration |
-| `--endpoint` | string | | OTLP endpoint (e.g. `localhost:4318`) |
+| `--endpoint` | string | | OTLP endpoint (e.g. `localhost:4318` or `http://localhost:4318`) |
 | `--protocol` | string | `http/protobuf` | OTLP protocol (`http/protobuf` or `grpc`) |
 | `--signals` | string | `traces` | Comma-separated signals: `traces`, `metrics`, `logs` |
 | `--slow-threshold` | duration | `1s` | Spans exceeding this duration emit a slow-span log record. Warns and has no effect unless `logs` is included in `--signals` |
@@ -106,7 +106,7 @@ motel emit --service <name> --operation <name> [flags]
 | `--attr` | string | | Span attribute in `key=value` format (repeatable) |
 | `--count` | int | 1 | Number of traces to emit |
 | `--rate` | string | `10/s` | Trace rate when count > 1 (e.g. `10/s`, `100/m`) |
-| `--endpoint` | string | | OTLP endpoint (e.g. `localhost:4318`) |
+| `--endpoint` | string | | OTLP endpoint (e.g. `localhost:4318` or `http://localhost:4318`) |
 | `--protocol` | string | `http/protobuf` | OTLP protocol (`http/protobuf` or `grpc`) |
 | `--stdout` | bool | false | Emit signals to stdout as JSON |
 

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -2105,6 +2105,12 @@ func TestValidateConfigMetrics(t *testing.T) {
 		require.NoError(t, ValidateConfig(cfg))
 	})
 
+	t.Run("valid errors-only counter", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{Name: "error.count", Type: "counter", ErrorsOnly: true}}, nil)
+		require.NoError(t, ValidateConfig(cfg))
+	})
+
 	t.Run("valid topology-defined gauge", func(t *testing.T) {
 		t.Parallel()
 		cfg := baseConfig([]MetricConfig{{Name: "cpu", Type: "gauge", Value: "0.5 +/- 0.1"}}, nil)
@@ -2153,6 +2159,14 @@ func TestValidateConfigMetrics(t *testing.T) {
 		err := ValidateConfig(cfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "gauge metrics require a value")
+	})
+
+	t.Run("errors-only non-counter rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseConfig([]MetricConfig{{Name: "error.duration", Type: "histogram", ErrorsOnly: true}}, nil)
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "errors_only is only valid for counter metrics")
 	})
 
 	t.Run("duplicate metric name across service and operation", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Normalize OTLP endpoints so documented URL forms work for preflight checks and exporters while preserving bare host and host:port behavior.
- Document `errors_only` metric behavior and validation rules, including the built-in metrics migration example.
- Add tests for URL endpoint resolution and `errors_only` validation.

## Validation
- `go test -count=1 ./cmd/motel ./pkg/synth`
- `make test`
- `make lint`
- `make build`

Fixes https://github.com/andrewh/motel/issues/180
Fixes https://github.com/andrewh/motel/issues/181
