### PR TITLE
[codex] clarify run reproducibility and log output docs

### DIFF
--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -321,9 +321,11 @@ Time-windowed overrides to operation behaviour and traffic.
 | `override` | map    | Per-operation overrides keyed by `service.operation`, or per-service overrides keyed by service name |
 | `traffic`  | object | Traffic pattern override for this window |
 
-Each operation override can set `duration`, `error_rate`, `attributes`, and
-`metrics`. Overlapping scenarios merge overrides by priority — higher-priority
-values win per field, attributes and metrics merge per key.
+Each operation override can set `duration`, `error_rate`, `attributes`,
+`metrics`, and `logs`. Service-level overrides can set `metrics` and `logs`.
+Overlapping scenarios merge overrides by priority — higher-priority values win
+per scalar field, attributes and metrics merge per key, log additions
+accumulate, and any active log disable wins.
 
 ```yaml
 scenarios:
@@ -361,6 +363,45 @@ scenarios:
         metrics:
           gateway.cpu.utilisation:
             value: 0.95 +/- 0.02
+```
+
+A `logs` override changes log output only while the scenario is active.
+`logs.add` appends scenario-only log records using the same record syntax as
+topology `logs`. `logs.disable: true` mutes base topology logs and derived
+error/slow logs at that scope for the scenario window.
+If a service otherwise relies on derived error/slow logs, active scenario log
+additions replace that derived fallback while they are active; add equivalent
+error or slow records when you want to keep them.
+
+Service-scope overrides are keyed by service name and apply to every span from
+that service. Operation-scope overrides are keyed by `service.operation` and
+apply only to that operation. When multiple scenarios are active, added logs
+from all active scenarios emit together, ordered by scenario priority, and a
+disable from any active scenario mutes base logs for that scope.
+
+```yaml
+scenarios:
+  - name: incident logging
+    at: +30s
+    duration: 5m
+    override:
+      checkout.authorize:
+        logs:
+          disable: true
+          add:
+            - severity: ERROR
+              body: "authorization degraded for {operation.name}"
+              condition: error
+              at: end
+              attributes:
+                incident.id:
+                  value: INC-42
+      checkout:
+        logs:
+          add:
+            - severity: WARN
+              body: "checkout service in incident mode"
+              probability: 0.1
 ```
 
 ### metrics
@@ -560,6 +601,10 @@ logs:
     body: "slow operation {service.name} {operation.name}"
     condition: slow
 ```
+
+Scenario [log overrides](#scenarios) can add incident-specific log records or
+mute base topology and derived logs for a service or operation during a
+scenario window.
 
 ## Derived Signals
 

--- a/docs/how-to/model-your-services.md
+++ b/docs/how-to/model-your-services.md
@@ -114,7 +114,7 @@ If you already have trace data — from a staging environment, production sampli
 
 You need spans in one of two formats:
 
-- **stdouttrace** — one JSON span per line, as produced by `motel run --stdout` or the OpenTelemetry Go SDK's stdout exporter
+- **stdouttrace** — one JSON span per line, as produced by trace-only `motel run --stdout` or the OpenTelemetry Go SDK's stdout exporter
 - **OTLP JSON** — the standard OTLP export format with `resourceSpans` arrays
 
 Export spans from your collector, or capture them directly:

--- a/docs/how-to/test-backend-integration.md
+++ b/docs/how-to/test-backend-integration.md
@@ -200,14 +200,14 @@ When migrating from one backend to another, use motel to send identical traffic 
 
 ### 1. Send the same traffic to both backends
 
-Run motel twice with the same topology and duration — once against each backend:
+Run motel twice with the same topology, duration, and seed — once against each backend:
 
 ```sh
 motel run --endpoint http://old-backend:4318 --protocol http/protobuf \
-  --duration 30s backend-test.yaml
+  --duration 30s --seed 4242 backend-test.yaml
 
 motel run --endpoint http://new-backend:4318 --protocol http/protobuf \
-  --duration 30s backend-test.yaml
+  --duration 30s --seed 4242 backend-test.yaml
 ```
 
 ### 2. Compare
@@ -219,7 +219,7 @@ Check both backends for:
 - Similar trace visualisation (waterfall view, service maps)
 - Error spans displayed and filterable
 
-The trace IDs will differ between runs, but the structure, timing distributions, and attribute values should be consistent. What matters is that both backends handle the same shape of data identically.
+The trace IDs will differ between runs, but the fixed seed makes simulation decisions reproducible within the same motel version, so structure, timing distributions, and attribute values should be easier to compare. Seeded runs are for repeatable comparisons, not a cross-version stable output contract. What matters is that both backends handle the same shape of data identically.
 
 ### 3. Use scenarios to stress-test
 

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -62,6 +62,7 @@ motel run <topology.yaml | URL> [flags]
 | `--label-scenarios` | bool | false | Add a `synth.scenarios` attribute to spans listing active scenario names |
 | `--time-offset` | duration | 0 | Shift span timestamps by this duration (e.g. `-1h` for past, `1h` for future) |
 | `--realtime` | bool | false | Emit spans at wall-clock times matching simulated timestamps |
+| `--seed` | uint | 0 | Seed for deterministic simulation decisions (0 = random); determinism is best-effort and not guaranteed across motel versions |
 | `--pprof` | string | | Start a pprof HTTP server on this address (e.g. `:6060`) |
 
 `--realtime` and `--time-offset` are mutually exclusive.
@@ -70,13 +71,13 @@ motel run <topology.yaml | URL> [flags]
 
 When `--stdout` is used, motel writes to two streams:
 
-- **stdout** — one JSON object per line, one span per line (stdouttrace format from the OpenTelemetry Go SDK). This is newline-delimited JSON, not the OTLP wire format.
+- **stdout** — emitted signal records as JSON. Trace-only output uses stdouttrace format from the OpenTelemetry Go SDK: one span JSON object per line. Metrics and logs use their own OpenTelemetry stdout exporter JSON shapes.
 - **stderr** — a single JSON statistics object on the final line, containing `traces`, `spans`, `errors`, `failed_traces`, `error_rate`, and other run metrics.
 
 To capture them separately:
 
 ```sh
-# Spans to file, stats to terminal
+# Trace-only stdouttrace spans to file, stats to terminal
 motel run --stdout --duration 5s topology.yaml > spans.jsonl
 
 # Stats to file, spans to terminal
@@ -86,7 +87,11 @@ motel run --stdout --duration 5s topology.yaml 2> stats.json
 motel run --stdout --duration 5s topology.yaml > spans.jsonl 2> stats.json
 ```
 
-The stdout format is the same format accepted by `motel import`, so you can round-trip: generate traces, then infer a topology from them.
+Trace-only stdout uses the same format accepted by `motel import`, so you can round-trip: generate traces, then infer a topology from them.
+This import round-trip applies to trace-only stdout output. When `--signals`
+includes metrics or logs, stdout may include metric export payloads or log
+records with different JSON shapes; mixed-signal stdout is useful for
+inspection and debugging, but should not be piped directly to `motel import`.
 
 ### emit
 


### PR DESCRIPTION
## Summary

- document `motel run --seed` in the run command reference and use a fixed seed in the backend migration comparison guide
- clarify that trace-only stdout is stdouttrace and importable, while metrics/logs stdout use their own exporter JSON shapes
- document scenario log overrides in the DSL reference, including `logs.add`, `logs.disable`, scope behavior, and overlap behavior

## Issues

Covers:

- https://github.com/andrewh/motel/issues/182
- https://github.com/andrewh/motel/issues/184
- https://github.com/andrewh/motel/issues/185

## Validation

- `make lint`
- `make test`