### PR TITLE
docs(research): fix strict mkdocs build for pipeline testing note

### DIFF
--- a/docs/research/collector-pipeline-testing.md
+++ b/docs/research/collector-pipeline-testing.md
@@ -39,11 +39,10 @@ with rapid, generating topologies with motel's engine.
             (second in-memory exporter)               over both sets
 ```
 
-The proof-of-concept lives in
-[`pkg/pipelinetest`](../../pkg/pipelinetest) (the reusable I/O harness) and
-[`pkg/synth/pipeline_test.go`](../../pkg/synth/pipeline_test.go) (the
-invariants). It passes the trivial conservation invariant over 100 generated
-topologies and demonstrates that the harness detects a lossy pipeline.
+The proof-of-concept lives in `pkg/pipelinetest` (the reusable I/O harness) and
+`pkg/synth/pipeline_test.go` (the invariants). It passes the trivial
+conservation invariant over 100 generated topologies and demonstrates that the
+harness detects a lossy pipeline.
 
 ## Scope: library, not a subcommand
 
@@ -137,8 +136,8 @@ Config-varying tests pay one subprocess start per config.
 
 ## Proof of concept
 
-Three tests in [`pkg/synth/pipeline_test.go`](../../pkg/synth/pipeline_test.go)
-exercise the architecture against a real `otelcol` v0.128.0:
+Three tests in `pkg/synth/pipeline_test.go` exercise the architecture against a
+real `otelcol` v0.128.0:
 
 - **`TestPipeline_AllSpansRoundTrip`** — generates 20 traces from a fixed
   topology through a pass-through pipeline (`otlp` → `otlphttp`, no processors)
@@ -165,8 +164,8 @@ go test ./pkg/synth/ -run TestPipeline -v
 ```
 
 The sink decode path also has a standalone unit test
-([`pkg/pipelinetest/sink_test.go`](../../pkg/pipelinetest/sink_test.go)) that
-needs no collector, so the harness has always-on coverage.
+(`pkg/pipelinetest/sink_test.go`) that needs no collector, so the harness has
+always-on coverage.
 
 ## Productionisation note
 


### PR DESCRIPTION
## What

The collector pipeline testing design note (added for issue 73) broke the docs
build. It linked to source files with `../../pkg/...` paths that point outside
the docs tree, and `mkdocs build --strict` aborts because it cannot resolve the
`.go` targets among the documentation files.

This references those files as inline code spans instead, matching how the other
docs (e.g. property-testing.md) cite source. No prose changes.

## Why a PR

The two issue-73 commits landed directly on main earlier (a worktree push
misconfiguration), so the docs workflow ran on main and failed. Direct pushes to
main are blocked by a hook, so this corrective change comes via a PR.

## Verification

`make site` (`mkdocs build --strict`) exits 0 with no warnings.