### PR TITLE
[codex] Expose in-memory config parser

### DIFF
--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -358,13 +358,8 @@ func unwrapHTTPError(err error) error {
 	return err
 }
 
-// LoadConfig reads and parses a YAML topology from a file path or URL.
-func LoadConfig(source string) (*Config, error) {
-	data, err := readSource(source)
-	if err != nil {
-		return nil, fmt.Errorf("reading config: %w", err)
-	}
-
+// ParseConfig parses YAML topology data and normalizes it into a Config.
+func ParseConfig(data []byte) (*Config, error) {
 	var raw rawConfig
 	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
@@ -429,6 +424,16 @@ func LoadConfig(source string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// LoadConfig reads and parses a YAML topology from a file path or URL.
+func LoadConfig(source string) (*Config, error) {
+	data, err := readSource(source)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	return ParseConfig(data)
 }
 
 // ValidateConfig checks a configuration for structural correctness.

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -20,6 +20,64 @@ func writeTestConfig(t *testing.T, content string) string {
 	return path
 }
 
+func TestParseConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("normalizes service and operation maps", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := ParseConfig([]byte(`
+version: 1
+services:
+  user-service:
+    operations:
+      list:
+        duration: 20ms +/- 5ms
+  gateway:
+    operations:
+      POST /users:
+        duration: 35ms +/- 10ms
+      GET /users:
+        duration: 30ms +/- 10ms
+        calls:
+          - user-service.list
+traffic:
+  rate: 50/s
+`))
+		require.NoError(t, err)
+		assert.Equal(t, 1, cfg.Version)
+		assert.Equal(t, "50/s", cfg.Traffic.Rate)
+		require.Len(t, cfg.Services, 2)
+		assert.Equal(t, "gateway", cfg.Services[0].Name)
+		assert.Equal(t, "user-service", cfg.Services[1].Name)
+		require.Len(t, cfg.Services[0].Operations, 2)
+		assert.Equal(t, "GET /users", cfg.Services[0].Operations[0].Name)
+		assert.Equal(t, "POST /users", cfg.Services[0].Operations[1].Name)
+		assert.Equal(t, []CallConfig{{Target: "user-service.list"}}, cfg.Services[0].Operations[0].Calls)
+	})
+
+	t.Run("requires version", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseConfig([]byte(`
+services:
+  gateway:
+    operations:
+      GET /users:
+        duration: 30ms +/- 10ms
+traffic:
+  rate: 100/s
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required field: version")
+	})
+
+	t.Run("reports invalid YAML", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseConfig([]byte(`{{{invalid yaml`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing config")
+	})
+}
+
 func TestLoadConfig(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/synth/metrics_test.go
+++ b/pkg/synth/metrics_test.go
@@ -753,7 +753,8 @@ func TestMetricObserverIntervalCounter(t *testing.T) {
 	require.NoError(t, err)
 
 	stop := obs.Start()
-	t.Cleanup(stop)
+	var stopOnce sync.Once
+	t.Cleanup(func() { stopOnce.Do(stop) })
 
 	// No spans observed — emission is driven purely by the timer.
 	require.Eventually(t, func() bool {
@@ -767,6 +768,7 @@ func TestMetricObserverIntervalCounter(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "interval counter should accumulate without any spans")
 
 	// Span observation must not double-record interval instruments.
+	stopOnce.Do(stop)
 	before := func() float64 {
 		rm := collectMetrics(t, reader)
 		m := findMetric(rm, "gc.count")

--- a/pkg/synth/traceimport/fuzz_test.go
+++ b/pkg/synth/traceimport/fuzz_test.go
@@ -4,7 +4,6 @@ package traceimport
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/andrewh/motel/pkg/synth"
@@ -34,7 +33,7 @@ func FuzzParseSpans(f *testing.F) {
 
 // FuzzMarshalRoundTrip uses coverage-guided fuzzing to explore the full
 // import pipeline: generate spans → build trees → collect stats → marshal YAML
-// → load config → validate. Any generated input must produce valid output.
+// → parse config → validate. Any generated input must produce valid output.
 func FuzzMarshalRoundTrip(f *testing.F) {
 	f.Fuzz(rapid.MakeFuzz(func(t *rapid.T) {
 		spans := genMultiTraceSpans(t)
@@ -51,21 +50,9 @@ func FuzzMarshalRoundTrip(f *testing.F) {
 			t.Fatalf("MarshalConfig: %v", err)
 		}
 
-		tmpFile, err := os.CreateTemp("", "fuzz-test-*.yaml")
+		cfg, err := synth.ParseConfig(yamlBytes)
 		if err != nil {
-			t.Fatalf("creating temp file: %v", err)
-		}
-		defer os.Remove(tmpFile.Name())
-
-		if _, err := tmpFile.Write(yamlBytes); err != nil {
-			tmpFile.Close()
-			t.Fatalf("writing temp file: %v", err)
-		}
-		tmpFile.Close()
-
-		cfg, err := synth.LoadConfig(tmpFile.Name())
-		if err != nil {
-			t.Fatalf("LoadConfig failed on generated YAML:\n%s\nerror: %v", yamlBytes, err)
+			t.Fatalf("ParseConfig failed on generated YAML:\n%s\nerror: %v", yamlBytes, err)
 		}
 		if err := synth.ValidateConfig(cfg); err != nil {
 			t.Fatalf("ValidateConfig failed on generated YAML:\n%s\nerror: %v", yamlBytes, err)

--- a/pkg/synth/traceimport/infer.go
+++ b/pkg/synth/traceimport/infer.go
@@ -143,21 +143,7 @@ func computeWindow(trees []*TraceTree) float64 {
 
 // validateRoundTrip checks that the generated YAML parses and validates correctly.
 func validateRoundTrip(yamlBytes []byte) error {
-	f, err := os.CreateTemp("", "synth-infer-*.yaml")
-	if err != nil {
-		return fmt.Errorf("creating temp file: %w", err)
-	}
-	defer os.Remove(f.Name()) //nolint:errcheck // best-effort cleanup of temp file
-
-	if _, err := f.Write(yamlBytes); err != nil {
-		_ = f.Close()
-		return fmt.Errorf("writing temp file: %w", err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("closing temp file: %w", err)
-	}
-
-	cfg, err := synth.LoadConfig(f.Name())
+	cfg, err := synth.ParseConfig(yamlBytes)
 	if err != nil {
 		return err
 	}

--- a/pkg/synth/traceimport/property_test.go
+++ b/pkg/synth/traceimport/property_test.go
@@ -5,7 +5,6 @@ package traceimport
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -412,22 +411,9 @@ func TestProperty_MarshalConfig_ProducesValidTopology(t *testing.T) {
 			t.Fatalf("MarshalConfig: %v", err)
 		}
 
-		// Write to temp file for LoadConfig (it reads from disk)
-		f, err := os.CreateTemp("", "property-test-*.yaml")
+		cfg, err := synth.ParseConfig(yamlBytes)
 		if err != nil {
-			t.Fatalf("creating temp file: %v", err)
-		}
-		defer os.Remove(f.Name())
-
-		if _, err := f.Write(yamlBytes); err != nil {
-			f.Close()
-			t.Fatalf("writing temp file: %v", err)
-		}
-		f.Close()
-
-		cfg, err := synth.LoadConfig(f.Name())
-		if err != nil {
-			t.Fatalf("LoadConfig failed on generated YAML:\n%s\nerror: %v", yamlBytes, err)
+			t.Fatalf("ParseConfig failed on generated YAML:\n%s\nerror: %v", yamlBytes, err)
 		}
 		if err := synth.ValidateConfig(cfg); err != nil {
 			t.Fatalf("ValidateConfig failed on generated YAML:\n%s\nerror: %v", yamlBytes, err)
@@ -451,21 +437,9 @@ func TestProperty_MarshalConfig_ContainsAllServices(t *testing.T) {
 			t.Fatalf("MarshalConfig: %v", err)
 		}
 
-		f, err := os.CreateTemp("", "property-test-*.yaml")
+		cfg, err := synth.ParseConfig(yamlBytes)
 		if err != nil {
-			t.Fatalf("creating temp file: %v", err)
-		}
-		defer os.Remove(f.Name())
-
-		if _, err := f.Write(yamlBytes); err != nil {
-			f.Close()
-			t.Fatalf("writing temp file: %v", err)
-		}
-		f.Close()
-
-		cfg, err := synth.LoadConfig(f.Name())
-		if err != nil {
-			t.Fatalf("LoadConfig: %v", err)
+			t.Fatalf("ParseConfig: %v", err)
 		}
 
 		// Every service in stats should appear in the config


### PR DESCRIPTION
## Summary

- Add `synth.ParseConfig([]byte)` so callers with YAML bytes can reuse motel's topology decoding, version checks, and map-to-slice normalization.
- Keep `synth.LoadConfig` as the file-or-URL entrypoint by delegating to `ParseConfig` after source reads.
- Use `ParseConfig` in trace-import generated-YAML validation, property tests, and fuzz round trips instead of temporary files.
- Stabilize the existing interval-counter metrics test by stopping the background emitter before asserting `Observe` does not record interval-driven instruments.

## Validation

- `go test ./pkg/synth -run 'TestParseConfig|TestLoadConfig'`
- `go test ./pkg/synth/traceimport`
- `go test ./pkg/synth -run TestMetricObserverIntervalCounter -count=50`
- `go test ./...`
- `make test`
- `make lint`
- `make build`

Fixes #197
