### PR TITLE
[codex] Add import confidence diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,10 @@ docs/tutorials/     # Getting started tutorial
 ## Commits and Releases
 
 - Single task per commit, no AI attribution in commit messages
+- Use conventional commits for commit subjects
+- Single-line commit messages are forbidden except for truly trivial changes
+- Every non-trivial commit message body must reference and ideally explain every change in the commit
+- Wrap commit message body text at 80 columns
 - Tag and release only for user-visible features or bug fixes, not for lint/docs/refactoring
 - GoReleaser runs via CI on tag push — updates GitHub release and Homebrew tap automatically
 

--- a/docs/explanation/import-pipeline/README.md
+++ b/docs/explanation/import-pipeline/README.md
@@ -156,9 +156,10 @@ duration is formatted as `mean +/- stddev` (e.g. `27ms +/- 4.8ms`).
 | cache | lookup | 2 | 0 | — |
 
 `FormatErrorRate()` only emits an `error_rate` field when errors > 0.
-If an operation has fewer samples than `--min-traces`, import prints a
-confidence warning with the operation sample count and error count. The YAML
-is still emitted, but the duration and error-rate estimates need review.
+When `--min-traces` is greater than 1, import also uses it as the
+per-operation sample target. Operations below that target produce a confidence
+warning with the operation sample count and error count. The YAML is still
+emitted, but the duration and error-rate estimates need review.
 
 ### Call counts (for probability)
 
@@ -176,8 +177,10 @@ was called and how many times the parent was invoked total:
 In the YAML output, probability 1.0 is omitted (the call is listed as a
 plain string target). Probability < 1.0 is written as a mapping with an
 explicit `probability` field.
-Calls observed only a few times are reported on stderr as low-confidence
-call probability estimates.
+When `--min-traces` is greater than 1, calls observed fewer times than that
+sample target are reported on stderr as low-confidence call probability
+estimates. Calls observed every time the parent ran are not warned as
+low-confidence probabilities.
 
 ## Stage 4: Infer call style
 
@@ -199,9 +202,9 @@ Both votes are parallel, so no `call_style` field appears in the output
 would include `call_style: sequential`.
 
 Traces 2 and 4 have only one child each, so no vote is cast.
-When the vote total is small or parallel and sequential votes are mixed,
-import reports the vote counts on stderr so the inferred call style can be
-checked against the real service behaviour.
+When `--min-traces` is greater than 1, a small call-style vote total or a
+meaningful minority vote reports the vote counts on stderr so the inferred
+call style can be checked against the real service behaviour.
 
 ## Stage 5: Detect service attributes
 
@@ -242,12 +245,13 @@ The rate is formatted as `3/s` in the traffic section.
 Before writing YAML, import reviews the collected statistics for weak
 evidence:
 
-- operations below `--min-traces`, including the observed error count
-- downstream calls observed only a few times
-- call-style inference with few votes or mixed parallel/sequential evidence
+- operations below the `--min-traces` sample target, including the observed error count
+- downstream calls observed fewer times than that target
+- call-style inference with few votes or meaningfully mixed parallel/sequential evidence
 
 Diagnostics are written to stderr as warnings. They do not make the import
-fail and they are not included in redirected topology YAML.
+fail and they are not included in redirected topology YAML. With the default
+`--min-traces=1`, only the existing trace-count warnings are emitted.
 
 ## Stage 8: Marshal to YAML
 

--- a/docs/explanation/import-pipeline/README.md
+++ b/docs/explanation/import-pipeline/README.md
@@ -156,6 +156,9 @@ duration is formatted as `mean +/- stddev` (e.g. `27ms +/- 4.8ms`).
 | cache | lookup | 2 | 0 | — |
 
 `FormatErrorRate()` only emits an `error_rate` field when errors > 0.
+If an operation has fewer samples than `--min-traces`, import prints a
+confidence warning with the operation sample count and error count. The YAML
+is still emitted, but the duration and error-rate estimates need review.
 
 ### Call counts (for probability)
 
@@ -173,6 +176,8 @@ was called and how many times the parent was invoked total:
 In the YAML output, probability 1.0 is omitted (the call is listed as a
 plain string target). Probability < 1.0 is written as a mapping with an
 explicit `probability` field.
+Calls observed only a few times are reported on stderr as low-confidence
+call probability estimates.
 
 ## Stage 4: Infer call style
 
@@ -194,6 +199,9 @@ Both votes are parallel, so no `call_style` field appears in the output
 would include `call_style: sequential`.
 
 Traces 2 and 4 have only one child each, so no vote is cast.
+When the vote total is small or parallel and sequential votes are mixed,
+import reports the vote counts on stderr so the inferred call style can be
+checked against the real service behaviour.
 
 ## Stage 5: Detect service attributes
 
@@ -227,7 +235,21 @@ The traffic rate is calculated from root span timestamps:
 
 The rate is formatted as `3/s` in the traffic section.
 
-## Stage 7: Marshal to YAML
+## Stage 7: Report confidence diagnostics
+
+**Code**: `diagnostics.go` → `ReportConfidenceDiagnostics()`
+
+Before writing YAML, import reviews the collected statistics for weak
+evidence:
+
+- operations below `--min-traces`, including the observed error count
+- downstream calls observed only a few times
+- call-style inference with few votes or mixed parallel/sequential evidence
+
+Diagnostics are written to stderr as warnings. They do not make the import
+fail and they are not included in redirected topology YAML.
+
+## Stage 8: Marshal to YAML
 
 **Code**: `marshal.go` → `MarshalConfig()`
 
@@ -266,7 +288,7 @@ traffic:
 Note: no `call_style` field appears because all votes were parallel
 (the default).
 
-## Stage 8: Round-trip validation
+## Stage 9: Round-trip validation
 
 **Code**: `infer.go` → `validateRoundTrip()`
 

--- a/docs/how-to/model-your-services.md
+++ b/docs/how-to/model-your-services.md
@@ -127,7 +127,7 @@ motel run --stdout --duration 30s topology.yaml > traces.jsonl
 cat exported-traces.json
 ```
 
-More traces produce better statistical accuracy. The import command warns if you have fewer traces than `--min-traces` (default: 1), and it also prints confidence diagnostics when individual operations, downstream calls, or call-style votes are based on small samples.
+More traces produce better statistical accuracy. The import command warns if the input has fewer traces than `--min-traces` (default: 1). When you raise `--min-traces`, import also uses that value as the sample target for per-operation, downstream-call, and call-style confidence diagnostics.
 
 ### 2. Run import
 
@@ -158,7 +158,7 @@ The inferred topology is a starting point, not a finished product. Review it for
 - **Duration distributions** — import calculates mean and standard deviation from the observed spans. Check that these match your expectations.
 - **Error rates** — derived from the proportion of error spans. Small sample sizes produce noisy estimates.
 - **Call style** — import votes on parallel vs sequential based on child span timing overlap. Verify this matches your service's actual behaviour.
-- **Confidence diagnostics** — warnings list operations below the requested sample count, downstream calls observed only a few times, and weak or mixed call-style votes. Treat these as review prompts, not validation failures.
+- **Confidence diagnostics** — warnings list operations below the requested sample target, downstream calls observed fewer times than the target, and weak or mixed call-style votes. Treat these as review prompts, not validation failures.
 - **Missing services** — import can only infer what it sees. If some call paths are rare, they may not appear in a small sample.
 
 Validate the inferred topology and generate traces from it:

--- a/docs/how-to/model-your-services.md
+++ b/docs/how-to/model-your-services.md
@@ -127,7 +127,7 @@ motel run --stdout --duration 30s topology.yaml > traces.jsonl
 cat exported-traces.json
 ```
 
-More traces produce better statistical accuracy. The import command warns if you have fewer traces than `--min-traces` (default: 1).
+More traces produce better statistical accuracy. The import command warns if you have fewer traces than `--min-traces` (default: 1), and it also prints confidence diagnostics when individual operations, downstream calls, or call-style votes are based on small samples.
 
 ### 2. Run import
 
@@ -145,7 +145,11 @@ The output is a YAML topology written to stdout. Redirect it to a file:
 motel import traces.jsonl > inferred-topology.yaml
 ```
 
-The generated YAML includes a comment header noting how many traces and spans were analysed.
+The generated YAML includes a comment header noting how many traces and spans were analysed. Confidence diagnostics are written to stderr, so redirecting stdout still produces a valid topology file:
+
+```sh
+motel import --min-traces 20 traces.jsonl > inferred-topology.yaml
+```
 
 ### 3. Review and adjust
 
@@ -154,6 +158,7 @@ The inferred topology is a starting point, not a finished product. Review it for
 - **Duration distributions** — import calculates mean and standard deviation from the observed spans. Check that these match your expectations.
 - **Error rates** — derived from the proportion of error spans. Small sample sizes produce noisy estimates.
 - **Call style** — import votes on parallel vs sequential based on child span timing overlap. Verify this matches your service's actual behaviour.
+- **Confidence diagnostics** — warnings list operations below the requested sample count, downstream calls observed only a few times, and weak or mixed call-style votes. Treat these as review prompts, not validation failures.
 - **Missing services** — import can only infer what it sees. If some call paths are rare, they may not appear in a small sample.
 
 Validate the inferred topology and generate traces from it:

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -176,6 +176,7 @@ Reads trace spans and generates a YAML topology. If no file is given, reads from
 The `auto` format detector examines the JSON structure to determine whether the input is stdouttrace JSON (one span per line), OTLP JSON (batched export format), or Jaeger JSON such as Grafana Explore Tempo downloads.
 
 Output is written to stdout as a YAML topology with a commented header noting how many traces and spans were analysed.
+Confidence diagnostics are written to stderr when inferred operations, downstream call probabilities, or call-style votes are based on weak evidence. Redirecting stdout still produces valid YAML suitable for `motel validate`.
 
 ### preview
 

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -176,7 +176,7 @@ Reads trace spans and generates a YAML topology. If no file is given, reads from
 The `auto` format detector examines the JSON structure to determine whether the input is stdouttrace JSON (one span per line), OTLP JSON (batched export format), or Jaeger JSON such as Grafana Explore Tempo downloads.
 
 Output is written to stdout as a YAML topology with a commented header noting how many traces and spans were analysed.
-Confidence diagnostics are written to stderr when inferred operations, downstream call probabilities, or call-style votes are based on weak evidence. Redirecting stdout still produces valid YAML suitable for `motel validate`.
+When `--min-traces` is greater than 1, confidence diagnostics are written to stderr when inferred operations, downstream call probabilities, or call-style votes are based on weak evidence relative to that sample target. Redirecting stdout still produces valid YAML suitable for `motel validate`.
 
 ### preview
 

--- a/pkg/synth/traceimport/diagnostics.go
+++ b/pkg/synth/traceimport/diagnostics.go
@@ -1,0 +1,80 @@
+package traceimport
+
+import (
+	"fmt"
+	"io"
+	"sort"
+)
+
+const (
+	lowConfidenceCallObservations = 3
+	lowConfidenceCallStyleVotes   = 3
+)
+
+func reportConfidenceDiagnostics(collector *StatsCollector, minSamples int, w io.Writer) {
+	if collector == nil || w == nil {
+		return
+	}
+	if minSamples < 1 {
+		minSamples = 1
+	}
+
+	for _, svcName := range sortedServiceNames(collector.Services) {
+		svc := collector.Services[svcName]
+		for _, opName := range sortedOpNames(svc.Ops) {
+			op := svc.Ops[opName]
+			ref := svcName + "." + opName
+			if op.TotalCount < minSamples {
+				_, _ = fmt.Fprintf(w, "warning: import confidence: %s has %d samples below requested minimum %d; duration and error_rate estimates may be noisy (errors=%d)\n",
+					ref, op.TotalCount, minSamples, op.ErrorCount)
+			}
+			for _, target := range sortedCallTargets(op.Calls) {
+				cs := op.Calls[target]
+				if cs.Count <= lowConfidenceCallObservations {
+					_, _ = fmt.Fprintf(w, "warning: import confidence: %s -> %s observed %d times across %d parent samples; inferred call probability needs review\n",
+						ref, target, cs.Count, op.TotalCount)
+				}
+			}
+			vote, ok := svc.CallStyles[opName]
+			if !ok {
+				continue
+			}
+			totalVotes := vote.Parallel + vote.Sequential
+			if totalVotes <= lowConfidenceCallStyleVotes || vote.Parallel > 0 && vote.Sequential > 0 {
+				style := "parallel"
+				if vote.Sequential > vote.Parallel {
+					style = "sequential"
+				}
+				_, _ = fmt.Fprintf(w, "warning: import confidence: %s call_style inferred as %s from parallel=%d sequential=%d votes; verify weak or mixed evidence\n",
+					ref, style, vote.Parallel, vote.Sequential)
+			}
+		}
+	}
+}
+
+func sortedServiceNames(services map[string]*ServiceStats) []string {
+	names := make([]string, 0, len(services))
+	for name := range services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedOpNames(ops map[string]*OpStats) []string {
+	names := make([]string, 0, len(ops))
+	for name := range ops {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedCallTargets(calls map[string]*CallStats) []string {
+	targets := make([]string, 0, len(calls))
+	for target := range calls {
+		targets = append(targets, target)
+	}
+	sort.Strings(targets)
+	return targets
+}

--- a/pkg/synth/traceimport/diagnostics.go
+++ b/pkg/synth/traceimport/diagnostics.go
@@ -3,13 +3,9 @@ package traceimport
 import (
 	"fmt"
 	"io"
-	"sort"
 )
 
-const (
-	lowConfidenceCallObservations = 3
-	lowConfidenceCallStyleVotes   = 3
-)
+const mixedCallStyleVoteRatio = 0.2
 
 func reportConfidenceDiagnostics(collector *StatsCollector, minSamples int, w io.Writer) {
 	if collector == nil || w == nil {
@@ -19,18 +15,18 @@ func reportConfidenceDiagnostics(collector *StatsCollector, minSamples int, w io
 		minSamples = 1
 	}
 
-	for _, svcName := range sortedServiceNames(collector.Services) {
+	for _, svcName := range sortedStringKeys(collector.Services) {
 		svc := collector.Services[svcName]
-		for _, opName := range sortedOpNames(svc.Ops) {
+		for _, opName := range sortedStringKeys(svc.Ops) {
 			op := svc.Ops[opName]
 			ref := svcName + "." + opName
 			if op.TotalCount < minSamples {
-				_, _ = fmt.Fprintf(w, "warning: import confidence: %s has %d samples below requested minimum %d; duration and error_rate estimates may be noisy (errors=%d)\n",
+				_, _ = fmt.Fprintf(w, "warning: import confidence: %s has %d operation samples below requested target %d from --min-traces; duration and error_rate estimates may be noisy (errors=%d)\n",
 					ref, op.TotalCount, minSamples, op.ErrorCount)
 			}
-			for _, target := range sortedCallTargets(op.Calls) {
+			for _, target := range sortedStringKeys(op.Calls) {
 				cs := op.Calls[target]
-				if cs.Count <= lowConfidenceCallObservations {
+				if minSamples > 1 && cs.Count < minSamples && cs.Count < op.TotalCount {
 					_, _ = fmt.Fprintf(w, "warning: import confidence: %s -> %s observed %d times across %d parent samples; inferred call probability needs review\n",
 						ref, target, cs.Count, op.TotalCount)
 				}
@@ -40,7 +36,7 @@ func reportConfidenceDiagnostics(collector *StatsCollector, minSamples int, w io
 				continue
 			}
 			totalVotes := vote.Parallel + vote.Sequential
-			if totalVotes <= lowConfidenceCallStyleVotes || vote.Parallel > 0 && vote.Sequential > 0 {
+			if minSamples > 1 && (totalVotes < minSamples || hasMixedCallStyleEvidence(vote)) {
 				style := "parallel"
 				if vote.Sequential > vote.Parallel {
 					style = "sequential"
@@ -52,29 +48,14 @@ func reportConfidenceDiagnostics(collector *StatsCollector, minSamples int, w io
 	}
 }
 
-func sortedServiceNames(services map[string]*ServiceStats) []string {
-	names := make([]string, 0, len(services))
-	for name := range services {
-		names = append(names, name)
+func hasMixedCallStyleEvidence(vote *CallStyleVote) bool {
+	total := vote.Parallel + vote.Sequential
+	if total == 0 || vote.Parallel == 0 || vote.Sequential == 0 {
+		return false
 	}
-	sort.Strings(names)
-	return names
-}
-
-func sortedOpNames(ops map[string]*OpStats) []string {
-	names := make([]string, 0, len(ops))
-	for name := range ops {
-		names = append(names, name)
+	minority := vote.Parallel
+	if vote.Sequential < minority {
+		minority = vote.Sequential
 	}
-	sort.Strings(names)
-	return names
-}
-
-func sortedCallTargets(calls map[string]*CallStats) []string {
-	targets := make([]string, 0, len(calls))
-	for target := range calls {
-		targets = append(targets, target)
-	}
-	sort.Strings(targets)
-	return targets
+	return float64(minority)/float64(total) >= mixedCallStyleVoteRatio
 }

--- a/pkg/synth/traceimport/diagnostics_test.go
+++ b/pkg/synth/traceimport/diagnostics_test.go
@@ -33,7 +33,7 @@ func TestReportConfidenceDiagnostics(t *testing.T) {
 	reportConfidenceDiagnostics(collector, 5, &warnings)
 
 	out := warnings.String()
-	assert.Contains(t, out, "api.handle has 2 samples below requested minimum 5")
+	assert.Contains(t, out, "api.handle has 2 operation samples below requested target 5 from --min-traces")
 	assert.Contains(t, out, "errors=1")
 	assert.Contains(t, out, "api.handle -> cache.lookup observed 1 times across 2 parent samples")
 	assert.Contains(t, out, "api.handle call_style inferred as parallel from parallel=1 sequential=1 votes")
@@ -55,6 +55,80 @@ func TestReportConfidenceDiagnostics_SkipsStrongEvidence(t *testing.T) {
 				},
 				CallStyles: map[string]*CallStyleVote{
 					"handle": {Parallel: 6},
+				},
+			},
+		},
+	}
+
+	var warnings bytes.Buffer
+	reportConfidenceDiagnostics(collector, 5, &warnings)
+
+	assert.Empty(t, warnings.String())
+}
+
+func TestReportConfidenceDiagnostics_DefaultMinTracesSkipsCallAndStyleWarnings(t *testing.T) {
+	t.Parallel()
+
+	collector := &StatsCollector{
+		Services: map[string]*ServiceStats{
+			"api": {
+				Ops: map[string]*OpStats{
+					"handle": {
+						TotalCount: 2,
+						Calls: map[string]*CallStats{
+							"cache.lookup": {Count: 1},
+						},
+					},
+				},
+				CallStyles: map[string]*CallStyleVote{
+					"handle": {Parallel: 1},
+				},
+			},
+		},
+	}
+
+	var warnings bytes.Buffer
+	reportConfidenceDiagnostics(collector, 1, &warnings)
+
+	assert.Empty(t, warnings.String())
+}
+
+func TestReportConfidenceDiagnostics_SkipsAlwaysOnCalls(t *testing.T) {
+	t.Parallel()
+
+	collector := &StatsCollector{
+		Services: map[string]*ServiceStats{
+			"api": {
+				Ops: map[string]*OpStats{
+					"handle": {
+						TotalCount: 2,
+						Calls: map[string]*CallStats{
+							"database.query": {Count: 2},
+						},
+					},
+				},
+				CallStyles: map[string]*CallStyleVote{},
+			},
+		},
+	}
+
+	var warnings bytes.Buffer
+	reportConfidenceDiagnostics(collector, 3, &warnings)
+
+	assert.NotContains(t, warnings.String(), "api.handle -> database.query")
+}
+
+func TestReportConfidenceDiagnostics_SkipsTinyCallStyleMinority(t *testing.T) {
+	t.Parallel()
+
+	collector := &StatsCollector{
+		Services: map[string]*ServiceStats{
+			"api": {
+				Ops: map[string]*OpStats{
+					"handle": {TotalCount: 100},
+				},
+				CallStyles: map[string]*CallStyleVote{
+					"handle": {Parallel: 99, Sequential: 1},
 				},
 			},
 		},

--- a/pkg/synth/traceimport/diagnostics_test.go
+++ b/pkg/synth/traceimport/diagnostics_test.go
@@ -1,0 +1,67 @@
+package traceimport
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReportConfidenceDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	collector := &StatsCollector{
+		Services: map[string]*ServiceStats{
+			"api": {
+				Ops: map[string]*OpStats{
+					"handle": {
+						ErrorCount: 1,
+						TotalCount: 2,
+						Calls: map[string]*CallStats{
+							"cache.lookup": {Count: 1},
+						},
+					},
+				},
+				CallStyles: map[string]*CallStyleVote{
+					"handle": {Parallel: 1, Sequential: 1},
+				},
+			},
+		},
+	}
+
+	var warnings bytes.Buffer
+	reportConfidenceDiagnostics(collector, 5, &warnings)
+
+	out := warnings.String()
+	assert.Contains(t, out, "api.handle has 2 samples below requested minimum 5")
+	assert.Contains(t, out, "errors=1")
+	assert.Contains(t, out, "api.handle -> cache.lookup observed 1 times across 2 parent samples")
+	assert.Contains(t, out, "api.handle call_style inferred as parallel from parallel=1 sequential=1 votes")
+}
+
+func TestReportConfidenceDiagnostics_SkipsStrongEvidence(t *testing.T) {
+	t.Parallel()
+
+	collector := &StatsCollector{
+		Services: map[string]*ServiceStats{
+			"api": {
+				Ops: map[string]*OpStats{
+					"handle": {
+						TotalCount: 10,
+						Calls: map[string]*CallStats{
+							"database.query": {Count: 10},
+						},
+					},
+				},
+				CallStyles: map[string]*CallStyleVote{
+					"handle": {Parallel: 6},
+				},
+			},
+		},
+	}
+
+	var warnings bytes.Buffer
+	reportConfidenceDiagnostics(collector, 5, &warnings)
+
+	assert.Empty(t, warnings.String())
+}

--- a/pkg/synth/traceimport/infer.go
+++ b/pkg/synth/traceimport/infer.go
@@ -50,6 +50,7 @@ func Import(r io.Reader, opts Options) ([]byte, error) {
 	// Step 3: Collect statistics
 	collector := NewStatsCollector()
 	collector.CollectFromTrees(trees)
+	reportConfidenceDiagnostics(collector, opts.MinTraces, opts.Warnings)
 
 	// Step 4: Infer service-level constant attributes
 	serviceAttrs := inferServiceAttributes(spans)

--- a/pkg/synth/traceimport/marshal.go
+++ b/pkg/synth/traceimport/marshal.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"sort"
 
 	"github.com/andrewh/motel/pkg/synth"
 	"gopkg.in/yaml.v3"
@@ -45,14 +44,7 @@ func MarshalConfig(collector *StatsCollector, serviceAttrs map[string]map[string
 		Traffic:  make(map[string]string),
 	}
 
-	// Sort service names for deterministic output
-	svcNames := make([]string, 0, len(collector.Services))
-	for name := range collector.Services {
-		svcNames = append(svcNames, name)
-	}
-	sort.Strings(svcNames)
-
-	for _, svcName := range svcNames {
+	for _, svcName := range sortedStringKeys(collector.Services) {
 		svcStats := collector.Services[svcName]
 		svc := inferredService{
 			Operations: make(map[string]inferredOperation),
@@ -62,13 +54,7 @@ func MarshalConfig(collector *StatsCollector, serviceAttrs map[string]map[string
 			svc.ResourceAttributes = attrs
 		}
 
-		opNames := make([]string, 0, len(svcStats.Ops))
-		for name := range svcStats.Ops {
-			opNames = append(opNames, name)
-		}
-		sort.Strings(opNames)
-
-		for _, opName := range opNames {
+		for _, opName := range sortedStringKeys(svcStats.Ops) {
 			opStats := svcStats.Ops[opName]
 			op := inferredOperation{
 				Duration:  FormatDuration(opStats.Durations),
@@ -84,13 +70,7 @@ func MarshalConfig(collector *StatsCollector, serviceAttrs map[string]map[string
 
 			// Calls
 			if len(opStats.Calls) > 0 {
-				callTargets := make([]string, 0, len(opStats.Calls))
-				for target := range opStats.Calls {
-					callTargets = append(callTargets, target)
-				}
-				sort.Strings(callTargets)
-
-				for _, target := range callTargets {
+				for _, target := range sortedStringKeys(opStats.Calls) {
 					cs := opStats.Calls[target]
 					prob := 1.0
 					if opStats.TotalCount > 0 {

--- a/pkg/synth/traceimport/sort.go
+++ b/pkg/synth/traceimport/sort.go
@@ -1,0 +1,12 @@
+package traceimport
+
+import "sort"
+
+func sortedStringKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
## Summary

Adds confidence diagnostics to `motel import` so inferred topologies surface weak statistical evidence without changing the generated YAML format.

- reports operations whose sample count is below `--min-traces`, including observed error counts
- reports downstream calls observed only a few times so inferred probabilities are easier to review
- reports weak or mixed call-style vote evidence with parallel and sequential vote counts
- documents how to interpret the warnings and confirms redirected stdout remains valid topology YAML

Closes https://github.com/andrewh/motel/issues/183

## Validation

- `go test ./pkg/synth/traceimport ./cmd/motel`
- `make test`
- `make lint`
- `make build`
- `build/motel import --min-traces 5 docs/explanation/import-pipeline/traces.jsonl > /private/tmp/motel-issue-183-inferred.yaml 2> /private/tmp/motel-issue-183-warnings.txt`
- `build/motel validate /private/tmp/motel-issue-183-inferred.yaml`
