### PR TITLE
Fix issues in docs and scenario validation

### DIFF
--- a/docs/explanation/import-pipeline/README.md
+++ b/docs/explanation/import-pipeline/README.md
@@ -237,7 +237,7 @@ and operations are sorted alphabetically for deterministic output.
 Each decision maps to a line in `inferred-topology.yaml`:
 
 ```yaml
-# Inferred from 4 traces (10 spans) observed over 1 seconds   ← trace/span count, window
+# Inferred from 4 traces (10 spans) observed over 1.4 seconds ← trace/span count, window
 version: 1
 services:
   api:

--- a/docs/explanation/import-pipeline/inferred-topology.yaml
+++ b/docs/explanation/import-pipeline/inferred-topology.yaml
@@ -1,4 +1,4 @@
-# Inferred from 4 traces (10 spans) observed over 1 seconds
+# Inferred from 4 traces (10 spans) observed over 1.4 seconds
 # Review and adjust durations, error rates, and call probabilities as needed
 
 version: 1

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -60,7 +60,7 @@ motel run <topology.yaml | URL> [flags]
 | `--stdout` | bool | false | Emit signals to stdout as JSON instead of sending to an endpoint |
 | `--semconv` | string | | Directory of additional semantic convention YAML files |
 | `--label-scenarios` | bool | false | Add a `synth.scenarios` attribute to spans listing active scenario names |
-| `--time-offset` | duration | 0 | Shift span timestamps by this duration (e.g. `-1h` for past, `1h` for future) |
+| `--time-offset` | duration | 0 | Shift span, metric, and log timestamps by this duration (e.g. `-1h` for past, `1h` for future) |
 | `--realtime` | bool | false | Emit spans at wall-clock times matching simulated timestamps |
 | `--pprof` | string | | Start a pprof HTTP server on this address (e.g. `:6060`) |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,12 +63,14 @@ nav:
       - docs/explanation/semantic-conventions.md
       - docs/explanation/performance-profile.md
       - docs/explanation/property-testing.md
+      - docs/explanation/swarm-testing.md
   - Demos:
       - docs/demos/demo-async-calls.md
       - docs/demos/demo-backpressure.md
       - docs/demos/demo-call-topology.md
       - docs/demos/demo-cascading-failure.md
       - docs/demos/demo-check.md
+      - docs/demos/demo-checks-file.md
       - docs/demos/demo-custom-semconv.md
       - docs/demos/demo-dgg.md
       - docs/demos/demo-emit.md
@@ -78,6 +80,7 @@ nav:
       - docs/demos/demo-quickstart.md
       - docs/demos/demo-scenarios.md
       - docs/demos/demo-span-events.md
+      - docs/demos/demo-swarm-testing.md
       - docs/demos/demo-time-offset.md
       - docs/demos/demo-traffic.md
       - docs/demos/demo-url-loading.md

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -670,8 +670,10 @@ func ValidateConfig(cfg *Config) error {
 		if _, err := ParseOffset(sc.At); err != nil {
 			return fmt.Errorf("scenario %q: invalid at: %w", sc.Name, err)
 		}
-		if _, err := time.ParseDuration(sc.Duration); err != nil {
+		if dur, err := time.ParseDuration(sc.Duration); err != nil {
 			return fmt.Errorf("scenario %q: invalid duration: %w", sc.Name, err)
+		} else if dur <= 0 {
+			return fmt.Errorf("scenario %q: duration must be positive, got %q", sc.Name, sc.Duration)
 		}
 		for ref, override := range sc.Override {
 			if !knownOps[ref] {

--- a/pkg/synth/scenario.go
+++ b/pkg/synth/scenario.go
@@ -45,6 +45,9 @@ func ParseOffset(s string) (time.Duration, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid offset %q: %w", s, err)
 	}
+	if d < 0 {
+		return 0, fmt.Errorf("offset must not be negative, got %q", s)
+	}
 	return d, nil
 }
 
@@ -60,6 +63,9 @@ func BuildScenarios(cfgs []ScenarioConfig, topo *Topology) ([]Scenario, error) {
 		dur, err := time.ParseDuration(cfg.Duration)
 		if err != nil {
 			return nil, fmt.Errorf("scenario %q: invalid duration: %w", cfg.Name, err)
+		}
+		if dur <= 0 {
+			return nil, fmt.Errorf("scenario %q: duration must be positive, got %q", cfg.Name, cfg.Duration)
 		}
 
 		overrides := make(map[string]Override, len(cfg.Override))

--- a/pkg/synth/scenario_test.go
+++ b/pkg/synth/scenario_test.go
@@ -37,6 +37,7 @@ func TestParseOffset(t *testing.T) {
 		{name: "complex duration", input: "+1h30m", want: 90 * time.Minute},
 		{name: "empty", input: "", wantErr: "offset is required"},
 		{name: "invalid", input: "+xyz", wantErr: "invalid"},
+		{name: "negative", input: "-5m", wantErr: "must not be negative"},
 	}
 
 	for _, tt := range tests {
@@ -277,6 +278,21 @@ func TestBuildScenariosWithAttributes(t *testing.T) {
 	require.Contains(t, scenarios[0].Overrides, "svc.op")
 	require.NotNil(t, scenarios[0].Overrides["svc.op"].Attributes)
 	assert.NotNil(t, scenarios[0].Overrides["svc.op"].Attributes.Get("http.status"))
+}
+
+func TestBuildScenariosNonPositiveDuration(t *testing.T) {
+	t.Parallel()
+
+	for _, dur := range []string{"0s", "-5m"} {
+		cfgs := []ScenarioConfig{{
+			Name:     "bad",
+			At:       "+1m",
+			Duration: dur,
+		}}
+		_, err := BuildScenarios(cfgs, minimalTopo())
+		require.Error(t, err, "duration %q", dur)
+		assert.Contains(t, err.Error(), "duration must be positive")
+	}
 }
 
 func TestBuildScenariosInvalidAttribute(t *testing.T) {

--- a/pkg/synth/traceimport/marshal.go
+++ b/pkg/synth/traceimport/marshal.go
@@ -148,7 +148,7 @@ func MarshalConfig(collector *StatsCollector, serviceAttrs map[string]map[string
 	data := buf.Bytes()
 
 	// Prepend header comment
-	header := fmt.Sprintf("# Inferred from %d traces (%d spans) observed over %.0f seconds\n# Review and adjust durations, error rates, and call probabilities as needed\n\n",
+	header := fmt.Sprintf("# Inferred from %d traces (%d spans) observed over %.1f seconds\n# Review and adjust durations, error rates, and call probabilities as needed\n\n",
 		traceCount, spanCount, windowSecs)
 
 	return append([]byte(header), data...), nil

--- a/pkg/synth/traceimport/marshal_test.go
+++ b/pkg/synth/traceimport/marshal_test.go
@@ -33,6 +33,20 @@ func TestMarshalConfig_Basic(t *testing.T) {
 	assert.Contains(t, yaml, "env: prod")
 }
 
+func TestMarshalConfig_Header(t *testing.T) {
+	collector := NewStatsCollector()
+	svc := collector.getService("api")
+	op := collector.getOp(svc, "handle")
+	op.Durations = []time.Duration{10 * time.Millisecond}
+	op.TotalCount = 1
+
+	data, err := MarshalConfig(collector, nil, 4, 10, 1.42)
+	require.NoError(t, err)
+
+	// Window is rendered with one decimal place, not rounded to a whole number.
+	assert.Contains(t, string(data), "# Inferred from 4 traces (10 spans) observed over 1.4 seconds")
+}
+
 func TestMarshalConfig_RoundTrip(t *testing.T) {
 	collector := NewStatsCollector()
 


### PR DESCRIPTION
Review of the project for bugs, documentation issues, and unsubstantiated claims. Most of the project holds up well — `motel check`/`motel import` worked-example outputs reproduce exactly, and the Alibaba/Meta citations were verified as accurately attributed.

## Fixed

- **Scenario validation gap (bug).** `ParseOffset`/`BuildScenarios`/`ValidateConfig` accepted a negative `at` (scenario active for the entire run) and a zero/negative `duration` (window that never activates). Both are now rejected at parse/validate time, with tests.
- **Generated import header.** Printed `observed over 1 seconds` — ungrammatical, and `%.0f` rounded the real ~1.42s window down to a value inconsistent with the reported `3/s` rate. Now shows one decimal place (`1.4 seconds`); the import-pipeline worked example is updated to match.
- **mkdocs nav.** Added three existing-but-unlisted pages (`swarm-testing` explanation plus the checks-file and swarm-testing demos). `swarm-testing.md` was linked from the CLI reference but unreachable in the built site.
- **`--time-offset` reference.** Said "span timestamps" but it shifts span, metric, and log timestamps (confirmed in code).

## Not changed (flagged for discussion)

- `shutdownAll` logs exporter shutdown errors but the process still exits 0, so callers can't detect telemetry-flush loss via exit code. Left as-is since log-and-continue may be deliberate and changing the exit-code contract is a behavior change.

All tests, `go vet`, and `gofmt -s` pass.

https://claude.ai/code/session_015YmJ2nAKjoq5iGVHpc666S

---
_Generated by [Claude Code](https://claude.ai/code/session_015YmJ2nAKjoq5iGVHpc666S)_