### PR TITLE
fix: address Go best-practices review findings

### DIFF
--- a/pkg/synth/logs.go
+++ b/pkg/synth/logs.go
@@ -309,7 +309,7 @@ func interpolateBody(body string, logAttrs map[string]any, info SpanInfo) string
 		}
 		for _, kv := range info.Attrs {
 			if string(kv.Key) == key {
-				return kv.Value.Emit()
+				return kv.Value.String()
 			}
 		}
 		switch key {

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -265,11 +265,10 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 				op.Links = append(op.Links, linkOp)
 			}
 			for _, callCfg := range opCfg.Calls {
-				targetSvc, targetOp, err := resolveRef(topo, callCfg.Target)
+				_, targetOp, err := resolveRef(topo, callCfg.Target)
 				if err != nil {
 					return nil, fmt.Errorf("service %q operation %q: %w", svcCfg.Name, opCfg.Name, err)
 				}
-				_ = targetSvc
 				call := Call{
 					Operation:   targetOp,
 					Probability: callCfg.Probability,

--- a/tools/dgg2motel/main.go
+++ b/tools/dgg2motel/main.go
@@ -103,7 +103,12 @@ func main() {
 			return nil
 		}
 
-		rel, _ := filepath.Rel(*dirFlag, path)
+		rel, err := filepath.Rel(*dirFlag, path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "skip %s: %v\n", path, err)
+			skipped++
+			return nil
+		}
 		outPath := filepath.Join(*outFlag, strings.TrimSuffix(rel, ".json")+".yaml")
 		if err := writeFile(outPath, yaml); err != nil {
 			return err


### PR DESCRIPTION
## Summary

Implements the genuine findings from a Go community best-practices review of the codebase. `gofmt`, `go vet`, `staticcheck`, and `go test ./...` were already clean apart from these items; after this change `staticcheck` is fully clean on production code.

## Changes

- **`pkg/synth/logs.go`** — replace deprecated `otel` log `Value.Emit()` with `Value.String()` (staticcheck `SA1019`).
- **`pkg/synth/topology.go`** — drop the dead `_ = targetSvc` assignment by discarding the unused return value from `resolveRef` directly.
- **`tools/dgg2motel/main.go`** — handle the previously discarded error from `filepath.Rel`, skipping the file consistently with the surrounding per-file error handling.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `staticcheck ./...` — clean on production code
- `go test ./...` — passing

## Notes

The broader review surfaced several automated-tool flags that turned out to be **false positives** and were intentionally left unchanged, including: the `wg.Go` / loop-variable "capture" concerns (correct under Go 1.25), the `//nolint:gosec` on `uint64`→`int64` timestamp conversion in `traceimport/span.go` (legitimately suppressing gosec G115), the `UnmarshalYAML` "missing doc comments" (they already exist), and the `rate.go` error wrapping (already uses `%w`).

https://claude.ai/code/session_016P9RjM4UKzFYWXyUxq2k7o

---
_Generated by [Claude Code](https://claude.ai/code/session_016P9RjM4UKzFYWXyUxq2k7o)_