### PR TITLE
[codex] Expose trace/span counts from traceimport.Import

### DIFF
--- a/cmd/motel/main.go
+++ b/cmd/motel/main.go
@@ -402,7 +402,7 @@ func importCmd() *cobra.Command {
 				r = f
 			}
 
-			yamlBytes, err := traceimport.Import(r, traceimport.Options{
+			result, err := traceimport.Import(r, traceimport.Options{
 				Format:           traceimport.Format(format),
 				MinTraces:        minTraces,
 				Warnings:         cmd.ErrOrStderr(),
@@ -416,7 +416,7 @@ func importCmd() *cobra.Command {
 				return err
 			}
 
-			_, err = cmd.OutOrStdout().Write(yamlBytes)
+			_, err = cmd.OutOrStdout().Write(result.YAML)
 			return err
 		},
 	}

--- a/pkg/synth/traceimport/infer.go
+++ b/pkg/synth/traceimport/infer.go
@@ -22,8 +22,15 @@ type Options struct {
 	MetaIncludeEmpty bool
 }
 
-// Import reads trace spans, analyses them, and produces a synth YAML config.
-func Import(r io.Reader, opts Options) ([]byte, error) {
+// Result contains the inferred topology and source counts from an import.
+type Result struct {
+	YAML       []byte
+	TraceCount int
+	SpanCount  int
+}
+
+// Import reads trace spans, analyses them, and produces a synth YAML topology.
+func Import(r io.Reader, opts Options) (Result, error) {
 	if opts.Warnings == nil {
 		opts.Warnings = os.Stderr
 	}
@@ -37,7 +44,7 @@ func Import(r io.Reader, opts Options) ([]byte, error) {
 	// Step 1: Parse spans
 	spans, err := ParseSpans(r, opts.Format)
 	if err != nil {
-		return nil, err
+		return Result{}, err
 	}
 
 	// Step 2: Build trace trees
@@ -66,15 +73,19 @@ func Import(r io.Reader, opts Options) ([]byte, error) {
 	// Step 6: Marshal to YAML
 	yamlBytes, err := MarshalConfig(collector, serviceAttrs, traceCount, len(spans), windowSecs)
 	if err != nil {
-		return nil, err
+		return Result{}, err
 	}
 
 	// Step 7: Round-trip validation
 	if err := validateRoundTrip(yamlBytes); err != nil {
-		return nil, fmt.Errorf("round-trip validation failed (this is a bug): %w", err)
+		return Result{}, fmt.Errorf("round-trip validation failed (this is a bug): %w", err)
 	}
 
-	return yamlBytes, nil
+	return Result{
+		YAML:       yamlBytes,
+		TraceCount: traceCount,
+		SpanCount:  len(spans),
+	}, nil
 }
 
 // inferServiceAttributes finds attributes with the same value on every span of a service.

--- a/pkg/synth/traceimport/infer.go
+++ b/pkg/synth/traceimport/infer.go
@@ -23,10 +23,20 @@ type Options struct {
 }
 
 // Result contains the inferred topology and source counts from an import.
+//
+// For span-based imports (OTLP, stdouttrace, auto) the counts are literal. For
+// Meta summary imports they are weighted estimates rather than observed values;
+// see the field comments.
 type Result struct {
-	YAML       []byte
+	// YAML is the inferred synth topology.
+	YAML []byte
+	// TraceCount is the number of source traces. For Meta summary imports it is
+	// the total weighted parent-sample count rather than a literal trace count.
 	TraceCount int
-	SpanCount  int
+	// SpanCount is the number of source spans. For Meta summary imports it is an
+	// estimate derived from the weighted call counts rather than a literal span
+	// count.
+	SpanCount int
 }
 
 // Import reads trace spans, analyses them, and produces a synth YAML topology.

--- a/pkg/synth/traceimport/infer_test.go
+++ b/pkg/synth/traceimport/infer_test.go
@@ -14,18 +14,25 @@ import (
 )
 
 func TestImport_StdouttraceFixture(t *testing.T) {
+	const (
+		expectedTraceCount = 55
+		expectedSpanCount  = 200
+	)
+
 	f, err := os.Open("testdata/basic-topology-stdout.jsonl")
 	require.NoError(t, err)
 	defer f.Close() //nolint:errcheck // test cleanup
 
 	var warnings bytes.Buffer
-	yamlBytes, err := Import(f, Options{
+	result, err := Import(f, Options{
 		Format:   FormatStdouttrace,
 		Warnings: &warnings,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, expectedTraceCount, result.TraceCount)
+	assert.Equal(t, expectedSpanCount, result.SpanCount)
 
-	yaml := string(yamlBytes)
+	yaml := string(result.YAML)
 
 	// Verify expected services are present
 	assert.Contains(t, yaml, "gateway:")
@@ -60,18 +67,25 @@ func TestImport_StdouttraceFixture(t *testing.T) {
 }
 
 func TestImport_OTLPFixture(t *testing.T) {
+	const (
+		expectedTraceCount = 1
+		expectedSpanCount  = 2
+	)
+
 	f, err := os.Open("testdata/single-trace-otlp.json")
 	require.NoError(t, err)
 	defer f.Close() //nolint:errcheck // test cleanup
 
 	var warnings bytes.Buffer
-	yamlBytes, err := Import(f, Options{
+	result, err := Import(f, Options{
 		Format:   FormatOTLP,
 		Warnings: &warnings,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, expectedTraceCount, result.TraceCount)
+	assert.Equal(t, expectedSpanCount, result.SpanCount)
 
-	yaml := string(yamlBytes)
+	yaml := string(result.YAML)
 	assert.Contains(t, yaml, "api-gateway:")
 	assert.Contains(t, yaml, "user-service:")
 	assert.Contains(t, yaml, "GET /users:")
@@ -87,43 +101,57 @@ func TestImport_AutoDetect(t *testing.T) {
 	defer f.Close() //nolint:errcheck // test cleanup
 
 	var warnings bytes.Buffer
-	yamlBytes, err := Import(f, Options{
+	result, err := Import(f, Options{
 		Format:   FormatAuto,
 		Warnings: &warnings,
 	})
 	require.NoError(t, err)
-	assert.Contains(t, string(yamlBytes), "gateway:")
+	assert.Contains(t, string(result.YAML), "gateway:")
 }
 
 func TestImport_MinimalSingleSpan(t *testing.T) {
+	const (
+		expectedTraceCount = 1
+		expectedSpanCount  = 1
+	)
+
 	line := `{"Name":"ping","SpanContext":{"TraceID":"aaa","SpanID":"bbb"},"Parent":{"TraceID":"aaa","SpanID":"0000000000000000"},"StartTime":"2024-01-01T00:00:00Z","EndTime":"2024-01-01T00:00:00.010Z","Attributes":[],"Status":{"Code":"Unset"},"InstrumentationScope":{"Name":"health"}}`
 
 	var warnings bytes.Buffer
-	yamlBytes, err := Import(strings.NewReader(line), Options{
+	result, err := Import(strings.NewReader(line), Options{
 		Format:   FormatStdouttrace,
 		Warnings: &warnings,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, expectedTraceCount, result.TraceCount)
+	assert.Equal(t, expectedSpanCount, result.SpanCount)
 
-	yaml := string(yamlBytes)
+	yaml := string(result.YAML)
 	assert.Contains(t, yaml, "health:")
 	assert.Contains(t, yaml, "ping:")
 	assert.Contains(t, yaml, "10ms")
 }
 
 func TestImport_WithErrors(t *testing.T) {
+	const (
+		expectedTraceCount = 2
+		expectedSpanCount  = 2
+	)
+
 	lines := strings.Join([]string{
 		`{"Name":"op","SpanContext":{"TraceID":"t1","SpanID":"s1"},"Parent":{"TraceID":"t1","SpanID":"0000000000000000"},"StartTime":"2024-01-01T00:00:00Z","EndTime":"2024-01-01T00:00:00.010Z","Attributes":[],"Status":{"Code":"Error"},"InstrumentationScope":{"Name":"svc"}}`,
 		`{"Name":"op","SpanContext":{"TraceID":"t2","SpanID":"s2"},"Parent":{"TraceID":"t2","SpanID":"0000000000000000"},"StartTime":"2024-01-01T00:00:01Z","EndTime":"2024-01-01T00:00:01.010Z","Attributes":[],"Status":{"Code":"Unset"},"InstrumentationScope":{"Name":"svc"}}`,
 	}, "\n")
 
 	var warnings bytes.Buffer
-	yamlBytes, err := Import(strings.NewReader(lines), Options{
+	result, err := Import(strings.NewReader(lines), Options{
 		Format:   FormatStdouttrace,
 		Warnings: &warnings,
 	})
 	require.NoError(t, err)
-	assert.Contains(t, string(yamlBytes), "error_rate: 50%")
+	assert.Equal(t, expectedTraceCount, result.TraceCount)
+	assert.Equal(t, expectedSpanCount, result.SpanCount)
+	assert.Contains(t, string(result.YAML), "error_rate: 50%")
 }
 
 func TestImport_EmptyInput(t *testing.T) {
@@ -182,6 +210,11 @@ func TestImport_MinTracesWarning(t *testing.T) {
 }
 
 func TestImport_MetaSummaryGzipProfileFilter(t *testing.T) {
+	const (
+		expectedTraceCount = 11
+		expectedSpanCount  = 32
+	)
+
 	csvData := strings.Join([]string{
 		"parent_name,children_set,num_calls,num_returning_calls,concurrency_rate,profile",
 		`root,"{'childA', 'childB'}",10.0,8.0,1,ads`,
@@ -197,14 +230,16 @@ func TestImport_MetaSummaryGzipProfileFilter(t *testing.T) {
 	require.NoError(t, gz.Close())
 
 	var warnings bytes.Buffer
-	yamlBytes, err := Import(&compressed, Options{
+	result, err := Import(&compressed, Options{
 		Format:      FormatMetaSummary,
 		MetaProfile: "ads",
 		Warnings:    &warnings,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, expectedTraceCount, result.TraceCount)
+	assert.Equal(t, expectedSpanCount, result.SpanCount)
 
-	yaml := string(yamlBytes)
+	yaml := string(result.YAML)
 	assert.Contains(t, yaml, metaServiceName("root")+":")
 	assert.Contains(t, yaml, metaServiceName("childA")+".invoke")
 	assert.Contains(t, yaml, metaServiceName("childB")+".invoke")
@@ -217,40 +252,54 @@ func TestImport_MetaSummaryGzipProfileFilter(t *testing.T) {
 }
 
 func TestImport_MetaSummarySequentialCallStyle(t *testing.T) {
+	const (
+		expectedTraceCount = 1
+		expectedSpanCount  = 3
+	)
+
 	csvData := strings.Join([]string{
 		"parent_name,children_set,num_calls,num_returning_calls,concurrency_rate,profile",
 		`root,"{'childA', 'childB'}",1,1,0,ads`,
 	}, "\n")
 
 	var warnings bytes.Buffer
-	yamlBytes, err := Import(strings.NewReader(csvData), Options{
+	result, err := Import(strings.NewReader(csvData), Options{
 		Format:   FormatMetaSummary,
 		Warnings: &warnings,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, expectedTraceCount, result.TraceCount)
+	assert.Equal(t, expectedSpanCount, result.SpanCount)
 
-	yaml := string(yamlBytes)
+	yaml := string(result.YAML)
 	assert.Contains(t, yaml, "call_style: sequential")
 	assert.Contains(t, warnings.String(), "only 1 weighted Meta parent sample")
 }
 
 func TestImport_MetaSummaryPreservesDistinctIngressIDs(t *testing.T) {
+	const (
+		expectedTraceCount = 2
+		expectedSpanCount  = 4
+	)
+
 	csvData := strings.Join([]string{
 		"parent_name,children_set,num_calls,num_returning_calls,concurrency_rate,profile",
 		`Service.A,"{'leaf'}",1,1,0,ads`,
 		`service-a,"{'leaf'}",1,1,0,ads`,
 	}, "\n")
 
-	yamlBytes, err := Import(strings.NewReader(csvData), Options{
+	result, err := Import(strings.NewReader(csvData), Options{
 		Format: FormatMetaSummary,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, expectedTraceCount, result.TraceCount)
+	assert.Equal(t, expectedSpanCount, result.SpanCount)
 
 	firstName := metaServiceName("Service.A")
 	secondName := metaServiceName("service-a")
 	require.NotEqual(t, firstName, secondName)
 
-	yaml := string(yamlBytes)
+	yaml := string(result.YAML)
 	assert.Contains(t, yaml, firstName+":")
 	assert.Contains(t, yaml, secondName+":")
 	assert.Contains(t, yaml, "meta.ingress_id: Service.A")

--- a/pkg/synth/traceimport/meta.go
+++ b/pkg/synth/traceimport/meta.go
@@ -59,22 +59,22 @@ type metaNameMapper struct {
 	attrs map[string]map[string]string
 }
 
-func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
+func importMetaSummary(r io.Reader, opts Options) (Result, error) {
 	reader, closeReader, err := metaInputReader(r)
 	if err != nil {
-		return nil, err
+		return Result{}, err
 	}
 	defer closeReader()
 
 	csvReader := csv.NewReader(reader)
 	header, err := csvReader.Read()
 	if err != nil {
-		return nil, fmt.Errorf("read Meta summary header: %w", err)
+		return Result{}, fmt.Errorf("read Meta summary header: %w", err)
 	}
 	cols := indexMetaHeader(header)
 	for _, name := range requiredMetaSummaryColumns {
 		if _, ok := cols[name]; !ok {
-			return nil, fmt.Errorf("missing required Meta summary column %q", name)
+			return Result{}, fmt.Errorf("missing required Meta summary column %q", name)
 		}
 	}
 
@@ -92,11 +92,11 @@ func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("read Meta summary row %d: %w", rowNumber, err)
+			return Result{}, fmt.Errorf("read Meta summary row %d: %w", rowNumber, err)
 		}
 		row, err := parseMetaParentRow(record, cols)
 		if err != nil {
-			return nil, fmt.Errorf("parse Meta summary row %d: %w", rowNumber, err)
+			return Result{}, fmt.Errorf("parse Meta summary row %d: %w", rowNumber, err)
 		}
 		if opts.MetaProfile != "" && row.profile != opts.MetaProfile {
 			continue
@@ -113,7 +113,7 @@ func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
 	}
 
 	if rowCount == 0 {
-		return nil, errors.New("no Meta summary rows matched the requested filters")
+		return Result{}, errors.New("no Meta summary rows matched the requested filters")
 	}
 	if sampleCount < opts.MinTraces {
 		_, _ = fmt.Fprintf(opts.Warnings, "warning: only %d weighted Meta parent samples available from %d rows (requested minimum: %d); results may be inaccurate\n",
@@ -126,12 +126,16 @@ func importMetaSummary(r io.Reader, opts Options) ([]byte, error) {
 
 	yamlBytes, err := MarshalConfig(collector, names.serviceAttributes(), sampleCount, spanCount, 0)
 	if err != nil {
-		return nil, err
+		return Result{}, err
 	}
 	if err := validateRoundTrip(yamlBytes); err != nil {
-		return nil, fmt.Errorf("round-trip validation failed (this is a bug): %w", err)
+		return Result{}, fmt.Errorf("round-trip validation failed (this is a bug): %w", err)
 	}
-	return yamlBytes, nil
+	return Result{
+		YAML:       yamlBytes,
+		TraceCount: sampleCount,
+		SpanCount:  spanCount,
+	}, nil
 }
 
 func metaInputReader(r io.Reader) (io.Reader, func() error, error) {


### PR DESCRIPTION
## Summary

- Change `traceimport.Import` to return a `traceimport.Result` containing the inferred YAML plus source trace and span counts.
- Populate counts for both span-based imports and Meta summary imports.
- Keep CLI behavior unchanged by writing only `result.YAML` from `motel import`.
- Add traceimport assertions covering returned counts for fixture, inline, and Meta summary imports.

## Impact

Consumers can reuse the public import pipeline and display import stats without copying unexported helpers or reimplementing the pipeline. The CLI output remains unchanged.

Fixes https://github.com/andrewh/motel/issues/202

## Validation

- `make test`
- `make lint`
