### PR TITLE
[codex] Add Meta trace summary import workflow

### DIFF
--- a/docs/research/empirical-validation.md
+++ b/docs/research/empirical-validation.md
@@ -64,6 +64,8 @@ Huye et al. characterise Meta's request workflows as wide and shallow at the
 aggregation tier; Du et al. quantify children set sizes of up to 50 at Meta
 (versus 1–10 at Alibaba). The modelled topology is a feed-style workflow with
 an aggregator fanning out to 40 ranking leaves plus cache and metadata calls.
+For the public ATC 2023 summary data import workflow, see
+[meta-trace-import.md](meta-trace-import.md).
 
 | Published metric   | Reported value           | Modelled in topology | check agrees |
 | ------------------ | ------------------------ | -------------------- | ------------ |

--- a/docs/research/meta-trace-import.md
+++ b/docs/research/meta-trace-import.md
@@ -1,0 +1,140 @@
+# Importing the Meta ATC 2023 Trace Summary Data
+
+Issue 93 asks whether `motel import` can ingest the public Meta distributed
+trace dataset released with Huye, Shkuro, and Sambasivan's USENIX ATC 2023
+paper. The public repository is useful for this, but it does not publish raw
+span exports. It publishes summary CSVs and a notebook that reproduces the
+paper's figures.
+
+This note records the current import path: convert a representative subset of
+`parent-data.csv.gz` into motel's `stdouttrace` JSON, import it, validate the
+resulting topology, and compare the imported topology against the metrics in
+the released summary data.
+
+## Source Data
+
+Repository: <https://github.com/facebookresearch/distributed_traces>
+
+License: CC BY-NC 4.0. Do not vendor the dataset into this repository. Download
+it during reproduction and preserve attribution if sharing derived artifacts.
+
+The upstream `summary_data_atc23/data/` directory currently contains:
+
+| File | Compressed size | Uncompressed size or row count | Role |
+| ---- | --------------- | ------------------------------ | ---- |
+| `trace-data.csv.gz` | 15 MB | 104 MB, 6,589,078 rows | One row per trace with `trace_size`, `num_services`, `call_depth`, `max_width`, and `profile` |
+| `parent-data.csv.gz` | 18 MB | 1.16 GB, 40,200,091 rows | One row per parent invocation with `parent_name`, `children_set`, call counts, concurrency, and `profile` |
+| `service-characteristics.csv` | 568 KB | 18,571 rows | One row per service on 2022-12-21 with fan-in, fan-out, and instance counts |
+| `service-endpoints.csv` | 231 KB | 13,030 rows | Thrift endpoint counts for services that communicate using Thrift RPC |
+| `service-history.csv` | 32 KB | 659 rows | Service and instance counts over time |
+| `inferred-path-data.csv` | 1.4 KB | 37 rows | Percent of paths ending at inferred services by depth and profile |
+
+The upstream notebook defines `parent-data.csv.gz` as one row per invocation of
+a parent ingress id. The row has a `children_set`, but no original trace id,
+span id, parent span id, timestamp, or duration. Because of that, the public
+data cannot be imported as raw traces directly.
+
+## Converter
+
+`tools/meta2stdouttrace` turns `parent-data.csv.gz` into `stdouttrace` JSON.
+Each selected parent invocation becomes one synthetic trace:
+
+- the parent ingress id becomes the root span
+- each entry in `children_set` becomes a child span
+- `concurrency_rate > 0` starts child spans in parallel; otherwise children are
+  sequenced
+- `meta.ingress_id`, `meta.profile`, `meta.num_calls`,
+  `meta.num_returning_calls`, and `meta.concurrency_rate` are preserved as span
+  attributes
+
+This is an ingestion harness, not a reconstruction of the original Meta traces.
+It proves that `motel import` can ingest a converted subset of the released
+public data and infer a valid topology from the parent-child observations. It
+does not reproduce the paper's full workflow depth because the released
+parent-data rows are not linked back into complete traces.
+
+## Reproduction
+
+Download the parent invocation data:
+
+```sh
+mkdir -p /tmp/motel-meta
+curl -L -o /tmp/motel-meta/parent-data.csv.gz \
+  https://raw.githubusercontent.com/facebookresearch/distributed_traces/main/summary_data_atc23/data/parent-data.csv.gz
+```
+
+Generate a deterministic 1,000-invocation Ads-profile sample:
+
+```sh
+go run ./tools/meta2stdouttrace \
+  -input /tmp/motel-meta/parent-data.csv.gz \
+  -profile ads \
+  -limit 1000 \
+  > /tmp/motel-meta/ads-parent-sample.jsonl
+```
+
+Build motel and import the sample:
+
+```sh
+make build
+build/motel import --format stdouttrace --min-traces 100 \
+  /tmp/motel-meta/ads-parent-sample.jsonl \
+  > /tmp/motel-meta/ads-parent-sample.yaml
+```
+
+Confidence warnings are expected with a 1,000-row subset because many inferred
+operations and call probabilities have fewer than 100 samples.
+
+Validate and analyze the imported topology:
+
+```sh
+build/motel validate /tmp/motel-meta/ads-parent-sample.yaml
+build/motel check --seed 42 /tmp/motel-meta/ads-parent-sample.yaml
+```
+
+Verified locally on 2026-06-14:
+
+```text
+Configuration valid: 130 services, 55 root operations
+
+PASS  max-depth: 1 (limit: 10)
+      path: meta-00986.invoke -> meta-aajb.invoke
+      p50: 1  p95: 1  p99: 1  max: 1  (1000 samples)
+PASS  max-fan-out: 22 (limit: 100)
+      worst: meta-00986-00076.invoke
+      p50: 2  p95: 7  p99: 22  max: 22  (1000 samples)
+PASS  max-spans: 23 static worst-case, 23 observed/1000 samples (limit: 10000)
+      p50: 3  p95: 8  p99: 23  max: 23  (1000 samples)
+```
+
+## Comparison
+
+The public summary data reports substantially larger production-scale
+structure than the 1,000-invocation import sample:
+
+| Metric | Released summary data | Imported subset |
+| ------ | --------------------- | --------------- |
+| Service-like entities | 18,571 services in `service-characteristics.csv` | 130 ingress-id services |
+| Trace or invocation rows | 6,589,078 trace rows; 40,200,091 parent invocation rows | 1,000 parent invocation traces |
+| Maximum workflow depth | 19 in `trace-data.csv.gz` | 1 |
+| Maximum width or fan-out | 166,171 max trace width; 5,865 service fan-out | 22 max child spans |
+| Maximum spans per trace | 1,702,486 `trace_size` | 23 |
+
+The depth mismatch is expected. `parent-data.csv.gz` gives isolated
+parent-to-children observations, so the converter can validate import of wide
+local fan-out but cannot reconstruct multi-hop workflows. The trace-level CSV
+does contain the published depth, width, and trace-size distributions, but not
+the span records needed by `motel import`.
+
+## Follow-Up Work
+
+- Add a native summary-data path that produces a topology directly from
+  `parent-data.csv.gz`, preserving parent call probabilities without first
+  materializing synthetic span JSON.
+- Add an importer mode or separate tool for large streaming inputs. The current
+  trace importer reads the whole input and caps it at 256 MB, while a full
+  synthetic expansion of 40.2 million parent invocations would be much larger.
+- Investigate whether Meta can publish raw trace exports or trace identifiers
+  that link `parent-data.csv.gz` rows back into complete workflows. That would
+  allow `motel import` to validate the paper's depth and span-count
+  distributions directly rather than through one-hop parent samples.

--- a/docs/research/related-work.md
+++ b/docs/research/related-work.md
@@ -32,6 +32,8 @@ but from production traces rather than a model.
   request workflow structure. Released public trace data.
   [USENIX](https://www.usenix.org/conference/atc23/presentation/huye) |
   [PDF](https://www.usenix.org/system/files/atc23-huye.pdf)
+  See [meta-trace-import.md](meta-trace-import.md) for the current motel import
+  workflow against the released summary data.
 
 - Luo et al., "Characterizing Microservice Dependency and Performance: Alibaba
   Trace Analysis," _ACM Symposium on Cloud Computing (SoCC)_, 2021. Earlier

--- a/tools/meta2stdouttrace/main.go
+++ b/tools/meta2stdouttrace/main.go
@@ -24,6 +24,26 @@ const (
 	defaultStartTime      = "2022-12-21T00:00:00Z"
 	rootParentSpanID      = "0000000000000000"
 	operationName         = "invoke"
+	spanIDTraceShift      = 32
+	rootSpanOrdinal       = uint64(0)
+)
+
+const (
+	columnParentName        = "parent_name"
+	columnChildrenSet       = "children_set"
+	columnNumCalls          = "num_calls"
+	columnNumReturningCalls = "num_returning_calls"
+	columnConcurrencyRate   = "concurrency_rate"
+	columnProfile           = "profile"
+)
+
+const (
+	attrMetaIngressID         = "meta.ingress_id"
+	attrMetaProfile           = "meta.profile"
+	attrMetaNumCalls          = "meta.num_calls"
+	attrMetaNumReturningCalls = "meta.num_returning_calls"
+	attrMetaConcurrencyRate   = "meta.concurrency_rate"
+	attrServiceName           = "service.name"
 )
 
 type options struct {
@@ -37,9 +57,9 @@ type options struct {
 type parentRow struct {
 	parentName        string
 	children          []string
-	numCalls          string
-	numReturningCalls string
-	concurrencyRate   string
+	numCalls          int
+	numReturningCalls int
+	concurrencyRate   float64
 	profile           string
 }
 
@@ -128,7 +148,14 @@ func run(w io.Writer, opts options) error {
 		return fmt.Errorf("read header: %w", err)
 	}
 	cols := indexHeader(header)
-	required := []string{"parent_name", "children_set", "num_calls", "num_returning_calls", "concurrency_rate", "profile"}
+	required := []string{
+		columnParentName,
+		columnChildrenSet,
+		columnNumCalls,
+		columnNumReturningCalls,
+		columnConcurrencyRate,
+		columnProfile,
+	}
 	for _, name := range required {
 		if _, ok := cols[name]; !ok {
 			return fmt.Errorf("missing required column %q", name)
@@ -139,14 +166,14 @@ func run(w io.Writer, opts options) error {
 	emitted := 0
 	rowNumber := 1
 	for {
+		rowNumber++
 		record, err := reader.Read()
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("read row %d: %w", rowNumber+1, err)
+			return fmt.Errorf("read row %d: %w", rowNumber, err)
 		}
-		rowNumber++
 
 		row, err := parseParentRow(record, cols)
 		if err != nil {
@@ -217,18 +244,48 @@ func indexHeader(header []string) map[string]int {
 }
 
 func parseParentRow(record []string, cols map[string]int) (parentRow, error) {
-	children, err := parseChildrenSet(record[cols["children_set"]])
+	children, err := parseChildrenSet(record[cols[columnChildrenSet]])
+	if err != nil {
+		return parentRow{}, err
+	}
+	numCalls, err := parseIntColumn(record, cols, columnNumCalls)
+	if err != nil {
+		return parentRow{}, err
+	}
+	numReturningCalls, err := parseIntColumn(record, cols, columnNumReturningCalls)
+	if err != nil {
+		return parentRow{}, err
+	}
+	concurrencyRate, err := parseFloatColumn(record, cols, columnConcurrencyRate)
 	if err != nil {
 		return parentRow{}, err
 	}
 	return parentRow{
-		parentName:        record[cols["parent_name"]],
+		parentName:        record[cols[columnParentName]],
 		children:          children,
-		numCalls:          record[cols["num_calls"]],
-		numReturningCalls: record[cols["num_returning_calls"]],
-		concurrencyRate:   record[cols["concurrency_rate"]],
-		profile:           record[cols["profile"]],
+		numCalls:          numCalls,
+		numReturningCalls: numReturningCalls,
+		concurrencyRate:   concurrencyRate,
+		profile:           record[cols[columnProfile]],
 	}, nil
+}
+
+func parseIntColumn(record []string, cols map[string]int, name string) (int, error) {
+	value := record[cols[name]]
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s %q: %w", name, value, err)
+	}
+	return n, nil
+}
+
+func parseFloatColumn(record []string, cols map[string]int, name string) (float64, error) {
+	value := record[cols[name]]
+	n, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s %q: %w", name, value, err)
+	}
+	return n, nil
 }
 
 func parseChildrenSet(value string) ([]string, error) {
@@ -253,8 +310,9 @@ func parseChildrenSet(value string) ([]string, error) {
 }
 
 func invocationEvents(row parentRow, index int, start time.Time) []stdouttraceEvent {
-	traceID := fmt.Sprintf("%032x", index+1)
-	rootSpanID := fmt.Sprintf("%016x", (index+1)<<16)
+	traceOrdinal := uint64(index) + 1
+	traceID := fmt.Sprintf("%032x", traceOrdinal)
+	rootSpanID := spanID(traceOrdinal, rootSpanOrdinal)
 	rootService := serviceName(row.parentName)
 	parentDuration := defaultParentDuration + time.Duration(len(row.children))*defaultChildDuration
 
@@ -265,13 +323,13 @@ func invocationEvents(row parentRow, index int, start time.Time) []stdouttraceEv
 		StartTime:   start,
 		EndTime:     start.Add(parentDuration),
 		Attributes: []sdkAttr{
-			stringAttr("meta.ingress_id", row.parentName),
-			stringAttr("meta.profile", row.profile),
-			stringAttr("meta.num_calls", row.numCalls),
-			stringAttr("meta.num_returning_calls", row.numReturningCalls),
-			stringAttr("meta.concurrency_rate", row.concurrencyRate),
+			stringAttr(attrMetaIngressID, row.parentName),
+			stringAttr(attrMetaProfile, row.profile),
+			stringAttr(attrMetaNumCalls, strconv.Itoa(row.numCalls)),
+			stringAttr(attrMetaNumReturningCalls, strconv.Itoa(row.numReturningCalls)),
+			stringAttr(attrMetaConcurrencyRate, strconv.FormatFloat(row.concurrencyRate, 'g', -1, 64)),
 		},
-		Resource:             []sdkAttr{stringAttr("service.name", rootService)},
+		Resource:             []sdkAttr{stringAttr(attrServiceName, rootService)},
 		Status:               sdkStatus{Code: "Unset"},
 		InstrumentationScope: sdkScope{Name: rootService},
 	}}
@@ -285,15 +343,15 @@ func invocationEvents(row parentRow, index int, start time.Time) []stdouttraceEv
 		childService := serviceName(child)
 		events = append(events, stdouttraceEvent{
 			Name:        operationName,
-			SpanContext: spanContext{TraceID: traceID, SpanID: fmt.Sprintf("%016x", ((index+1)<<16)+i+1)},
+			SpanContext: spanContext{TraceID: traceID, SpanID: spanID(traceOrdinal, uint64(i)+1)},
 			Parent:      spanContext{TraceID: traceID, SpanID: rootSpanID},
 			StartTime:   childStart,
 			EndTime:     childStart.Add(defaultChildDuration),
 			Attributes: []sdkAttr{
-				stringAttr("meta.ingress_id", child),
-				stringAttr("meta.profile", row.profile),
+				stringAttr(attrMetaIngressID, child),
+				stringAttr(attrMetaProfile, row.profile),
 			},
-			Resource:             []sdkAttr{stringAttr("service.name", childService)},
+			Resource:             []sdkAttr{stringAttr(attrServiceName, childService)},
 			Status:               sdkStatus{Code: "Unset"},
 			InstrumentationScope: sdkScope{Name: childService},
 		})
@@ -301,9 +359,12 @@ func invocationEvents(row parentRow, index int, start time.Time) []stdouttraceEv
 	return events
 }
 
-func isConcurrent(value string) bool {
-	rate, err := strconv.ParseFloat(value, 64)
-	return err == nil && rate > 0
+func spanID(traceOrdinal uint64, childOrdinal uint64) string {
+	return fmt.Sprintf("%016x", traceOrdinal<<spanIDTraceShift|childOrdinal)
+}
+
+func isConcurrent(rate float64) bool {
+	return rate > 0
 }
 
 func serviceName(ingressID string) string {

--- a/tools/meta2stdouttrace/main.go
+++ b/tools/meta2stdouttrace/main.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"compress/gzip"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	defaultLimit          = 1000
+	defaultParentDuration = 5 * time.Millisecond
+	defaultChildDuration  = time.Millisecond
+	defaultTraceSpacing   = 10 * time.Millisecond
+	defaultStartTime      = "2022-12-21T00:00:00Z"
+	rootParentSpanID      = "0000000000000000"
+	operationName         = "invoke"
+)
+
+type options struct {
+	input        string
+	limit        int
+	profile      string
+	includeEmpty bool
+	start        time.Time
+}
+
+type parentRow struct {
+	parentName        string
+	children          []string
+	numCalls          string
+	numReturningCalls string
+	concurrencyRate   string
+	profile           string
+}
+
+type stdouttraceEvent struct {
+	Name                 string      `json:"Name"`
+	SpanContext          spanContext `json:"SpanContext"`
+	Parent               spanContext `json:"Parent"`
+	StartTime            time.Time   `json:"StartTime"`
+	EndTime              time.Time   `json:"EndTime"`
+	Attributes           []sdkAttr   `json:"Attributes,omitempty"`
+	Resource             []sdkAttr   `json:"Resource,omitempty"`
+	Status               sdkStatus   `json:"Status"`
+	InstrumentationScope sdkScope    `json:"InstrumentationScope"`
+}
+
+type spanContext struct {
+	TraceID string `json:"TraceID"`
+	SpanID  string `json:"SpanID"`
+}
+
+type sdkAttr struct {
+	Key   string   `json:"Key"`
+	Value sdkValue `json:"Value"`
+}
+
+type sdkValue struct {
+	Type  string `json:"Type"`
+	Value any    `json:"Value"`
+}
+
+type sdkStatus struct {
+	Code string `json:"Code"`
+}
+
+type sdkScope struct {
+	Name string `json:"Name"`
+}
+
+func main() {
+	opts, err := parseFlags()
+	if err != nil {
+		fatal(err)
+	}
+	if err := run(os.Stdout, opts); err != nil {
+		fatal(err)
+	}
+}
+
+func parseFlags() (options, error) {
+	input := flag.String("input", "", "path to summary_data_atc23/data/parent-data.csv.gz")
+	limit := flag.Int("limit", defaultLimit, "maximum parent invocations to emit after filtering")
+	profile := flag.String("profile", "", "optional trace profile filter: ads, fetch, or raas")
+	includeEmpty := flag.Bool("include-empty", false, "include parent invocations with an empty children_set")
+	startValue := flag.String("start", defaultStartTime, "base timestamp for synthetic spans")
+	flag.Parse()
+
+	if *input == "" {
+		return options{}, errors.New("-input is required")
+	}
+	if *limit < 1 {
+		return options{}, errors.New("-limit must be positive")
+	}
+	start, err := time.Parse(time.RFC3339, *startValue)
+	if err != nil {
+		return options{}, fmt.Errorf("parse -start: %w", err)
+	}
+	return options{
+		input:        *input,
+		limit:        *limit,
+		profile:      *profile,
+		includeEmpty: *includeEmpty,
+		start:        start,
+	}, nil
+}
+
+func run(w io.Writer, opts options) error {
+	rc, err := openInput(opts.input)
+	if err != nil {
+		return err
+	}
+	defer rc.Close() //nolint:errcheck // read-only input
+
+	reader := csv.NewReader(rc)
+	header, err := reader.Read()
+	if err != nil {
+		return fmt.Errorf("read header: %w", err)
+	}
+	cols := indexHeader(header)
+	required := []string{"parent_name", "children_set", "num_calls", "num_returning_calls", "concurrency_rate", "profile"}
+	for _, name := range required {
+		if _, ok := cols[name]; !ok {
+			return fmt.Errorf("missing required column %q", name)
+		}
+	}
+
+	enc := json.NewEncoder(w)
+	emitted := 0
+	rowNumber := 1
+	for {
+		record, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read row %d: %w", rowNumber+1, err)
+		}
+		rowNumber++
+
+		row, err := parseParentRow(record, cols)
+		if err != nil {
+			return fmt.Errorf("parse row %d: %w", rowNumber, err)
+		}
+		if opts.profile != "" && row.profile != opts.profile {
+			continue
+		}
+		if !opts.includeEmpty && len(row.children) == 0 {
+			continue
+		}
+
+		traceStart := opts.start.Add(time.Duration(emitted) * defaultTraceSpacing)
+		events := invocationEvents(row, emitted, traceStart)
+		for _, event := range events {
+			if err := enc.Encode(event); err != nil {
+				return fmt.Errorf("write span: %w", err)
+			}
+		}
+		emitted++
+		if emitted >= opts.limit {
+			break
+		}
+	}
+	if emitted == 0 {
+		return errors.New("no parent invocations matched the requested filters")
+	}
+	return nil
+}
+
+func openInput(path string) (io.ReadCloser, error) {
+	f, err := os.Open(path) //nolint:gosec // user-supplied input path
+	if err != nil {
+		return nil, fmt.Errorf("open input: %w", err)
+	}
+	if !strings.HasSuffix(path, ".gz") {
+		return f, nil
+	}
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("open gzip stream: %w", err)
+	}
+	return combinedReadCloser{Reader: gz, closers: []io.Closer{gz, f}}, nil
+}
+
+type combinedReadCloser struct {
+	io.Reader
+	closers []io.Closer
+}
+
+func (c combinedReadCloser) Close() error {
+	var closeErr error
+	for _, closer := range c.closers {
+		if err := closer.Close(); err != nil && closeErr == nil {
+			closeErr = err
+		}
+	}
+	return closeErr
+}
+
+func indexHeader(header []string) map[string]int {
+	cols := make(map[string]int, len(header))
+	for i, name := range header {
+		cols[name] = i
+	}
+	return cols
+}
+
+func parseParentRow(record []string, cols map[string]int) (parentRow, error) {
+	children, err := parseChildrenSet(record[cols["children_set"]])
+	if err != nil {
+		return parentRow{}, err
+	}
+	return parentRow{
+		parentName:        record[cols["parent_name"]],
+		children:          children,
+		numCalls:          record[cols["num_calls"]],
+		numReturningCalls: record[cols["num_returning_calls"]],
+		concurrencyRate:   record[cols["concurrency_rate"]],
+		profile:           record[cols["profile"]],
+	}, nil
+}
+
+func parseChildrenSet(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "set()" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(value, "{") || !strings.HasSuffix(value, "}") {
+		return nil, fmt.Errorf("children_set %q is not a Python set literal", value)
+	}
+	parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(value, "{"), "}"), ",")
+	children := make([]string, 0, len(parts))
+	for _, part := range parts {
+		child := strings.Trim(strings.TrimSpace(part), `'"`)
+		if child == "" {
+			continue
+		}
+		children = append(children, child)
+	}
+	sort.Strings(children)
+	return children, nil
+}
+
+func invocationEvents(row parentRow, index int, start time.Time) []stdouttraceEvent {
+	traceID := fmt.Sprintf("%032x", index+1)
+	rootSpanID := fmt.Sprintf("%016x", (index+1)<<16)
+	rootService := serviceName(row.parentName)
+	parentDuration := defaultParentDuration + time.Duration(len(row.children))*defaultChildDuration
+
+	events := []stdouttraceEvent{{
+		Name:        operationName,
+		SpanContext: spanContext{TraceID: traceID, SpanID: rootSpanID},
+		Parent:      spanContext{TraceID: traceID, SpanID: rootParentSpanID},
+		StartTime:   start,
+		EndTime:     start.Add(parentDuration),
+		Attributes: []sdkAttr{
+			stringAttr("meta.ingress_id", row.parentName),
+			stringAttr("meta.profile", row.profile),
+			stringAttr("meta.num_calls", row.numCalls),
+			stringAttr("meta.num_returning_calls", row.numReturningCalls),
+			stringAttr("meta.concurrency_rate", row.concurrencyRate),
+		},
+		Resource:             []sdkAttr{stringAttr("service.name", rootService)},
+		Status:               sdkStatus{Code: "Unset"},
+		InstrumentationScope: sdkScope{Name: rootService},
+	}}
+
+	parallel := isConcurrent(row.concurrencyRate)
+	for i, child := range row.children {
+		childStart := start.Add(defaultChildDuration)
+		if !parallel {
+			childStart = childStart.Add(time.Duration(i) * defaultChildDuration)
+		}
+		childService := serviceName(child)
+		events = append(events, stdouttraceEvent{
+			Name:        operationName,
+			SpanContext: spanContext{TraceID: traceID, SpanID: fmt.Sprintf("%016x", ((index+1)<<16)+i+1)},
+			Parent:      spanContext{TraceID: traceID, SpanID: rootSpanID},
+			StartTime:   childStart,
+			EndTime:     childStart.Add(defaultChildDuration),
+			Attributes: []sdkAttr{
+				stringAttr("meta.ingress_id", child),
+				stringAttr("meta.profile", row.profile),
+			},
+			Resource:             []sdkAttr{stringAttr("service.name", childService)},
+			Status:               sdkStatus{Code: "Unset"},
+			InstrumentationScope: sdkScope{Name: childService},
+		})
+	}
+	return events
+}
+
+func isConcurrent(value string) bool {
+	rate, err := strconv.ParseFloat(value, 64)
+	return err == nil && rate > 0
+}
+
+func serviceName(ingressID string) string {
+	var b strings.Builder
+	b.WriteString("meta-")
+	lastHyphen := false
+	for _, r := range strings.ToLower(ingressID) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+			lastHyphen = false
+		case !lastHyphen:
+			b.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	return strings.TrimSuffix(b.String(), "-")
+}
+
+func stringAttr(key, value string) sdkAttr {
+	return sdkAttr{
+		Key: key,
+		Value: sdkValue{
+			Type:  "STRING",
+			Value: value,
+		},
+	}
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/tools/meta2stdouttrace/main_test.go
+++ b/tools/meta2stdouttrace/main_test.go
@@ -8,7 +8,32 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/andrewh/motel/pkg/synth/traceimport"
 )
+
+func writeGzipCSV(t *testing.T, lines []string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	input := filepath.Join(dir, "parent-data.csv.gz")
+	f, err := os.Create(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gz := gzip.NewWriter(f)
+	_, err = gz.Write([]byte(strings.Join(lines, "\n")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return input
+}
 
 func TestParseChildrenSet(t *testing.T) {
 	tests := []struct {
@@ -40,14 +65,60 @@ func TestParseChildrenSetRejectsUnexpectedFormat(t *testing.T) {
 	}
 }
 
+func TestParseParentRowParsesNumericFields(t *testing.T) {
+	header := []string{
+		columnParentName,
+		columnChildrenSet,
+		columnNumCalls,
+		columnNumReturningCalls,
+		columnConcurrencyRate,
+		columnProfile,
+	}
+	record := []string{"10382-00001", "{'AAJB'}", "5", "4", "0.5", "ads"}
+
+	row, err := parseParentRow(record, indexHeader(header))
+	if err != nil {
+		t.Fatalf("parseParentRow() error = %v", err)
+	}
+	if row.numCalls != 5 {
+		t.Fatalf("numCalls = %d, want 5", row.numCalls)
+	}
+	if row.numReturningCalls != 4 {
+		t.Fatalf("numReturningCalls = %d, want 4", row.numReturningCalls)
+	}
+	if row.concurrencyRate != 0.5 {
+		t.Fatalf("concurrencyRate = %v, want 0.5", row.concurrencyRate)
+	}
+}
+
+func TestParseParentRowRejectsInvalidNumericField(t *testing.T) {
+	header := []string{
+		columnParentName,
+		columnChildrenSet,
+		columnNumCalls,
+		columnNumReturningCalls,
+		columnConcurrencyRate,
+		columnProfile,
+	}
+	record := []string{"10382-00001", "{'AAJB'}", "five", "4", "0.5", "ads"}
+
+	_, err := parseParentRow(record, indexHeader(header))
+	if err == nil {
+		t.Fatal("parseParentRow() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), columnNumCalls) {
+		t.Fatalf("parseParentRow() error = %v, want %q", err, columnNumCalls)
+	}
+}
+
 func TestInvocationEvents(t *testing.T) {
 	start := time.Date(2022, 12, 21, 0, 0, 0, 0, time.UTC)
 	row := parentRow{
 		parentName:        "10382-00001",
 		children:          []string{"AAJB", "ABAC"},
-		numCalls:          "5",
-		numReturningCalls: "4",
-		concurrencyRate:   "0.5",
+		numCalls:          5,
+		numReturningCalls: 4,
+		concurrencyRate:   0.5,
 		profile:           "ads",
 	}
 
@@ -64,35 +135,86 @@ func TestInvocationEvents(t *testing.T) {
 	if !events[1].StartTime.Equal(events[2].StartTime) {
 		t.Fatalf("concurrent children start at %s and %s", events[1].StartTime, events[2].StartTime)
 	}
+	if events[0].Attributes[2].Value.Value != "5" {
+		t.Fatalf("num_calls attribute = %v, want 5", events[0].Attributes[2].Value.Value)
+	}
+}
+
+func TestInvocationEventsRootParentImportsAsEmpty(t *testing.T) {
+	start := time.Date(2022, 12, 21, 0, 0, 0, 0, time.UTC)
+	events := invocationEvents(parentRow{
+		parentName:        "10382-00001",
+		numCalls:          5,
+		numReturningCalls: 4,
+		concurrencyRate:   0,
+		profile:           "ads",
+	}, 0, start)
+
+	var out strings.Builder
+	if err := json.NewEncoder(&out).Encode(events[0]); err != nil {
+		t.Fatalf("encode event: %v", err)
+	}
+	spans, err := traceimport.ParseSpans(strings.NewReader(out.String()), traceimport.FormatStdouttrace)
+	if err != nil {
+		t.Fatalf("ParseSpans() error = %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("len(spans) = %d, want 1", len(spans))
+	}
+	if spans[0].ParentID != "" {
+		t.Fatalf("root ParentID = %q, want empty", spans[0].ParentID)
+	}
+}
+
+func TestSpanIDUsesUint64Layout(t *testing.T) {
+	tests := []struct {
+		traceOrdinal uint64
+		childOrdinal uint64
+		want         string
+	}{
+		{traceOrdinal: 1, childOrdinal: 0, want: "0000000100000000"},
+		{traceOrdinal: 1, childOrdinal: 1, want: "0000000100000001"},
+		{traceOrdinal: 2, childOrdinal: 0, want: "0000000200000000"},
+	}
+
+	for _, tt := range tests {
+		got := spanID(tt.traceOrdinal, tt.childOrdinal)
+		if got != tt.want {
+			t.Fatalf("spanID(%d, %d) = %q, want %q", tt.traceOrdinal, tt.childOrdinal, got, tt.want)
+		}
+	}
+}
+
+func TestServiceNameNormalizesIngressID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "AAJB", want: "meta-aajb"},
+		{input: "A..B__", want: "meta-a-b"},
+		{input: "10382-00001", want: "meta-10382-00001"},
+		{input: "\u03a3 Worker", want: "meta-\u03c3-worker"},
+	}
+
+	for _, tt := range tests {
+		got := serviceName(tt.input)
+		if got != tt.want {
+			t.Fatalf("serviceName(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
 }
 
 func TestRunConvertsParentData(t *testing.T) {
-	dir := t.TempDir()
-	input := filepath.Join(dir, "parent-data.csv.gz")
-	f, err := os.Create(input)
-	if err != nil {
-		t.Fatal(err)
-	}
-	gz := gzip.NewWriter(f)
-	_, err = gz.Write([]byte(strings.Join([]string{
+	input := writeGzipCSV(t, []string{
 		"parent_name,children_set,c_set_index,num_calls,num_returning_calls,concurrency_rate,profile",
 		"00001-00001,set(),1,0,0,0.0,ads",
 		"10382-00001,\"{'AAJB', 'ABAC'}\",2,5,4,0.5,ads",
 		"20400-00001,{'AACD'},1,1,1,0.0,fetch",
 		"",
-	}, "\n")))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := gz.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
+	})
 
 	var out strings.Builder
-	err = run(&out, options{
+	err := run(&out, options{
 		input:   input,
 		limit:   1,
 		profile: "ads",
@@ -112,5 +234,58 @@ func TestRunConvertsParentData(t *testing.T) {
 	}
 	if event.Attributes[1].Value.Value != "ads" {
 		t.Fatalf("profile attribute = %v, want ads", event.Attributes[1].Value.Value)
+	}
+}
+
+func TestRunIncludesEmptyParents(t *testing.T) {
+	input := writeGzipCSV(t, []string{
+		"parent_name,children_set,c_set_index,num_calls,num_returning_calls,concurrency_rate,profile",
+		"00001-00001,set(),1,0,0,0.0,ads",
+		"10382-00001,\"{'AAJB', 'ABAC'}\",2,5,4,0.5,ads",
+		"",
+	})
+
+	var out strings.Builder
+	err := run(&out, options{
+		input:        input,
+		limit:        1,
+		profile:      "ads",
+		includeEmpty: true,
+		start:        time.Date(2022, 12, 21, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("got %d JSON lines, want 1", len(lines))
+	}
+	var event stdouttraceEvent
+	if err := json.Unmarshal([]byte(lines[0]), &event); err != nil {
+		t.Fatalf("unmarshal first event: %v", err)
+	}
+	if event.Resource[0].Value.Value != "meta-00001-00001" {
+		t.Fatalf("service.name = %v, want meta-00001-00001", event.Resource[0].Value.Value)
+	}
+}
+
+func TestRunReportsParseDataRowNumber(t *testing.T) {
+	input := writeGzipCSV(t, []string{
+		"parent_name,children_set,c_set_index,num_calls,num_returning_calls,concurrency_rate,profile",
+		"10382-00001,not-a-set,1,5,4,0.5,ads",
+		"",
+	})
+
+	err := run(&strings.Builder{}, options{
+		input: input,
+		limit: 1,
+		start: time.Date(2022, 12, 21, 0, 0, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("run() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "parse row 2") {
+		t.Fatalf("run() error = %v, want parse row 2", err)
 	}
 }

--- a/tools/meta2stdouttrace/main_test.go
+++ b/tools/meta2stdouttrace/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseChildrenSet(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "empty set", input: "set()", want: nil},
+		{name: "single child", input: "{'AACD'}", want: []string{"AACD"}},
+		{name: "sorted children", input: "{'AAJB', 'ABAC'}", want: []string{"AAJB", "ABAC"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseChildrenSet(tt.input)
+			if err != nil {
+				t.Fatalf("parseChildrenSet() error = %v", err)
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Fatalf("parseChildrenSet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseChildrenSetRejectsUnexpectedFormat(t *testing.T) {
+	if _, err := parseChildrenSet("['AACD']"); err == nil {
+		t.Fatal("parseChildrenSet() error = nil, want error")
+	}
+}
+
+func TestInvocationEvents(t *testing.T) {
+	start := time.Date(2022, 12, 21, 0, 0, 0, 0, time.UTC)
+	row := parentRow{
+		parentName:        "10382-00001",
+		children:          []string{"AAJB", "ABAC"},
+		numCalls:          "5",
+		numReturningCalls: "4",
+		concurrencyRate:   "0.5",
+		profile:           "ads",
+	}
+
+	events := invocationEvents(row, 0, start)
+	if len(events) != 3 {
+		t.Fatalf("len(events) = %d, want 3", len(events))
+	}
+	if events[0].Resource[0].Value.Value != "meta-10382-00001" {
+		t.Fatalf("root service = %v, want meta-10382-00001", events[0].Resource[0].Value.Value)
+	}
+	if events[1].Parent.SpanID != events[0].SpanContext.SpanID {
+		t.Fatalf("child parent span = %q, want %q", events[1].Parent.SpanID, events[0].SpanContext.SpanID)
+	}
+	if !events[1].StartTime.Equal(events[2].StartTime) {
+		t.Fatalf("concurrent children start at %s and %s", events[1].StartTime, events[2].StartTime)
+	}
+}
+
+func TestRunConvertsParentData(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "parent-data.csv.gz")
+	f, err := os.Create(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gz := gzip.NewWriter(f)
+	_, err = gz.Write([]byte(strings.Join([]string{
+		"parent_name,children_set,c_set_index,num_calls,num_returning_calls,concurrency_rate,profile",
+		"00001-00001,set(),1,0,0,0.0,ads",
+		"10382-00001,\"{'AAJB', 'ABAC'}\",2,5,4,0.5,ads",
+		"20400-00001,{'AACD'},1,1,1,0.0,fetch",
+		"",
+	}, "\n")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	err = run(&out, options{
+		input:   input,
+		limit:   1,
+		profile: "ads",
+		start:   time.Date(2022, 12, 21, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d JSON lines, want 3", len(lines))
+	}
+	var event stdouttraceEvent
+	if err := json.Unmarshal([]byte(lines[0]), &event); err != nil {
+		t.Fatalf("unmarshal first event: %v", err)
+	}
+	if event.Attributes[1].Value.Value != "ads" {
+		t.Fatalf("profile attribute = %v, want ads", event.Attributes[1].Value.Value)
+	}
+}


### PR DESCRIPTION
## Summary

- add `tools/meta2stdouttrace` to convert Meta ATC 2023 `parent-data.csv.gz`
  summary rows into motel-compatible `stdouttrace` JSON
- document the public dataset source, format, license constraints, subset import
  workflow, validation results, and comparison with released summary metrics
- link the new workflow from the existing research docs

## Validation

- `make lint`
- `make test`
- `make build`
- `go run ./tools/meta2stdouttrace -input /private/tmp/motel-issue93/parent-data.csv.gz -profile ads -limit 1000 > /private/tmp/motel-issue93/ads-parent-sample.jsonl`
- `build/motel import --format stdouttrace --min-traces 100 /private/tmp/motel-issue93/ads-parent-sample.jsonl > /private/tmp/motel-issue93/ads-parent-sample.yaml`
- `build/motel validate /private/tmp/motel-issue93/ads-parent-sample.yaml`
- `build/motel check --seed 42 /private/tmp/motel-issue93/ads-parent-sample.yaml`

## Notes

Related issue: https://github.com/andrewh/motel/issues/93

Follow-up limitations captured in:

- https://github.com/andrewh/motel/issues/191
- https://github.com/andrewh/motel/issues/192
