### PR TITLE
[codex] Support Meta summary imports

### DIFF
--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -380,14 +380,16 @@ func validateCmd() *cobra.Command {
 
 func importCmd() *cobra.Command {
 	var (
-		format    string
-		minTraces int
+		format           string
+		minTraces        int
+		metaProfile      string
+		metaIncludeEmpty bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "import [file]",
 		Short: "Import a topology config from trace data",
-		Long:  "Reads trace spans (stdouttrace, OTLP JSON, or Jaeger JSON) and generates a synth YAML topology config.",
+		Long:  "Reads trace spans or supported summary data and generates a synth YAML topology config.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var r io.Reader = os.Stdin
@@ -401,9 +403,11 @@ func importCmd() *cobra.Command {
 			}
 
 			yamlBytes, err := traceimport.Import(r, traceimport.Options{
-				Format:    traceimport.Format(format),
-				MinTraces: minTraces,
-				Warnings:  cmd.ErrOrStderr(),
+				Format:           traceimport.Format(format),
+				MinTraces:        minTraces,
+				Warnings:         cmd.ErrOrStderr(),
+				MetaProfile:      metaProfile,
+				MetaIncludeEmpty: metaIncludeEmpty,
 			})
 			if err != nil {
 				if strings.Contains(err.Error(), "no spans found") {
@@ -417,8 +421,10 @@ func importCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&format, "format", "auto", "input format: auto, stdouttrace, otlp, or jaeger (Jaeger JSON, including Grafana Explore Tempo downloads)")
+	cmd.Flags().StringVar(&format, "format", "auto", "input format: auto, stdouttrace, otlp, jaeger, or meta-summary (Meta ATC 2023 parent-data.csv)")
 	cmd.Flags().IntVar(&minTraces, "min-traces", 1, "minimum traces for statistical accuracy (warns if fewer)")
+	cmd.Flags().StringVar(&metaProfile, "profile", "", "profile filter for --format meta-summary: ads, fetch, or raas")
+	cmd.Flags().BoolVar(&metaIncludeEmpty, "include-empty", false, "include empty children_set rows for --format meta-summary")
 
 	return cmd
 }

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -972,6 +972,29 @@ func TestImportCommand(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, stderr.String(), "only 1 trace")
 	})
+
+	t.Run("meta summary format", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "parent-data.csv")
+		input := strings.Join([]string{
+			"parent_name,children_set,num_calls,num_returning_calls,concurrency_rate,profile",
+			`root,"{'childA', 'childB'}",2,2,1,ads`,
+			`root,"{'fetchOnly'}",1,1,0,fetch`,
+		}, "\n")
+		require.NoError(t, os.WriteFile(path, []byte(input), 0o600))
+
+		root := rootCmd()
+		root.SetArgs([]string{"import", "--format", "meta-summary", "--profile", "ads", path})
+		var out bytes.Buffer
+		root.SetOut(&out)
+
+		err := root.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, out.String(), "meta-root:")
+		assert.Contains(t, out.String(), "meta-childa.invoke")
+		assert.NotContains(t, out.String(), "meta-fetchonly")
+	})
 }
 
 func TestRunStdoutImportRoundTrip(t *testing.T) {

--- a/cmd/motel/main_test.go
+++ b/cmd/motel/main_test.go
@@ -991,9 +991,11 @@ func TestImportCommand(t *testing.T) {
 
 		err := root.Execute()
 		require.NoError(t, err)
-		assert.Contains(t, out.String(), "meta-root:")
-		assert.Contains(t, out.String(), "meta-childa.invoke")
-		assert.NotContains(t, out.String(), "meta-fetchonly")
+		assert.Contains(t, out.String(), "meta-root-")
+		assert.Contains(t, out.String(), "meta-childa-")
+		assert.Contains(t, out.String(), "meta.ingress_id: root")
+		assert.Contains(t, out.String(), "meta.ingress_id: childA")
+		assert.NotContains(t, out.String(), "meta.ingress_id: fetchOnly")
 	})
 }
 

--- a/docs/how-to/model-your-services.md
+++ b/docs/how-to/model-your-services.md
@@ -146,6 +146,9 @@ directly instead of expanding it to synthetic spans:
 motel import --format meta-summary --profile ads parent-data.csv.gz > meta-topology.yaml
 ```
 
+For full-size local import and comparison commands, see
+[Importing the Meta ATC 2023 Trace Summary Data](../research/meta-trace-import.md).
+
 The output is a YAML topology written to stdout. Redirect it to a file:
 
 ```sh

--- a/docs/how-to/model-your-services.md
+++ b/docs/how-to/model-your-services.md
@@ -139,6 +139,13 @@ motel import traces.jsonl
 cat traces.jsonl | motel import
 ```
 
+For the Meta ATC 2023 public summary dataset, import `parent-data.csv.gz`
+directly instead of expanding it to synthetic spans:
+
+```sh
+motel import --format meta-summary --profile ads parent-data.csv.gz > meta-topology.yaml
+```
+
 The output is a YAML topology written to stdout. Redirect it to a file:
 
 ```sh

--- a/docs/man/man1/motel.1
+++ b/docs/man/man1/motel.1
@@ -109,6 +109,9 @@ no file is given. Output is a YAML topology written to stdout.
 \fIauto\fR|\fIstdouttrace\fR|\fIotlp\fR|\fIjaeger\fR|\fImeta\-summary\fR
 Input format (default: auto). The auto detector examines the first JSON object.
 Use \fImeta\-summary\fR for Meta ATC 2023 parent-data.csv or parent-data.csv.gz.
+Meta ingress ids are emitted as collision-resistant \fImeta-<slug>-<hash>\fR
+service names, with the exact upstream id preserved in the
+\fImeta.ingress_id\fR resource attribute.
 .TP
 .B \-\-include\-empty
 Include empty children_set rows for \fB\-\-format meta\-summary\fR.

--- a/docs/man/man1/motel.1
+++ b/docs/man/man1/motel.1
@@ -11,8 +11,10 @@ motel \- synthetic OpenTelemetry generator
 \fItopology.yaml\fR | \fIURL\fR
 .PP
 .B motel import
-[\fB\-\-format\fR \fIauto\fR|\fIstdouttrace\fR|\fIotlp\fR]
+[\fB\-\-format\fR \fIauto\fR|\fIstdouttrace\fR|\fIotlp\fR|\fIjaeger\fR|\fImeta\-summary\fR]
+[\fB\-\-include\-empty\fR]
 [\fB\-\-min\-traces\fR \fIN\fR]
+[\fB\-\-profile\fR \fIprofile\fR]
 [\fIfile\fR]
 .PP
 .B motel check
@@ -104,12 +106,20 @@ Infer a topology from existing trace data. Reads from \fIfile\fR or stdin if
 no file is given. Output is a YAML topology written to stdout.
 .TP
 .B \-\-format
-\fIauto\fR|\fIstdouttrace\fR|\fIotlp\fR
-Input format (default: auto). The auto detector examines the first line.
+\fIauto\fR|\fIstdouttrace\fR|\fIotlp\fR|\fIjaeger\fR|\fImeta\-summary\fR
+Input format (default: auto). The auto detector examines the first JSON object.
+Use \fImeta\-summary\fR for Meta ATC 2023 parent-data.csv or parent-data.csv.gz.
+.TP
+.B \-\-include\-empty
+Include empty children_set rows for \fB\-\-format meta\-summary\fR.
 .TP
 .B \-\-min\-traces
 \fIN\fR
 Minimum traces for statistical accuracy; warns if fewer (default: 1).
+.TP
+.B \-\-profile
+\fIprofile\fR
+Profile filter for \fB\-\-format meta\-summary\fR: ads, fetch, or raas.
 .SS check
 Run structural checks on a topology. Computes worst\-case trace depth,
 fan\-out per span, and total spans per trace using static graph analysis,

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -180,7 +180,9 @@ Use `--format meta-summary` to import the Meta ATC 2023
 `summary_data_atc23/data/parent-data.csv.gz` file directly. This path streams
 plain CSV or gzip input, applies the optional `--profile` filter, and infers
 call probabilities and sequential/parallel call style from `children_set` and
-`concurrency_rate`.
+`concurrency_rate`. Meta ingress ids are emitted as collision-resistant
+`meta-<slug>-<hash>` service names, with the exact upstream id preserved in the
+`meta.ingress_id` resource attribute.
 
 Output is written to stdout as a YAML topology with a commented header noting how many traces and spans were analysed.
 When `--min-traces` is greater than 1, confidence diagnostics are written to stderr when inferred operations, downstream call probabilities, or call-style votes are based on weak evidence relative to that sample target. Redirecting stdout still produces valid YAML suitable for `motel validate`.

--- a/docs/reference/synth.md
+++ b/docs/reference/synth.md
@@ -166,14 +166,21 @@ Infer a topology from existing trace data.
 motel import [file] [flags]
 ```
 
-Reads trace spans and generates a YAML topology. If no file is given, reads from stdin.
+Reads trace spans or supported summary data and generates a YAML topology. If no file is given, reads from stdin.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--format` | string | `auto` | Input format: `auto`, `stdouttrace`, `otlp`, or `jaeger` |
+| `--format` | string | `auto` | Input format: `auto`, `stdouttrace`, `otlp`, `jaeger`, or `meta-summary` |
+| `--include-empty` | bool | false | Include empty `children_set` rows for `--format meta-summary` |
 | `--min-traces` | int | 1 | Minimum traces for statistical accuracy (warns if fewer) |
+| `--profile` | string |  | Profile filter for `--format meta-summary`: `ads`, `fetch`, or `raas` |
 
 The `auto` format detector examines the JSON structure to determine whether the input is stdouttrace JSON (one span per line), OTLP JSON (batched export format), or Jaeger JSON such as Grafana Explore Tempo downloads.
+Use `--format meta-summary` to import the Meta ATC 2023
+`summary_data_atc23/data/parent-data.csv.gz` file directly. This path streams
+plain CSV or gzip input, applies the optional `--profile` filter, and infers
+call probabilities and sequential/parallel call style from `children_set` and
+`concurrency_rate`.
 
 Output is written to stdout as a YAML topology with a commented header noting how many traces and spans were analysed.
 When `--min-traces` is greater than 1, confidence diagnostics are written to stderr when inferred operations, downstream call probabilities, or call-style votes are based on weak evidence relative to that sample target. Redirecting stdout still produces valid YAML suitable for `motel validate`.

--- a/docs/research/meta-trace-import.md
+++ b/docs/research/meta-trace-import.md
@@ -43,10 +43,12 @@ parent operation sample and one child operation sample per entry in
 
 - the parent and child ingress ids become `meta-*` services with an `invoke`
   operation
-- downstream call probability is inferred from how often each child appears
-  for a parent ingress id
+- `num_calls` weights downstream call probability so high-volume
+  `(parent_name, children_set)` rows contribute more than rare rows
+- `num_returning_calls` estimates the parent operation `error_rate` from calls
+  that did not return
 - `concurrency_rate > 0` votes for parallel call style; otherwise multi-child
-  rows vote for sequential call style
+  rows vote for sequential call style, again weighted by `num_calls`
 - `--profile ads|fetch|raas` filters rows by the released profile column
 - empty `children_set` rows are skipped unless `--include-empty` is set
 
@@ -292,8 +294,9 @@ Use the `trace-data.csv.gz` numbers to compare published full-workflow depth,
 width, trace size, and services per trace against the one-hop topology inferred
 from `parent-data.csv.gz`. Use the `parent-data.csv.gz` summary and
 `motel check` output to inspect local parent fan-out and generated trace size.
-The generated topology is expected to preserve parent-child probabilities from
-the summary data, but it cannot recover the original multi-hop workflows.
+The generated topology is expected to preserve `num_calls`-weighted
+parent-child probabilities from the summary data, but it cannot recover the
+original multi-hop workflows.
 
 ## Comparison
 

--- a/docs/research/meta-trace-import.md
+++ b/docs/research/meta-trace-import.md
@@ -111,7 +111,7 @@ build/motel import --format stdouttrace --min-traces 100 \
 Confidence warnings are expected with a 1,000-row subset because many inferred
 operations and call probabilities have fewer than 100 samples.
 
-Validate and analyze the imported topology:
+Validate and analyze the subset topology:
 
 ```sh
 build/motel validate /tmp/motel-meta/ads-parent-sample.yaml
@@ -132,6 +132,168 @@ PASS  max-fan-out: 22 (limit: 100)
 PASS  max-spans: 23 static worst-case, 23 observed/1000 samples (limit: 10000)
       p50: 3  p95: 8  p99: 23  max: 23  (1000 samples)
 ```
+
+## Full-Size Local Workflow
+
+The native `meta-summary` path is intended for the full
+`parent-data.csv.gz`, not just the 1,000-row compatibility sample. The
+compressed file is small enough to download quickly, but it expands to about
+1.16 GB and contains 40.2 million rows, so keep the dataset and generated YAML
+under a scratch directory and redirect warnings and analysis output to files.
+
+Download the summary files used by the import and comparison steps:
+
+```sh
+mkdir -p /tmp/motel-meta
+base=https://raw.githubusercontent.com/facebookresearch/distributed_traces/main/summary_data_atc23/data
+for file in \
+  parent-data.csv.gz \
+  trace-data.csv.gz \
+  service-characteristics.csv \
+  service-endpoints.csv \
+  service-history.csv \
+  inferred-path-data.csv
+do
+  curl -L -o "/tmp/motel-meta/$file" "$base/$file"
+done
+```
+
+Build the current motel binary:
+
+```sh
+make build
+```
+
+Import each published profile from the complete parent invocation CSV:
+
+```sh
+for profile in ads fetch raas
+do
+  build/motel import --format meta-summary --profile "$profile" \
+    /tmp/motel-meta/parent-data.csv.gz \
+    > "/tmp/motel-meta/${profile}-parent-summary.yaml" \
+    2> "/tmp/motel-meta/${profile}-parent-summary.warnings.txt"
+done
+```
+
+To import all profiles into one topology, omit `--profile`:
+
+```sh
+build/motel import --format meta-summary \
+  /tmp/motel-meta/parent-data.csv.gz \
+  > /tmp/motel-meta/all-parent-summary.yaml \
+  2> /tmp/motel-meta/all-parent-summary.warnings.txt
+```
+
+By default, empty `children_set` rows are skipped so the generated topology
+focuses on observed parent-to-child calls. Add `--include-empty` when you also
+want parent ingress ids that only appear with no children.
+
+Validate and check every generated topology:
+
+```sh
+for topology in /tmp/motel-meta/*-parent-summary.yaml
+do
+  name=$(basename "$topology" .yaml)
+  build/motel validate "$topology" \
+    > "/tmp/motel-meta/${name}.validate.txt"
+  build/motel check --seed 42 --samples 1000 \
+    --max-depth 20 --max-fan-out 200000 --max-spans 200000 \
+    "$topology" \
+    > "/tmp/motel-meta/${name}.check.txt"
+done
+```
+
+The relaxed check limits make this an analysis run rather than an assertion
+that the topology is small. Use `--samples 0` for a faster static-only pass, or
+`--sample-strategy swarm` when you want to exercise rare call branches more
+aggressively than random sampling.
+
+Summarize the released trace-level and service-level CSVs alongside motel's
+generated topology checks:
+
+```sh
+python3 - <<'PY'
+import csv
+import gzip
+from collections import defaultdict
+from pathlib import Path
+
+root = Path("/tmp/motel-meta")
+
+def int_value(row, key):
+    value = row.get(key, "")
+    return int(float(value)) if value else 0
+
+def child_count(value):
+    value = value.strip()
+    if not value or value == "set()":
+        return 0
+    return value.count(",") + 1
+
+trace_stats = defaultdict(lambda: {
+    "rows": 0,
+    "max_depth": 0,
+    "max_width": 0,
+    "max_trace_size": 0,
+    "max_services": 0,
+})
+with gzip.open(root / "trace-data.csv.gz", "rt", newline="") as f:
+    for row in csv.DictReader(f):
+        stats = trace_stats[row["profile"]]
+        stats["rows"] += 1
+        stats["max_depth"] = max(stats["max_depth"], int_value(row, "call_depth"))
+        stats["max_width"] = max(stats["max_width"], int_value(row, "max_width"))
+        stats["max_trace_size"] = max(
+            stats["max_trace_size"], int_value(row, "trace_size"))
+        stats["max_services"] = max(
+            stats["max_services"], int_value(row, "num_services"))
+
+parent_stats = defaultdict(lambda: {
+    "rows": 0,
+    "nonempty_rows": 0,
+    "max_children_set": 0,
+})
+with gzip.open(root / "parent-data.csv.gz", "rt", newline="") as f:
+    for row in csv.DictReader(f):
+        count = child_count(row["children_set"])
+        stats = parent_stats[row["profile"]]
+        stats["rows"] += 1
+        if count:
+            stats["nonempty_rows"] += 1
+        stats["max_children_set"] = max(stats["max_children_set"], count)
+
+service_rows = 0
+service_stats = {"max_fan_out_all": 0, "max_fan_in_all": 0, "max_instances": 0}
+with open(root / "service-characteristics.csv", newline="") as f:
+    for row in csv.DictReader(f):
+        service_rows += 1
+        service_stats["max_fan_out_all"] = max(
+            service_stats["max_fan_out_all"], int_value(row, "num_fan_out_all"))
+        service_stats["max_fan_in_all"] = max(
+            service_stats["max_fan_in_all"], int_value(row, "num_fan_in_all"))
+        service_stats["max_instances"] = max(
+            service_stats["max_instances"], int_value(row, "num_instances"))
+
+print("trace-data.csv.gz")
+for profile, stats in sorted(trace_stats.items()):
+    print(profile, stats)
+
+print("\nparent-data.csv.gz")
+for profile, stats in sorted(parent_stats.items()):
+    print(profile, stats)
+
+print("\nservice-characteristics.csv")
+print({"rows": service_rows, **service_stats})
+PY
+```
+
+Use the `trace-data.csv.gz` numbers to compare published full-workflow depth,
+width, trace size, and services per trace against the one-hop topology inferred
+from `parent-data.csv.gz`. Use the `parent-data.csv.gz` summary and
+`motel check` output to inspect local parent fan-out and generated trace size.
+The generated topology is expected to preserve parent-child probabilities from
+the summary data, but it cannot recover the original multi-hop workflows.
 
 ## Comparison
 

--- a/docs/research/meta-trace-import.md
+++ b/docs/research/meta-trace-import.md
@@ -41,8 +41,9 @@ data cannot be imported as raw traces directly.
 parent operation sample and one child operation sample per entry in
 `children_set`:
 
-- the parent and child ingress ids become `meta-*` services with an `invoke`
-  operation
+- the parent and child ingress ids become `meta-<slug>-<hash>` services with
+  an `invoke` operation, and the exact upstream id is preserved as the
+  `meta.ingress_id` resource attribute
 - `num_calls` weights downstream call probability so high-volume
   `(parent_name, children_set)` rows contribute more than rare rows
 - `num_returning_calls` estimates the parent operation `error_rate` from calls

--- a/docs/research/meta-trace-import.md
+++ b/docs/research/meta-trace-import.md
@@ -6,10 +6,10 @@ paper. The public repository is useful for this, but it does not publish raw
 span exports. It publishes summary CSVs and a notebook that reproduces the
 paper's figures.
 
-This note records the current import path: convert a representative subset of
-`parent-data.csv.gz` into motel's `stdouttrace` JSON, import it, validate the
-resulting topology, and compare the imported topology against the metrics in
-the released summary data.
+This note records two import paths: a native `meta-summary` mode that streams
+`parent-data.csv.gz` directly into a topology, and the older
+`tools/meta2stdouttrace` converter that materializes a representative subset as
+`stdouttrace` JSON for compatibility testing.
 
 ## Source Data
 
@@ -34,6 +34,26 @@ a parent ingress id. The row has a `children_set`, but no original trace id,
 span id, parent span id, timestamp, or duration. Because of that, the public
 data cannot be imported as raw traces directly.
 
+## Native Import
+
+`motel import --format meta-summary` reads `parent-data.csv` or
+`parent-data.csv.gz` directly. Each selected parent invocation contributes one
+parent operation sample and one child operation sample per entry in
+`children_set`:
+
+- the parent and child ingress ids become `meta-*` services with an `invoke`
+  operation
+- downstream call probability is inferred from how often each child appears
+  for a parent ingress id
+- `concurrency_rate > 0` votes for parallel call style; otherwise multi-child
+  rows vote for sequential call style
+- `--profile ads|fetch|raas` filters rows by the released profile column
+- empty `children_set` rows are skipped unless `--include-empty` is set
+
+This path does not reconstruct complete multi-hop traces because the public
+parent rows do not include trace identifiers linking parent invocations back
+into workflows.
+
 ## Converter
 
 `tools/meta2stdouttrace` turns `parent-data.csv.gz` into `stdouttrace` JSON.
@@ -47,11 +67,9 @@ Each selected parent invocation becomes one synthetic trace:
   `meta.num_returning_calls`, and `meta.concurrency_rate` are preserved as span
   attributes
 
-This is an ingestion harness, not a reconstruction of the original Meta traces.
+This remains useful as an ingestion harness for the generic stdouttrace parser.
 It proves that `motel import` can ingest a converted subset of the released
-public data and infer a valid topology from the parent-child observations. It
-does not reproduce the paper's full workflow depth because the released
-parent-data rows are not linked back into complete traces.
+public data and infer a valid topology from the parent-child observations.
 
 ## Reproduction
 
@@ -63,7 +81,16 @@ curl -L -o /tmp/motel-meta/parent-data.csv.gz \
   https://raw.githubusercontent.com/facebookresearch/distributed_traces/main/summary_data_atc23/data/parent-data.csv.gz
 ```
 
-Generate a deterministic 1,000-invocation Ads-profile sample:
+Build motel and import the Ads profile directly from the compressed CSV:
+
+```sh
+make build
+build/motel import --format meta-summary --profile ads --min-traces 100 \
+  /tmp/motel-meta/parent-data.csv.gz \
+  > /tmp/motel-meta/ads-parent-summary.yaml
+```
+
+For a smaller compatibility sample, generate deterministic `stdouttrace` JSON:
 
 ```sh
 go run ./tools/meta2stdouttrace \
@@ -73,10 +100,9 @@ go run ./tools/meta2stdouttrace \
   > /tmp/motel-meta/ads-parent-sample.jsonl
 ```
 
-Build motel and import the sample:
+Then import the sample:
 
 ```sh
-make build
 build/motel import --format stdouttrace --min-traces 100 \
   /tmp/motel-meta/ads-parent-sample.jsonl \
   > /tmp/motel-meta/ads-parent-sample.yaml
@@ -128,12 +154,9 @@ the span records needed by `motel import`.
 
 ## Follow-Up Work
 
-- Add a native summary-data path that produces a topology directly from
-  `parent-data.csv.gz`, preserving parent call probabilities without first
-  materializing synthetic span JSON.
-- Add an importer mode or separate tool for large streaming inputs. The current
-  trace importer reads the whole input and caps it at 256 MB, while a full
-  synthetic expansion of 40.2 million parent invocations would be much larger.
+- Extend bounded-memory import beyond the Meta summary path. Explicit
+  `stdouttrace` input is scanned incrementally, but OTLP and Jaeger JSON still
+  require whole-document parsing and retain the 256 MB safety cap.
 - Investigate whether Meta can publish raw trace exports or trace identifiers
   that link `parent-data.csv.gz` rows back into complete workflows. That would
   allow `motel import` to validate the paper's depth and span-count

--- a/pkg/synth/traceimport/infer.go
+++ b/pkg/synth/traceimport/infer.go
@@ -15,9 +15,11 @@ import (
 
 // Options controls import behaviour.
 type Options struct {
-	Format    Format
-	MinTraces int
-	Warnings  io.Writer // defaults to os.Stderr
+	Format           Format
+	MinTraces        int
+	Warnings         io.Writer // defaults to os.Stderr
+	MetaProfile      string
+	MetaIncludeEmpty bool
 }
 
 // Import reads trace spans, analyses them, and produces a synth YAML config.
@@ -27,6 +29,9 @@ func Import(r io.Reader, opts Options) ([]byte, error) {
 	}
 	if opts.MinTraces == 0 {
 		opts.MinTraces = 1
+	}
+	if opts.Format == FormatMetaSummary {
+		return importMetaSummary(r, opts)
 	}
 
 	// Step 1: Parse spans

--- a/pkg/synth/traceimport/infer_test.go
+++ b/pkg/synth/traceimport/infer_test.go
@@ -4,6 +4,7 @@ package traceimport
 
 import (
 	"bytes"
+	"compress/gzip"
 	"os"
 	"strings"
 	"testing"
@@ -178,4 +179,54 @@ func TestImport_MinTracesWarning(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, warnings.String(), "only 1 trace")
 	assert.Contains(t, warnings.String(), "requested minimum: 5")
+}
+
+func TestImport_MetaSummaryGzipProfileFilter(t *testing.T) {
+	csvData := strings.Join([]string{
+		"parent_name,children_set,num_calls,num_returning_calls,concurrency_rate,profile",
+		`root,"{'childA', 'childB'}",2,2,1,ads`,
+		`root,"{'childA'}",1,1,0,ads`,
+		`root,"{'fetchOnly'}",1,1,0,fetch`,
+		"leaf,set(),0,0,0,ads",
+	}, "\n")
+
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, err := gz.Write([]byte(csvData))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	var warnings bytes.Buffer
+	yamlBytes, err := Import(&compressed, Options{
+		Format:      FormatMetaSummary,
+		MetaProfile: "ads",
+		Warnings:    &warnings,
+	})
+	require.NoError(t, err)
+
+	yaml := string(yamlBytes)
+	assert.Contains(t, yaml, "meta-root:")
+	assert.Contains(t, yaml, "meta-childa.invoke")
+	assert.Contains(t, yaml, "meta-childb.invoke")
+	assert.Contains(t, yaml, "probability: 0.5")
+	assert.NotContains(t, yaml, "meta-fetchonly")
+	assert.NotContains(t, yaml, "meta-leaf")
+}
+
+func TestImport_MetaSummarySequentialCallStyle(t *testing.T) {
+	csvData := strings.Join([]string{
+		"parent_name,children_set,num_calls,num_returning_calls,concurrency_rate,profile",
+		`root,"{'childA', 'childB'}",2,2,0,ads`,
+	}, "\n")
+
+	var warnings bytes.Buffer
+	yamlBytes, err := Import(strings.NewReader(csvData), Options{
+		Format:   FormatMetaSummary,
+		Warnings: &warnings,
+	})
+	require.NoError(t, err)
+
+	yaml := string(yamlBytes)
+	assert.Contains(t, yaml, "call_style: sequential")
+	assert.Contains(t, warnings.String(), "only 1 Meta parent invocation")
 }

--- a/pkg/synth/traceimport/infer_test.go
+++ b/pkg/synth/traceimport/infer_test.go
@@ -205,13 +205,15 @@ func TestImport_MetaSummaryGzipProfileFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	yaml := string(yamlBytes)
-	assert.Contains(t, yaml, "meta-root:")
-	assert.Contains(t, yaml, "meta-childa.invoke")
-	assert.Contains(t, yaml, "meta-childb.invoke")
+	assert.Contains(t, yaml, metaServiceName("root")+":")
+	assert.Contains(t, yaml, metaServiceName("childA")+".invoke")
+	assert.Contains(t, yaml, metaServiceName("childB")+".invoke")
 	assert.Contains(t, yaml, "probability: 0.91")
 	assert.Contains(t, yaml, "error_rate: 18%")
-	assert.NotContains(t, yaml, "meta-fetchonly")
-	assert.NotContains(t, yaml, "meta-leaf")
+	assert.Contains(t, yaml, "meta.ingress_id: root")
+	assert.Contains(t, yaml, "meta.ingress_id: childA")
+	assert.NotContains(t, yaml, metaServiceName("fetchOnly"))
+	assert.NotContains(t, yaml, metaServiceName("leaf"))
 }
 
 func TestImport_MetaSummarySequentialCallStyle(t *testing.T) {
@@ -230,4 +232,37 @@ func TestImport_MetaSummarySequentialCallStyle(t *testing.T) {
 	yaml := string(yamlBytes)
 	assert.Contains(t, yaml, "call_style: sequential")
 	assert.Contains(t, warnings.String(), "only 1 weighted Meta parent sample")
+}
+
+func TestImport_MetaSummaryPreservesDistinctIngressIDs(t *testing.T) {
+	csvData := strings.Join([]string{
+		"parent_name,children_set,num_calls,num_returning_calls,concurrency_rate,profile",
+		`Service.A,"{'leaf'}",1,1,0,ads`,
+		`service-a,"{'leaf'}",1,1,0,ads`,
+	}, "\n")
+
+	yamlBytes, err := Import(strings.NewReader(csvData), Options{
+		Format: FormatMetaSummary,
+	})
+	require.NoError(t, err)
+
+	firstName := metaServiceName("Service.A")
+	secondName := metaServiceName("service-a")
+	require.NotEqual(t, firstName, secondName)
+
+	yaml := string(yamlBytes)
+	assert.Contains(t, yaml, firstName+":")
+	assert.Contains(t, yaml, secondName+":")
+	assert.Contains(t, yaml, "meta.ingress_id: Service.A")
+	assert.Contains(t, yaml, "meta.ingress_id: service-a")
+}
+
+func TestMetaServiceNameUsesStableCollisionResistantSuffix(t *testing.T) {
+	firstName := metaServiceName("Service.A")
+	secondName := metaServiceName("service-a")
+
+	assert.NotEqual(t, firstName, secondName)
+	assert.Regexp(t, `^meta-service-a-[0-9a-f]{16}$`, firstName)
+	assert.Regexp(t, `^meta-service-a-[0-9a-f]{16}$`, secondName)
+	assert.Equal(t, firstName, metaServiceName("Service.A"))
 }

--- a/pkg/synth/traceimport/infer_test.go
+++ b/pkg/synth/traceimport/infer_test.go
@@ -184,7 +184,7 @@ func TestImport_MinTracesWarning(t *testing.T) {
 func TestImport_MetaSummaryGzipProfileFilter(t *testing.T) {
 	csvData := strings.Join([]string{
 		"parent_name,children_set,num_calls,num_returning_calls,concurrency_rate,profile",
-		`root,"{'childA', 'childB'}",2,2,1,ads`,
+		`root,"{'childA', 'childB'}",10.0,8.0,1,ads`,
 		`root,"{'childA'}",1,1,0,ads`,
 		`root,"{'fetchOnly'}",1,1,0,fetch`,
 		"leaf,set(),0,0,0,ads",
@@ -208,7 +208,8 @@ func TestImport_MetaSummaryGzipProfileFilter(t *testing.T) {
 	assert.Contains(t, yaml, "meta-root:")
 	assert.Contains(t, yaml, "meta-childa.invoke")
 	assert.Contains(t, yaml, "meta-childb.invoke")
-	assert.Contains(t, yaml, "probability: 0.5")
+	assert.Contains(t, yaml, "probability: 0.91")
+	assert.Contains(t, yaml, "error_rate: 18%")
 	assert.NotContains(t, yaml, "meta-fetchonly")
 	assert.NotContains(t, yaml, "meta-leaf")
 }
@@ -216,7 +217,7 @@ func TestImport_MetaSummaryGzipProfileFilter(t *testing.T) {
 func TestImport_MetaSummarySequentialCallStyle(t *testing.T) {
 	csvData := strings.Join([]string{
 		"parent_name,children_set,num_calls,num_returning_calls,concurrency_rate,profile",
-		`root,"{'childA', 'childB'}",2,2,0,ads`,
+		`root,"{'childA', 'childB'}",1,1,0,ads`,
 	}, "\n")
 
 	var warnings bytes.Buffer
@@ -228,5 +229,5 @@ func TestImport_MetaSummarySequentialCallStyle(t *testing.T) {
 
 	yaml := string(yamlBytes)
 	assert.Contains(t, yaml, "call_style: sequential")
-	assert.Contains(t, warnings.String(), "only 1 Meta parent invocation")
+	assert.Contains(t, warnings.String(), "only 1 weighted Meta parent sample")
 }

--- a/pkg/synth/traceimport/marshal.go
+++ b/pkg/synth/traceimport/marshal.go
@@ -57,7 +57,7 @@ func MarshalConfig(collector *StatsCollector, serviceAttrs map[string]map[string
 		for _, opName := range sortedStringKeys(svcStats.Ops) {
 			opStats := svcStats.Ops[opName]
 			op := inferredOperation{
-				Duration:  FormatDuration(opStats.Durations),
+				Duration:  opStats.formatDuration(),
 				ErrorRate: FormatErrorRate(opStats.ErrorCount, opStats.TotalCount),
 			}
 

--- a/pkg/synth/traceimport/marshal_test.go
+++ b/pkg/synth/traceimport/marshal_test.go
@@ -14,8 +14,8 @@ func TestMarshalConfig_Basic(t *testing.T) {
 	collector := NewStatsCollector()
 	svc := collector.getService("api")
 	op := collector.getOp(svc, "GET /users")
-	op.Durations = []time.Duration{30 * time.Millisecond, 40 * time.Millisecond}
-	op.TotalCount = 2
+	recordTestDuration(op, 30*time.Millisecond, 1)
+	recordTestDuration(op, 40*time.Millisecond, 1)
 
 	attrs := map[string]map[string]string{
 		"api": {"env": "prod"},
@@ -37,8 +37,7 @@ func TestMarshalConfig_Header(t *testing.T) {
 	collector := NewStatsCollector()
 	svc := collector.getService("api")
 	op := collector.getOp(svc, "handle")
-	op.Durations = []time.Duration{10 * time.Millisecond}
-	op.TotalCount = 1
+	recordTestDuration(op, 10*time.Millisecond, 1)
 
 	data, err := MarshalConfig(collector, nil, 4, 10, 1.42)
 	require.NoError(t, err)
@@ -53,16 +52,14 @@ func TestMarshalConfig_RoundTrip(t *testing.T) {
 	// Build a small topology: gateway -> backend
 	gw := collector.getService("gateway")
 	gwOp := collector.getOp(gw, "handle")
-	gwOp.Durations = []time.Duration{50 * time.Millisecond}
-	gwOp.TotalCount = 1
+	recordTestDuration(gwOp, 50*time.Millisecond, 1)
 	gwOp.Calls = map[string]*CallStats{
 		"backend.process": {Count: 1},
 	}
 
 	be := collector.getService("backend")
 	beOp := collector.getOp(be, "process")
-	beOp.Durations = []time.Duration{20 * time.Millisecond}
-	beOp.TotalCount = 1
+	recordTestDuration(beOp, 20*time.Millisecond, 1)
 
 	data, err := MarshalConfig(collector, nil, 1, 2, 0)
 	require.NoError(t, err)
@@ -76,16 +73,14 @@ func TestMarshalConfig_WithProbability(t *testing.T) {
 	collector := NewStatsCollector()
 	svc := collector.getService("api")
 	op := collector.getOp(svc, "handle")
-	op.Durations = []time.Duration{10 * time.Millisecond}
-	op.TotalCount = 10
+	recordTestDuration(op, 10*time.Millisecond, 10)
 	op.Calls = map[string]*CallStats{
 		"cache.get": {Count: 5},
 	}
 
 	cache := collector.getService("cache")
 	cacheOp := collector.getOp(cache, "get")
-	cacheOp.Durations = []time.Duration{1 * time.Millisecond}
-	cacheOp.TotalCount = 5
+	recordTestDuration(cacheOp, time.Millisecond, 5)
 
 	data, err := MarshalConfig(collector, nil, 10, 15, 1.0)
 	require.NoError(t, err)
@@ -99,8 +94,7 @@ func TestMarshalConfig_SequentialCallStyle(t *testing.T) {
 	collector := NewStatsCollector()
 	svc := collector.getService("api")
 	op := collector.getOp(svc, "handle")
-	op.Durations = []time.Duration{10 * time.Millisecond}
-	op.TotalCount = 1
+	recordTestDuration(op, 10*time.Millisecond, 1)
 	svc.CallStyles["handle"] = &CallStyleVote{Sequential: 5, Parallel: 1}
 
 	data, err := MarshalConfig(collector, nil, 1, 1, 0)
@@ -108,4 +102,9 @@ func TestMarshalConfig_SequentialCallStyle(t *testing.T) {
 
 	yaml := string(data)
 	assert.Contains(t, yaml, "call_style: sequential")
+}
+
+func recordTestDuration(op *OpStats, d time.Duration, count int) {
+	op.RecordDuration(d, count)
+	op.TotalCount += count
 }

--- a/pkg/synth/traceimport/meta.go
+++ b/pkg/synth/traceimport/meta.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -39,10 +40,12 @@ var requiredMetaSummaryColumns = []string{
 }
 
 type metaParentRow struct {
-	parentName      string
-	children        []string
-	concurrencyRate float64
-	profile         string
+	parentName        string
+	children          []string
+	numCalls          int
+	numReturningCalls int
+	concurrencyRate   float64
+	profile           string
 }
 
 func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
@@ -66,6 +69,7 @@ func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
 
 	collector := NewStatsCollector()
 	rowCount := 0
+	sampleCount := 0
 	spanCount := 0
 	rowNumber := 1
 
@@ -89,24 +93,26 @@ func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
 			continue
 		}
 
-		recordMetaInvocation(collector, row)
+		weight := row.observationWeight()
+		recordMetaInvocation(collector, row, weight)
 		rowCount++
-		spanCount += 1 + len(row.children)
+		sampleCount += weight
+		spanCount += weight * (1 + len(row.children))
 	}
 
 	if rowCount == 0 {
 		return nil, errors.New("no Meta summary rows matched the requested filters")
 	}
-	if rowCount < opts.MinTraces {
-		_, _ = fmt.Fprintf(opts.Warnings, "warning: only %d Meta parent invocations available (requested minimum: %d); results may be inaccurate\n",
-			rowCount, opts.MinTraces)
+	if sampleCount < opts.MinTraces {
+		_, _ = fmt.Fprintf(opts.Warnings, "warning: only %d weighted Meta parent samples available from %d rows (requested minimum: %d); results may be inaccurate\n",
+			sampleCount, rowCount, opts.MinTraces)
 	}
-	if rowCount == 1 {
-		_, _ = fmt.Fprintf(opts.Warnings, "warning: only 1 Meta parent invocation available; duration distributions will be exact values. Use more rows for statistical accuracy.\n")
+	if sampleCount == 1 {
+		_, _ = fmt.Fprintf(opts.Warnings, "warning: only 1 weighted Meta parent sample available; duration distributions will be exact values. Use more rows for statistical accuracy.\n")
 	}
 	reportConfidenceDiagnostics(collector, opts.MinTraces, opts.Warnings)
 
-	yamlBytes, err := MarshalConfig(collector, nil, rowCount, spanCount, 0)
+	yamlBytes, err := MarshalConfig(collector, nil, sampleCount, spanCount, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -153,10 +159,12 @@ func parseMetaParentRow(record []string, cols map[string]int) (metaParentRow, er
 	if err != nil {
 		return metaParentRow{}, err
 	}
-	if _, err := parseMetaIntColumn(record, cols, metaColumnNumCalls); err != nil {
+	numCalls, err := parseMetaCountColumn(record, cols, metaColumnNumCalls)
+	if err != nil {
 		return metaParentRow{}, err
 	}
-	if _, err := parseMetaIntColumn(record, cols, metaColumnNumReturningCalls); err != nil {
+	numReturningCalls, err := parseMetaCountColumn(record, cols, metaColumnNumReturningCalls)
+	if err != nil {
 		return metaParentRow{}, err
 	}
 	concurrencyRate, err := parseMetaFloatColumn(record, cols, metaColumnConcurrencyRate)
@@ -168,10 +176,12 @@ func parseMetaParentRow(record []string, cols map[string]int) (metaParentRow, er
 		return metaParentRow{}, err
 	}
 	return metaParentRow{
-		parentName:      parentName,
-		children:        children,
-		concurrencyRate: concurrencyRate,
-		profile:         profile,
+		parentName:        parentName,
+		children:          children,
+		numCalls:          numCalls,
+		numReturningCalls: numReturningCalls,
+		concurrencyRate:   concurrencyRate,
+		profile:           profile,
 	}, nil
 }
 
@@ -186,16 +196,29 @@ func metaColumnValue(record []string, cols map[string]int, name string) (string,
 	return strings.TrimSpace(record[idx]), nil
 }
 
-func parseMetaIntColumn(record []string, cols map[string]int, name string) (int, error) {
+func parseMetaCountColumn(record []string, cols map[string]int, name string) (int, error) {
 	value, err := metaColumnValue(record, cols, name)
 	if err != nil {
 		return 0, err
 	}
-	n, err := strconv.Atoi(value)
+	if n, err := strconv.Atoi(value); err == nil {
+		if n < 0 {
+			return 0, fmt.Errorf("%s %q must be non-negative", name, value)
+		}
+		return n, nil
+	}
+	n, err := strconv.ParseFloat(value, 64)
 	if err != nil {
 		return 0, fmt.Errorf("%s %q: %w", name, value, err)
 	}
-	return n, nil
+	if n < 0 || math.Trunc(n) != n {
+		return 0, fmt.Errorf("%s %q must be a non-negative integer", name, value)
+	}
+	maxInt := int(^uint(0) >> 1)
+	if n > float64(maxInt) {
+		return 0, fmt.Errorf("%s %q exceeds maximum integer size", name, value)
+	}
+	return int(n), nil
 }
 
 func parseMetaFloatColumn(record []string, cols map[string]int, name string) (float64, error) {
@@ -231,19 +254,30 @@ func parseMetaChildrenSet(value string) ([]string, error) {
 	return children, nil
 }
 
-func recordMetaInvocation(collector *StatsCollector, row metaParentRow) {
+func (r metaParentRow) observationWeight() int {
+	if r.numCalls > 0 {
+		return r.numCalls
+	}
+	return 1
+}
+
+func recordMetaInvocation(collector *StatsCollector, row metaParentRow, weight int) {
 	parentService := metaServiceName(row.parentName)
 	parentStats := collector.getService(parentService)
 	parentOp := collector.getOp(parentStats, metaOperationName)
-	parentOp.RecordDuration(metaParentDuration+time.Duration(len(row.children))*metaChildDuration, false)
-	parentOp.TotalCount++
+	// Meta summary rows have no latency, so these are nominal placeholders.
+	parentOp.RecordDuration(metaParentDuration+time.Duration(len(row.children))*metaChildDuration, weight)
+	parentOp.TotalCount += weight
+	if row.numCalls > row.numReturningCalls {
+		parentOp.ErrorCount += row.numCalls - row.numReturningCalls
+	}
 
 	if len(row.children) >= 2 {
 		vote := collector.getCallStyle(parentStats, metaOperationName)
 		if row.concurrencyRate > 0 {
-			vote.Parallel++
+			vote.Parallel += weight
 		} else {
-			vote.Sequential++
+			vote.Sequential += weight
 		}
 	}
 
@@ -258,15 +292,16 @@ func recordMetaInvocation(collector *StatsCollector, row metaParentRow) {
 			call = &CallStats{}
 			parentOp.Calls[childRef] = call
 		}
-		call.Count++
+		call.Count += weight
 
 		childOp := collector.getOp(collector.getService(childService), metaOperationName)
-		childOp.RecordDuration(metaChildDuration, false)
-		childOp.TotalCount++
+		childOp.RecordDuration(metaChildDuration, weight)
+		childOp.TotalCount += weight
 	}
 }
 
 func metaServiceName(ingressID string) string {
+	// This display name is intentionally lossy; collisions merge ingress stats.
 	var b strings.Builder
 	b.WriteString("meta-")
 	lastHyphen := false

--- a/pkg/synth/traceimport/meta.go
+++ b/pkg/synth/traceimport/meta.go
@@ -1,0 +1,284 @@
+package traceimport
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	metaColumnParentName        = "parent_name"
+	metaColumnChildrenSet       = "children_set"
+	metaColumnNumCalls          = "num_calls"
+	metaColumnNumReturningCalls = "num_returning_calls"
+	metaColumnConcurrencyRate   = "concurrency_rate"
+	metaColumnProfile           = "profile"
+
+	metaOperationName  = "invoke"
+	metaParentDuration = 5 * time.Millisecond
+	metaChildDuration  = time.Millisecond
+	gzipMagicByte0     = 0x1f
+	gzipMagicByte1     = 0x8b
+)
+
+var requiredMetaSummaryColumns = []string{
+	metaColumnParentName,
+	metaColumnChildrenSet,
+	metaColumnNumCalls,
+	metaColumnNumReturningCalls,
+	metaColumnConcurrencyRate,
+	metaColumnProfile,
+}
+
+type metaParentRow struct {
+	parentName      string
+	children        []string
+	concurrencyRate float64
+	profile         string
+}
+
+func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
+	reader, closeReader, err := metaInputReader(r)
+	if err != nil {
+		return nil, err
+	}
+	defer closeReader()
+
+	csvReader := csv.NewReader(reader)
+	header, err := csvReader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read Meta summary header: %w", err)
+	}
+	cols := indexMetaHeader(header)
+	for _, name := range requiredMetaSummaryColumns {
+		if _, ok := cols[name]; !ok {
+			return nil, fmt.Errorf("missing required Meta summary column %q", name)
+		}
+	}
+
+	collector := NewStatsCollector()
+	rowCount := 0
+	spanCount := 0
+	rowNumber := 1
+
+	for {
+		rowNumber++
+		record, err := csvReader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read Meta summary row %d: %w", rowNumber, err)
+		}
+		row, err := parseMetaParentRow(record, cols)
+		if err != nil {
+			return nil, fmt.Errorf("parse Meta summary row %d: %w", rowNumber, err)
+		}
+		if opts.MetaProfile != "" && row.profile != opts.MetaProfile {
+			continue
+		}
+		if !opts.MetaIncludeEmpty && len(row.children) == 0 {
+			continue
+		}
+
+		recordMetaInvocation(collector, row)
+		rowCount++
+		spanCount += 1 + len(row.children)
+	}
+
+	if rowCount == 0 {
+		return nil, errors.New("no Meta summary rows matched the requested filters")
+	}
+	if rowCount < opts.MinTraces {
+		_, _ = fmt.Fprintf(opts.Warnings, "warning: only %d Meta parent invocations available (requested minimum: %d); results may be inaccurate\n",
+			rowCount, opts.MinTraces)
+	}
+	if rowCount == 1 {
+		_, _ = fmt.Fprintf(opts.Warnings, "warning: only 1 Meta parent invocation available; duration distributions will be exact values. Use more rows for statistical accuracy.\n")
+	}
+	reportConfidenceDiagnostics(collector, opts.MinTraces, opts.Warnings)
+
+	yamlBytes, err := MarshalConfig(collector, nil, rowCount, spanCount, 0)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateRoundTrip(yamlBytes); err != nil {
+		return nil, fmt.Errorf("round-trip validation failed (this is a bug): %w", err)
+	}
+	return yamlBytes, nil
+}
+
+func metaInputReader(r io.Reader) (io.Reader, func() error, error) {
+	br := bufio.NewReader(r)
+	magic, err := br.Peek(2)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, nil, fmt.Errorf("read Meta summary input: %w", err)
+	}
+	if len(magic) == 2 && magic[0] == gzipMagicByte0 && magic[1] == gzipMagicByte1 {
+		gz, err := gzip.NewReader(br)
+		if err != nil {
+			return nil, nil, fmt.Errorf("open gzip stream: %w", err)
+		}
+		return gz, gz.Close, nil
+	}
+	return br, func() error { return nil }, nil
+}
+
+func indexMetaHeader(header []string) map[string]int {
+	cols := make(map[string]int, len(header))
+	for i, name := range header {
+		cols[strings.TrimSpace(name)] = i
+	}
+	return cols
+}
+
+func parseMetaParentRow(record []string, cols map[string]int) (metaParentRow, error) {
+	parentName, err := metaColumnValue(record, cols, metaColumnParentName)
+	if err != nil {
+		return metaParentRow{}, err
+	}
+	childrenValue, err := metaColumnValue(record, cols, metaColumnChildrenSet)
+	if err != nil {
+		return metaParentRow{}, err
+	}
+	children, err := parseMetaChildrenSet(childrenValue)
+	if err != nil {
+		return metaParentRow{}, err
+	}
+	if _, err := parseMetaIntColumn(record, cols, metaColumnNumCalls); err != nil {
+		return metaParentRow{}, err
+	}
+	if _, err := parseMetaIntColumn(record, cols, metaColumnNumReturningCalls); err != nil {
+		return metaParentRow{}, err
+	}
+	concurrencyRate, err := parseMetaFloatColumn(record, cols, metaColumnConcurrencyRate)
+	if err != nil {
+		return metaParentRow{}, err
+	}
+	profile, err := metaColumnValue(record, cols, metaColumnProfile)
+	if err != nil {
+		return metaParentRow{}, err
+	}
+	return metaParentRow{
+		parentName:      parentName,
+		children:        children,
+		concurrencyRate: concurrencyRate,
+		profile:         profile,
+	}, nil
+}
+
+func metaColumnValue(record []string, cols map[string]int, name string) (string, error) {
+	idx, ok := cols[name]
+	if !ok {
+		return "", fmt.Errorf("missing column %q", name)
+	}
+	if idx >= len(record) {
+		return "", fmt.Errorf("missing value for column %q", name)
+	}
+	return strings.TrimSpace(record[idx]), nil
+}
+
+func parseMetaIntColumn(record []string, cols map[string]int, name string) (int, error) {
+	value, err := metaColumnValue(record, cols, name)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s %q: %w", name, value, err)
+	}
+	return n, nil
+}
+
+func parseMetaFloatColumn(record []string, cols map[string]int, name string) (float64, error) {
+	value, err := metaColumnValue(record, cols, name)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s %q: %w", name, value, err)
+	}
+	return n, nil
+}
+
+func parseMetaChildrenSet(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "set()" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(value, "{") || !strings.HasSuffix(value, "}") {
+		return nil, fmt.Errorf("children_set %q is not a Python set literal", value)
+	}
+	parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(value, "{"), "}"), ",")
+	children := make([]string, 0, len(parts))
+	for _, part := range parts {
+		child := strings.Trim(strings.TrimSpace(part), `'"`)
+		if child == "" {
+			continue
+		}
+		children = append(children, child)
+	}
+	sort.Strings(children)
+	return children, nil
+}
+
+func recordMetaInvocation(collector *StatsCollector, row metaParentRow) {
+	parentService := metaServiceName(row.parentName)
+	parentStats := collector.getService(parentService)
+	parentOp := collector.getOp(parentStats, metaOperationName)
+	parentOp.RecordDuration(metaParentDuration+time.Duration(len(row.children))*metaChildDuration, false)
+	parentOp.TotalCount++
+
+	if len(row.children) >= 2 {
+		vote := collector.getCallStyle(parentStats, metaOperationName)
+		if row.concurrencyRate > 0 {
+			vote.Parallel++
+		} else {
+			vote.Sequential++
+		}
+	}
+
+	for _, child := range row.children {
+		childService := metaServiceName(child)
+		childRef := childService + "." + metaOperationName
+		if parentOp.Calls == nil {
+			parentOp.Calls = make(map[string]*CallStats)
+		}
+		call := parentOp.Calls[childRef]
+		if call == nil {
+			call = &CallStats{}
+			parentOp.Calls[childRef] = call
+		}
+		call.Count++
+
+		childOp := collector.getOp(collector.getService(childService), metaOperationName)
+		childOp.RecordDuration(metaChildDuration, false)
+		childOp.TotalCount++
+	}
+}
+
+func metaServiceName(ingressID string) string {
+	var b strings.Builder
+	b.WriteString("meta-")
+	lastHyphen := false
+	for _, r := range strings.ToLower(ingressID) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+			lastHyphen = false
+		case !lastHyphen:
+			b.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	return strings.TrimSuffix(b.String(), "-")
+}

--- a/pkg/synth/traceimport/meta.go
+++ b/pkg/synth/traceimport/meta.go
@@ -3,7 +3,9 @@ package traceimport
 import (
 	"bufio"
 	"compress/gzip"
+	"crypto/sha256"
 	"encoding/csv"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -23,11 +25,15 @@ const (
 	metaColumnConcurrencyRate   = "concurrency_rate"
 	metaColumnProfile           = "profile"
 
-	metaOperationName  = "invoke"
-	metaParentDuration = 5 * time.Millisecond
-	metaChildDuration  = time.Millisecond
-	gzipMagicByte0     = 0x1f
-	gzipMagicByte1     = 0x8b
+	metaOperationName       = "invoke"
+	metaServicePrefix       = "meta-"
+	metaIngressIDAttribute  = "meta.ingress_id"
+	metaNameHashBytes       = 8
+	metaFallbackServiceSlug = "ingress"
+	metaParentDuration      = 5 * time.Millisecond
+	metaChildDuration       = time.Millisecond
+	gzipMagicByte0          = 0x1f
+	gzipMagicByte1          = 0x8b
 )
 
 var requiredMetaSummaryColumns = []string{
@@ -46,6 +52,11 @@ type metaParentRow struct {
 	numReturningCalls int
 	concurrencyRate   float64
 	profile           string
+}
+
+type metaNameMapper struct {
+	names map[string]string
+	attrs map[string]map[string]string
 }
 
 func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
@@ -68,6 +79,7 @@ func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
 	}
 
 	collector := NewStatsCollector()
+	names := newMetaNameMapper()
 	rowCount := 0
 	sampleCount := 0
 	spanCount := 0
@@ -94,7 +106,7 @@ func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
 		}
 
 		weight := row.observationWeight()
-		recordMetaInvocation(collector, row, weight)
+		recordMetaInvocation(collector, names, row, weight)
 		rowCount++
 		sampleCount += weight
 		spanCount += weight * (1 + len(row.children))
@@ -112,7 +124,7 @@ func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
 	}
 	reportConfidenceDiagnostics(collector, opts.MinTraces, opts.Warnings)
 
-	yamlBytes, err := MarshalConfig(collector, nil, sampleCount, spanCount, 0)
+	yamlBytes, err := MarshalConfig(collector, names.serviceAttributes(), sampleCount, spanCount, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -261,8 +273,31 @@ func (r metaParentRow) observationWeight() int {
 	return 1
 }
 
-func recordMetaInvocation(collector *StatsCollector, row metaParentRow, weight int) {
-	parentService := metaServiceName(row.parentName)
+func newMetaNameMapper() *metaNameMapper {
+	return &metaNameMapper{
+		names: make(map[string]string),
+		attrs: make(map[string]map[string]string),
+	}
+}
+
+func (m *metaNameMapper) serviceName(ingressID string) string {
+	if name, ok := m.names[ingressID]; ok {
+		return name
+	}
+	name := metaServiceName(ingressID)
+	m.names[ingressID] = name
+	m.attrs[name] = map[string]string{
+		metaIngressIDAttribute: ingressID,
+	}
+	return name
+}
+
+func (m *metaNameMapper) serviceAttributes() map[string]map[string]string {
+	return m.attrs
+}
+
+func recordMetaInvocation(collector *StatsCollector, names *metaNameMapper, row metaParentRow, weight int) {
+	parentService := names.serviceName(row.parentName)
 	parentStats := collector.getService(parentService)
 	parentOp := collector.getOp(parentStats, metaOperationName)
 	// Meta summary rows have no latency, so these are nominal placeholders.
@@ -282,7 +317,7 @@ func recordMetaInvocation(collector *StatsCollector, row metaParentRow, weight i
 	}
 
 	for _, child := range row.children {
-		childService := metaServiceName(child)
+		childService := names.serviceName(child)
 		childRef := childService + "." + metaOperationName
 		if parentOp.Calls == nil {
 			parentOp.Calls = make(map[string]*CallStats)
@@ -301,9 +336,12 @@ func recordMetaInvocation(collector *StatsCollector, row metaParentRow, weight i
 }
 
 func metaServiceName(ingressID string) string {
-	// This display name is intentionally lossy; collisions merge ingress stats.
+	digest := sha256.Sum256([]byte(ingressID))
+	return metaServicePrefix + metaServiceSlug(ingressID) + "-" + hex.EncodeToString(digest[:metaNameHashBytes])
+}
+
+func metaServiceSlug(ingressID string) string {
 	var b strings.Builder
-	b.WriteString("meta-")
 	lastHyphen := false
 	for _, r := range strings.ToLower(ingressID) {
 		switch {
@@ -315,5 +353,9 @@ func metaServiceName(ingressID string) string {
 			lastHyphen = true
 		}
 	}
-	return strings.TrimSuffix(b.String(), "-")
+	slug := strings.Trim(b.String(), "-")
+	if slug == "" {
+		return metaFallbackServiceSlug
+	}
+	return slug
 }

--- a/pkg/synth/traceimport/property_test.go
+++ b/pkg/synth/traceimport/property_test.go
@@ -81,6 +81,14 @@ func genDurations(t *rapid.T) []time.Duration {
 	return ds
 }
 
+func recordDurations(ds []time.Duration) OpStats {
+	var op OpStats
+	for _, d := range ds {
+		op.RecordDuration(d, 1)
+	}
+	return op
+}
+
 // --- Tree invariants ---
 
 func TestProperty_BuildTrees_AllSpansPresent(t *testing.T) {
@@ -206,7 +214,7 @@ func TestProperty_Stats_ErrorCountBounded(t *testing.T) {
 	})
 }
 
-func TestProperty_Stats_DurationsLengthMatchesCount(t *testing.T) {
+func TestProperty_Stats_DurationCountMatchesCount(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		spans := genTree(t)
 		trees := BuildTrees(spans, nil)
@@ -215,15 +223,15 @@ func TestProperty_Stats_DurationsLengthMatchesCount(t *testing.T) {
 
 		for svcName, svcStats := range collector.Services {
 			for opName, opStats := range svcStats.Ops {
-				if len(opStats.Durations) != opStats.TotalCount {
-					t.Fatalf("%s.%s: durations length %d != total count %d", svcName, opName, len(opStats.Durations), opStats.TotalCount)
+				if opStats.DurationCount != opStats.TotalCount {
+					t.Fatalf("%s.%s: duration count %d != total count %d", svcName, opName, opStats.DurationCount, opStats.TotalCount)
 				}
 			}
 		}
 	})
 }
 
-func TestProperty_Stats_DurationsPositive(t *testing.T) {
+func TestProperty_Stats_DurationMeanPositive(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		spans := genTree(t)
 		trees := BuildTrees(spans, nil)
@@ -232,10 +240,8 @@ func TestProperty_Stats_DurationsPositive(t *testing.T) {
 
 		for svcName, svcStats := range collector.Services {
 			for opName, opStats := range svcStats.Ops {
-				for i, d := range opStats.Durations {
-					if d < 0 {
-						t.Fatalf("%s.%s: duration[%d] = %v is negative", svcName, opName, i, d)
-					}
+				if opStats.DurationCount > 0 && opStats.meanDuration() < 0 {
+					t.Fatalf("%s.%s: mean duration %v is negative", svcName, opName, opStats.meanDuration())
 				}
 			}
 		}
@@ -290,10 +296,11 @@ func TestProperty_Stats_CallCountsMatchChildren(t *testing.T) {
 
 // --- Duration arithmetic ---
 
-func TestProperty_MeanDuration_BetweenMinMax(t *testing.T) {
+func TestProperty_DurationMean_BetweenMinMax(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		ds := genDurations(t)
-		mean := MeanDuration(ds)
+		op := recordDurations(ds)
+		mean := op.meanDuration()
 
 		min, max := ds[0], ds[0]
 		for _, d := range ds[1:] {
@@ -310,51 +317,49 @@ func TestProperty_MeanDuration_BetweenMinMax(t *testing.T) {
 	})
 }
 
-func TestProperty_MeanDuration_Idempotent(t *testing.T) {
+func TestProperty_DurationMean_Idempotent(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		ds := genDurations(t)
-		m1 := MeanDuration(ds)
-		m2 := MeanDuration(ds)
+		op := recordDurations(ds)
+		m1 := op.meanDuration()
+		m2 := op.meanDuration()
 		if m1 != m2 {
-			t.Fatalf("MeanDuration not idempotent: %v != %v", m1, m2)
+			t.Fatalf("duration mean not idempotent: %v != %v", m1, m2)
 		}
 	})
 }
 
-func TestProperty_MeanDuration_Uniform(t *testing.T) {
+func TestProperty_DurationMean_Uniform(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		d := time.Duration(rapid.Int64Range(int64(time.Microsecond), int64(10*time.Second)).Draw(t, "d"))
 		n := rapid.IntRange(1, 100).Draw(t, "n")
-		ds := make([]time.Duration, n)
-		for i := range ds {
-			ds[i] = d
-		}
-		mean := MeanDuration(ds)
+		var op OpStats
+		op.RecordDuration(d, n)
+		mean := op.meanDuration()
 		if mean != d {
 			t.Fatalf("mean of %d identical %v values = %v", n, d, mean)
 		}
 	})
 }
 
-func TestProperty_StdDevDuration_NonNegative(t *testing.T) {
+func TestProperty_DurationStdDev_NonNegative(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		ds := genDurations(t)
-		sd := StdDevDuration(ds)
+		op := recordDurations(ds)
+		sd := op.stdDevDuration()
 		if sd < 0 {
 			t.Fatalf("stddev = %v is negative", sd)
 		}
 	})
 }
 
-func TestProperty_StdDevDuration_ZeroForUniform(t *testing.T) {
+func TestProperty_DurationStdDev_ZeroForUniform(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		d := time.Duration(rapid.Int64Range(int64(time.Microsecond), int64(10*time.Second)).Draw(t, "d"))
 		n := rapid.IntRange(2, 100).Draw(t, "n")
-		ds := make([]time.Duration, n)
-		for i := range ds {
-			ds[i] = d
-		}
-		sd := StdDevDuration(ds)
+		var op OpStats
+		op.RecordDuration(d, n)
+		sd := op.stdDevDuration()
 		if sd != 0 {
 			t.Fatalf("stddev of %d identical %v values = %v, expected 0", n, d, sd)
 		}

--- a/pkg/synth/traceimport/span.go
+++ b/pkg/synth/traceimport/span.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -46,25 +45,26 @@ const (
 // maxInputSize is the maximum input size to prevent OOM on large trace exports.
 const maxInputSize = 256 * 1024 * 1024 // 256 MB
 const maxStdouttraceLineSize = 10 * 1024 * 1024
+const bytesPerMegabyte = 1024 * 1024
 
 // ParseSpans reads spans from the given reader in the specified format.
 // FormatAuto inspects the first JSON object to determine the format.
 // Whole-document JSON inputs are limited to 256 MB to prevent OOM on large trace
-// exports. Line-delimited stdouttrace inputs are scanned incrementally.
+// exports. Explicit line-delimited stdouttrace inputs are scanned incrementally.
 func ParseSpans(r io.Reader, format Format) ([]Span, error) {
 	switch format {
 	case FormatStdouttrace:
 		return parseStdouttraceReader(r)
 	case FormatAuto:
-		return parseAutoSpans(r)
+		return parseAutoSpans(r, maxInputSize)
 	case FormatOTLP:
-		data, err := readLimitedInput(r)
+		data, err := readLimitedInput(r, maxInputSize)
 		if err != nil {
 			return nil, err
 		}
 		return parseOTLP(data)
 	case FormatJaeger:
-		data, err := readLimitedInput(r)
+		data, err := readLimitedInput(r, maxInputSize)
 		if err != nil {
 			return nil, err
 		}
@@ -76,17 +76,8 @@ func ParseSpans(r io.Reader, format Format) ([]Span, error) {
 	}
 }
 
-func parseAutoSpans(r io.Reader) ([]Span, error) {
-	br := bufio.NewReader(r)
-	prefix, firstLine, err := readDetectionPrefix(br)
-	if err != nil {
-		return nil, err
-	}
-	if firstLineFormat(firstLine) == FormatStdouttrace {
-		return parseStdouttraceReader(io.MultiReader(bytes.NewReader(prefix), br))
-	}
-
-	data, err := readLimitedInput(io.MultiReader(bytes.NewReader(prefix), br))
+func parseAutoSpans(r io.Reader, maxSize int) ([]Span, error) {
+	data, err := readLimitedInput(r, maxSize)
 	if err != nil {
 		return nil, err
 	}
@@ -106,13 +97,13 @@ func parseAutoSpans(r io.Reader) ([]Span, error) {
 	}
 }
 
-func readLimitedInput(r io.Reader) ([]byte, error) {
-	data, err := io.ReadAll(io.LimitReader(r, maxInputSize+1))
+func readLimitedInput(r io.Reader, maxSize int) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, int64(maxSize)+1))
 	if err != nil {
 		return nil, fmt.Errorf("reading input: %w", err)
 	}
-	if len(data) > maxInputSize {
-		return nil, fmt.Errorf("input exceeds maximum size of %d MB; stdouttrace and meta-summary inputs can be streamed with explicit --format", maxInputSize/(1024*1024))
+	if len(data) > maxSize {
+		return nil, fmt.Errorf("input exceeds maximum size of %s; stdouttrace and meta-summary inputs can be streamed with explicit --format", formatInputSize(maxSize))
 	}
 	data = bytes.TrimSpace(data)
 	if len(data) == 0 {
@@ -121,44 +112,11 @@ func readLimitedInput(r io.Reader) ([]byte, error) {
 	return data, nil
 }
 
-func readDetectionPrefix(br *bufio.Reader) ([]byte, []byte, error) {
-	var prefix []byte
-	for {
-		line, err := br.ReadBytes('\n')
-		if len(line) > 0 {
-			prefix = append(prefix, line...)
-			trimmed := bytes.TrimSpace(line)
-			if len(trimmed) > 0 {
-				return prefix, trimmed, nil
-			}
-		}
-		if errors.Is(err, io.EOF) {
-			if len(bytes.TrimSpace(prefix)) == 0 {
-				return nil, nil, fmt.Errorf("no spans found in input")
-			}
-			return prefix, bytes.TrimSpace(prefix), nil
-		}
-		if err != nil {
-			return nil, nil, fmt.Errorf("reading input: %w", err)
-		}
+func formatInputSize(size int) string {
+	if size >= bytesPerMegabyte {
+		return fmt.Sprintf("%d MB", size/bytesPerMegabyte)
 	}
-}
-
-func firstLineFormat(firstLine []byte) Format {
-	var probe map[string]json.RawMessage
-	if err := json.Unmarshal(firstLine, &probe); err != nil {
-		return ""
-	}
-	if _, ok := probe["SpanContext"]; ok {
-		return FormatStdouttrace
-	}
-	if _, ok := probe["resourceSpans"]; ok {
-		return FormatOTLP
-	}
-	if isJaegerData(probe["data"]) {
-		return FormatJaeger
-	}
-	return ""
+	return fmt.Sprintf("%d bytes", size)
 }
 
 // detectFormat examines the input to determine the format.

--- a/pkg/synth/traceimport/span.go
+++ b/pkg/synth/traceimport/span.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -35,38 +36,64 @@ type Format string
 
 // Supported trace input formats.
 const (
-	FormatAuto        Format = "auto"        // Detects the format from the input.
-	FormatStdouttrace Format = "stdouttrace" // Line-delimited JSON from the OTel stdout exporter.
-	FormatOTLP        Format = "otlp"        // OTLP protobuf JSON.
-	FormatJaeger      Format = "jaeger"      // Jaeger JSON export format (also used by Grafana Tempo).
+	FormatAuto        Format = "auto"         // Detects the format from the input.
+	FormatStdouttrace Format = "stdouttrace"  // Line-delimited JSON from the OTel stdout exporter.
+	FormatOTLP        Format = "otlp"         // OTLP protobuf JSON.
+	FormatJaeger      Format = "jaeger"       // Jaeger JSON export format (also used by Grafana Tempo).
+	FormatMetaSummary Format = "meta-summary" // Meta ATC 2023 parent-data.csv summary rows.
 )
 
 // maxInputSize is the maximum input size to prevent OOM on large trace exports.
 const maxInputSize = 256 * 1024 * 1024 // 256 MB
+const maxStdouttraceLineSize = 10 * 1024 * 1024
 
 // ParseSpans reads spans from the given reader in the specified format.
 // FormatAuto inspects the first JSON object to determine the format.
-// Input is limited to 256 MB to prevent OOM on large trace exports.
+// Whole-document JSON inputs are limited to 256 MB to prevent OOM on large trace
+// exports. Line-delimited stdouttrace inputs are scanned incrementally.
 func ParseSpans(r io.Reader, format Format) ([]Span, error) {
-	data, err := io.ReadAll(io.LimitReader(r, maxInputSize+1))
-	if err != nil {
-		return nil, fmt.Errorf("reading input: %w", err)
-	}
-	if len(data) > maxInputSize {
-		return nil, fmt.Errorf("input exceeds maximum size of %d MB", maxInputSize/(1024*1024))
-	}
-	data = bytes.TrimSpace(data)
-	if len(data) == 0 {
-		return nil, fmt.Errorf("no spans found in input")
-	}
-
-	if format == FormatAuto {
-		format, err = detectFormat(data)
+	switch format {
+	case FormatStdouttrace:
+		return parseStdouttraceReader(r)
+	case FormatAuto:
+		return parseAutoSpans(r)
+	case FormatOTLP:
+		data, err := readLimitedInput(r)
 		if err != nil {
 			return nil, err
 		}
+		return parseOTLP(data)
+	case FormatJaeger:
+		data, err := readLimitedInput(r)
+		if err != nil {
+			return nil, err
+		}
+		return parseJaeger(data)
+	case FormatMetaSummary:
+		return nil, fmt.Errorf("meta-summary input is summary data, not trace spans; use Import")
+	default:
+		return nil, fmt.Errorf("unknown format %q, valid formats: auto, stdouttrace, otlp, jaeger, meta-summary", format)
+	}
+}
+
+func parseAutoSpans(r io.Reader) ([]Span, error) {
+	br := bufio.NewReader(r)
+	prefix, firstLine, err := readDetectionPrefix(br)
+	if err != nil {
+		return nil, err
+	}
+	if firstLineFormat(firstLine) == FormatStdouttrace {
+		return parseStdouttraceReader(io.MultiReader(bytes.NewReader(prefix), br))
 	}
 
+	data, err := readLimitedInput(io.MultiReader(bytes.NewReader(prefix), br))
+	if err != nil {
+		return nil, err
+	}
+	format, err := detectFormat(data)
+	if err != nil {
+		return nil, err
+	}
 	switch format {
 	case FormatStdouttrace:
 		return parseStdouttrace(data)
@@ -75,8 +102,63 @@ func ParseSpans(r io.Reader, format Format) ([]Span, error) {
 	case FormatJaeger:
 		return parseJaeger(data)
 	default:
-		return nil, fmt.Errorf("unknown format %q, valid formats: auto, stdouttrace, otlp, jaeger", format)
+		return nil, fmt.Errorf("unknown format %q, valid formats: auto, stdouttrace, otlp, jaeger, meta-summary", format)
 	}
+}
+
+func readLimitedInput(r io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxInputSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading input: %w", err)
+	}
+	if len(data) > maxInputSize {
+		return nil, fmt.Errorf("input exceeds maximum size of %d MB; stdouttrace and meta-summary inputs can be streamed with explicit --format", maxInputSize/(1024*1024))
+	}
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return nil, fmt.Errorf("no spans found in input")
+	}
+	return data, nil
+}
+
+func readDetectionPrefix(br *bufio.Reader) ([]byte, []byte, error) {
+	var prefix []byte
+	for {
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 {
+			prefix = append(prefix, line...)
+			trimmed := bytes.TrimSpace(line)
+			if len(trimmed) > 0 {
+				return prefix, trimmed, nil
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			if len(bytes.TrimSpace(prefix)) == 0 {
+				return nil, nil, fmt.Errorf("no spans found in input")
+			}
+			return prefix, bytes.TrimSpace(prefix), nil
+		}
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading input: %w", err)
+		}
+	}
+}
+
+func firstLineFormat(firstLine []byte) Format {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(firstLine, &probe); err != nil {
+		return ""
+	}
+	if _, ok := probe["SpanContext"]; ok {
+		return FormatStdouttrace
+	}
+	if _, ok := probe["resourceSpans"]; ok {
+		return FormatOTLP
+	}
+	if isJaegerData(probe["data"]) {
+		return FormatJaeger
+	}
+	return ""
 }
 
 // detectFormat examines the input to determine the format.
@@ -172,9 +254,13 @@ var excludedAttributes = map[string]bool{
 }
 
 func parseStdouttrace(data []byte) ([]Span, error) {
+	return parseStdouttraceReader(bytes.NewReader(data))
+}
+
+func parseStdouttraceReader(r io.Reader) ([]Span, error) {
 	var spans []Span
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 1024*1024), maxStdouttraceLineSize)
 	lineNum := 0
 
 	for scanner.Scan() {

--- a/pkg/synth/traceimport/span_test.go
+++ b/pkg/synth/traceimport/span_test.go
@@ -133,6 +133,13 @@ func TestParseSpans_AutoDetect(t *testing.T) {
 	assert.Equal(t, "op", spans[0].Operation)
 }
 
+func TestParseSpans_AutoDetectSingleLineJSONRespectsInputLimit(t *testing.T) {
+	input := `{"resourceSpans":[]}` + strings.Repeat(" ", 32)
+	_, err := parseAutoSpans(strings.NewReader(input), len(`{"resourceSpans":[]}`)-1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "input exceeds maximum size")
+}
+
 func TestDetectFormat_PrettyPrintedOTLP(t *testing.T) {
 	input := "{\n  \"resourceSpans\": []\n}"
 	format, err := detectFormat([]byte(input))

--- a/pkg/synth/traceimport/stats.go
+++ b/pkg/synth/traceimport/stats.go
@@ -11,7 +11,6 @@ import (
 
 // OpStats accumulates statistics for a single (service, operation) pair.
 type OpStats struct {
-	Durations     []time.Duration
 	DurationCount int
 	DurationMean  float64
 	DurationM2    float64
@@ -63,7 +62,7 @@ func (c *StatsCollector) walkNode(node *SpanNode) {
 	op := c.getOp(svc, node.Span.Operation)
 
 	duration := node.Span.EndTime.Sub(node.Span.StartTime)
-	op.RecordDuration(duration, true)
+	op.RecordDuration(duration, 1)
 	op.TotalCount++
 	if node.Span.IsError {
 		op.ErrorCount++
@@ -102,15 +101,16 @@ func (c *StatsCollector) walkNode(node *SpanNode) {
 	}
 }
 
-func (o *OpStats) RecordDuration(d time.Duration, keepSample bool) {
-	o.DurationCount++
-	value := float64(d)
-	delta := value - o.DurationMean
-	o.DurationMean += delta / float64(o.DurationCount)
-	o.DurationM2 += delta * (value - o.DurationMean)
-	if keepSample {
-		o.Durations = append(o.Durations, d)
+func (o *OpStats) RecordDuration(d time.Duration, weight int) {
+	if weight <= 0 {
+		return
 	}
+	value := float64(d)
+	nextCount := o.DurationCount + weight
+	delta := value - o.DurationMean
+	o.DurationMean += delta * float64(weight) / float64(nextCount)
+	o.DurationM2 += delta * (value - o.DurationMean) * float64(weight)
+	o.DurationCount = nextCount
 }
 
 func (o *OpStats) meanDuration() time.Duration {
@@ -121,7 +121,7 @@ func (o *OpStats) meanDuration() time.Duration {
 		}
 		return mean
 	}
-	return MeanDuration(o.Durations)
+	return 0
 }
 
 func (o *OpStats) stdDevDuration() time.Duration {
@@ -131,7 +131,7 @@ func (o *OpStats) stdDevDuration() time.Duration {
 	if o.DurationCount == 1 {
 		return 0
 	}
-	return StdDevDuration(o.Durations)
+	return 0
 }
 
 func (o *OpStats) formatDuration() string {
@@ -204,45 +204,6 @@ func isSequential(children []*SpanNode) bool {
 		}
 	}
 	return true
-}
-
-// MeanDuration computes the mean of a duration slice.
-// Uses float64 accumulator to avoid int64 overflow on large inputs.
-func MeanDuration(durations []time.Duration) time.Duration {
-	if len(durations) == 0 {
-		return 0
-	}
-	var sum float64
-	for _, d := range durations {
-		sum += float64(d)
-	}
-	mean := time.Duration(sum / float64(len(durations)))
-	if mean <= 0 {
-		return time.Microsecond
-	}
-	return mean
-}
-
-// StdDevDuration computes the sample standard deviation of a duration slice.
-func StdDevDuration(durations []time.Duration) time.Duration {
-	if len(durations) < 2 {
-		return 0
-	}
-	mean := float64(MeanDuration(durations))
-	var sumSq float64
-	for _, d := range durations {
-		diff := float64(d) - mean
-		sumSq += diff * diff
-	}
-	return time.Duration(math.Sqrt(sumSq / float64(len(durations)-1)))
-}
-
-// FormatDuration produces a human-friendly distribution string.
-// Returns "Xms +/- Yms" when stddev is significant, or "Xms" when negligible.
-func FormatDuration(durations []time.Duration) string {
-	mean := MeanDuration(durations)
-	stddev := StdDevDuration(durations)
-	return formatDurationStats(mean, stddev)
 }
 
 func formatDurationStats(mean time.Duration, stddev time.Duration) string {

--- a/pkg/synth/traceimport/stats.go
+++ b/pkg/synth/traceimport/stats.go
@@ -11,10 +11,13 @@ import (
 
 // OpStats accumulates statistics for a single (service, operation) pair.
 type OpStats struct {
-	Durations  []time.Duration
-	ErrorCount int
-	TotalCount int
-	Calls      map[string]*CallStats // key: "targetService.targetOp"
+	Durations     []time.Duration
+	DurationCount int
+	DurationMean  float64
+	DurationM2    float64
+	ErrorCount    int
+	TotalCount    int
+	Calls         map[string]*CallStats // key: "targetService.targetOp"
 }
 
 // CallStats tracks how often a downstream call appears.
@@ -60,7 +63,7 @@ func (c *StatsCollector) walkNode(node *SpanNode) {
 	op := c.getOp(svc, node.Span.Operation)
 
 	duration := node.Span.EndTime.Sub(node.Span.StartTime)
-	op.Durations = append(op.Durations, duration)
+	op.RecordDuration(duration, true)
 	op.TotalCount++
 	if node.Span.IsError {
 		op.ErrorCount++
@@ -97,6 +100,42 @@ func (c *StatsCollector) walkNode(node *SpanNode) {
 	for _, child := range node.Children {
 		c.walkNode(child)
 	}
+}
+
+func (o *OpStats) RecordDuration(d time.Duration, keepSample bool) {
+	o.DurationCount++
+	value := float64(d)
+	delta := value - o.DurationMean
+	o.DurationMean += delta / float64(o.DurationCount)
+	o.DurationM2 += delta * (value - o.DurationMean)
+	if keepSample {
+		o.Durations = append(o.Durations, d)
+	}
+}
+
+func (o *OpStats) meanDuration() time.Duration {
+	if o.DurationCount > 0 {
+		mean := time.Duration(o.DurationMean)
+		if mean <= 0 {
+			return time.Microsecond
+		}
+		return mean
+	}
+	return MeanDuration(o.Durations)
+}
+
+func (o *OpStats) stdDevDuration() time.Duration {
+	if o.DurationCount > 1 {
+		return time.Duration(math.Sqrt(o.DurationM2 / float64(o.DurationCount-1)))
+	}
+	if o.DurationCount == 1 {
+		return 0
+	}
+	return StdDevDuration(o.Durations)
+}
+
+func (o *OpStats) formatDuration() string {
+	return formatDurationStats(o.meanDuration(), o.stdDevDuration())
 }
 
 func (c *StatsCollector) getService(name string) *ServiceStats {
@@ -203,7 +242,10 @@ func StdDevDuration(durations []time.Duration) time.Duration {
 func FormatDuration(durations []time.Duration) string {
 	mean := MeanDuration(durations)
 	stddev := StdDevDuration(durations)
+	return formatDurationStats(mean, stddev)
+}
 
+func formatDurationStats(mean time.Duration, stddev time.Duration) string {
 	meanStr := roundDuration(mean).String()
 	if stddev == 0 || float64(stddev) < float64(mean)*0.01 {
 		return meanStr

--- a/pkg/synth/traceimport/stats_test.go
+++ b/pkg/synth/traceimport/stats_test.go
@@ -9,35 +9,44 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMeanDuration(t *testing.T) {
-	durations := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
-	assert.Equal(t, 20*time.Millisecond, MeanDuration(durations))
-}
+func TestOpStatsDurationStats(t *testing.T) {
+	var op OpStats
+	op.RecordDuration(10*time.Millisecond, 1)
+	op.RecordDuration(20*time.Millisecond, 1)
+	op.RecordDuration(30*time.Millisecond, 1)
 
-func TestMeanDuration_Empty(t *testing.T) {
-	assert.Equal(t, time.Duration(0), MeanDuration(nil))
-}
-
-func TestStdDevDuration(t *testing.T) {
-	durations := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
-	stddev := StdDevDuration(durations)
+	assert.Equal(t, 3, op.DurationCount)
+	assert.Equal(t, 20*time.Millisecond, op.meanDuration())
+	stddev := op.stdDevDuration()
 	assert.InDelta(t, 10*time.Millisecond, stddev, float64(time.Millisecond))
 }
 
-func TestStdDevDuration_Single(t *testing.T) {
-	assert.Equal(t, time.Duration(0), StdDevDuration([]time.Duration{5 * time.Millisecond}))
+func TestOpStatsDurationStats_Weighted(t *testing.T) {
+	var op OpStats
+	op.RecordDuration(10*time.Millisecond, 2)
+	op.RecordDuration(40*time.Millisecond, 1)
+
+	assert.Equal(t, 3, op.DurationCount)
+	assert.Equal(t, 20*time.Millisecond, op.meanDuration())
+	assert.Contains(t, op.formatDuration(), "+/-")
 }
 
-func TestFormatDuration_WithVariance(t *testing.T) {
-	durations := []time.Duration{20 * time.Millisecond, 30 * time.Millisecond, 40 * time.Millisecond}
-	result := FormatDuration(durations)
+func TestOpStatsFormatDuration_WithVariance(t *testing.T) {
+	var op OpStats
+	op.RecordDuration(20*time.Millisecond, 1)
+	op.RecordDuration(30*time.Millisecond, 1)
+	op.RecordDuration(40*time.Millisecond, 1)
+
+	result := op.formatDuration()
 	assert.Contains(t, result, "+/-")
 	assert.Contains(t, result, "ms")
 }
 
-func TestFormatDuration_Fixed(t *testing.T) {
-	durations := []time.Duration{10 * time.Millisecond}
-	result := FormatDuration(durations)
+func TestOpStatsFormatDuration_Fixed(t *testing.T) {
+	var op OpStats
+	op.RecordDuration(10*time.Millisecond, 1)
+
+	result := op.formatDuration()
 	assert.NotContains(t, result, "+/-")
 }
 


### PR DESCRIPTION
## Summary

- Add `motel import --format meta-summary` for Meta ATC 2023 `parent-data.csv` and `parent-data.csv.gz` inputs.
- Stream Meta summary CSV rows directly into topology statistics, with `--profile` filtering, `--include-empty`, inferred call probabilities, and sequential/parallel call-style votes from `concurrency_rate`.
- Scan explicit `stdouttrace` imports line by line instead of reading the whole input behind the 256 MB JSON cap, while keeping OTLP and Jaeger whole-document inputs capped.
- Update import docs, the man page, the modeling how-to, and the Meta research workflow.

## Reasoning

The public Meta ATC 2023 data is summary CSV, not raw trace spans. Converting the full `parent-data.csv.gz` file to synthetic `stdouttrace` would be much larger than the existing read-all cap and would duplicate data just to recover parent-to-child observations already present in the CSV. A native `meta-summary` format preserves those observations directly and keeps memory proportional to discovered services and calls rather than to the uncompressed CSV body.

For generic trace imports, only line-delimited `stdouttrace` can be scanned incrementally without changing the semantics of OTLP or Jaeger parsing. Those JSON formats still require whole-document parsing, so they keep the existing safety cap and clearer guidance to use explicit streamed formats when appropriate.

Fixes https://github.com/andrewh/motel/issues/191
Fixes https://github.com/andrewh/motel/issues/192

## Validation

- `go test ./pkg/synth/traceimport`
- `go test ./cmd/motel`
- `make test`
- `make lint`
- `make build`
