### PR TITLE
[codex] support Grafana OTLP JSON exports

### DIFF
--- a/pkg/synth/traceimport/span.go
+++ b/pkg/synth/traceimport/span.go
@@ -129,7 +129,7 @@ func detectFormat(data []byte) (Format, error) {
 		if _, ok := probe["SpanContext"]; ok {
 			return FormatStdouttrace, nil
 		}
-		if _, ok := probe["resourceSpans"]; ok {
+		if isOTLPProbe(probe) {
 			return FormatOTLP, nil
 		}
 		if isJaegerData(probe["data"]) {
@@ -141,7 +141,7 @@ func detectFormat(data []byte) (Format, error) {
 	// Try the full input as a single JSON document.
 	if hasMore {
 		if err := json.Unmarshal(data, &probe); err == nil {
-			if _, ok := probe["resourceSpans"]; ok {
+			if isOTLPProbe(probe) {
 				return FormatOTLP, nil
 			}
 			if _, ok := probe["SpanContext"]; ok {
@@ -153,7 +153,15 @@ func detectFormat(data []byte) (Format, error) {
 		}
 	}
 
-	return "", fmt.Errorf("cannot detect format: input has neither SpanContext (stdouttrace), resourceSpans (OTLP), nor data[].spans[].operationName (Jaeger/Tempo)")
+	return "", fmt.Errorf("cannot detect format: input has neither SpanContext (stdouttrace), resourceSpans/batches (OTLP), nor data[].spans[].operationName (Jaeger/Tempo)")
+}
+
+func isOTLPProbe(probe map[string]json.RawMessage) bool {
+	if _, ok := probe["resourceSpans"]; ok {
+		return true
+	}
+	_, ok := probe["batches"]
+	return ok
 }
 
 // stdouttraceEvent mirrors the Go SDK's stdouttrace JSON output.
@@ -517,9 +525,41 @@ type otlpTraces struct {
 	ResourceSpans []otlpResourceSpans `json:"resourceSpans"`
 }
 
+func (t *otlpTraces) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		ResourceSpans []otlpResourceSpans `json:"resourceSpans"`
+		Batches       []otlpResourceSpans `json:"batches"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	t.ResourceSpans = wire.ResourceSpans
+	if t.ResourceSpans == nil {
+		t.ResourceSpans = wire.Batches
+	}
+	return nil
+}
+
 type otlpResourceSpans struct {
 	Resource   otlpResource     `json:"resource"`
 	ScopeSpans []otlpScopeSpans `json:"scopeSpans"`
+}
+
+func (rs *otlpResourceSpans) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		Resource                    otlpResource     `json:"resource"`
+		ScopeSpans                  []otlpScopeSpans `json:"scopeSpans"`
+		InstrumentationLibrarySpans []otlpScopeSpans `json:"instrumentationLibrarySpans"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	rs.Resource = wire.Resource
+	rs.ScopeSpans = wire.ScopeSpans
+	if rs.ScopeSpans == nil {
+		rs.ScopeSpans = wire.InstrumentationLibrarySpans
+	}
+	return nil
 }
 
 type otlpResource struct {
@@ -529,6 +569,26 @@ type otlpResource struct {
 type otlpScopeSpans struct {
 	Scope otlpScope  `json:"scope"`
 	Spans []otlpSpan `json:"spans"`
+}
+
+func (ss *otlpScopeSpans) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		Scope                  *otlpScope `json:"scope"`
+		InstrumentationLibrary *otlpScope `json:"instrumentationLibrary"`
+		Spans                  []otlpSpan `json:"spans"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	if wire.Scope != nil {
+		ss.Scope = *wire.Scope
+	} else if wire.InstrumentationLibrary != nil {
+		ss.Scope = *wire.InstrumentationLibrary
+	} else {
+		ss.Scope = otlpScope{}
+	}
+	ss.Spans = wire.Spans
+	return nil
 }
 
 type otlpScope struct {

--- a/pkg/synth/traceimport/span_test.go
+++ b/pkg/synth/traceimport/span_test.go
@@ -24,6 +24,13 @@ func TestDetectFormat_OTLP(t *testing.T) {
 	assert.Equal(t, FormatOTLP, format)
 }
 
+func TestDetectFormat_GrafanaTempoBatches(t *testing.T) {
+	input := `{"batches":[{"resource":{},"instrumentationLibrarySpans":[]}]}`
+	format, err := detectFormat([]byte(input))
+	require.NoError(t, err)
+	assert.Equal(t, FormatOTLP, format)
+}
+
 func TestDetectFormat_Unknown(t *testing.T) {
 	input := `{"something":"else"}`
 	_, err := detectFormat([]byte(input))
@@ -99,6 +106,37 @@ func TestParseOTLP_Basic(t *testing.T) {
 	assert.Equal(t, "api", s.Service)
 	assert.Equal(t, "GET /users", s.Operation)
 	assert.False(t, s.IsError)
+	assert.Equal(t, "GET", s.Attributes["http.method"])
+}
+
+func TestParseOTLP_GrafanaTempoExport(t *testing.T) {
+	input := `{
+		"batches": [{
+			"resource": {"attributes": []},
+			"instrumentationLibrarySpans": [{
+				"instrumentationLibrary": {"name": "api-gateway"},
+				"spans": [{
+					"traceId": "AQIDBAUGBwgJCgsMDQ4PEA==",
+					"spanId": "AQIDBAUGBwg=",
+					"name": "GET /users",
+					"startTimeUnixNano": "1700000000000000000",
+					"endTimeUnixNano": "1700000000030000000",
+					"status": {},
+					"attributes": [{"key": "http.method", "value": {"stringValue": "GET"}}]
+				}]
+			}]
+		}]
+	}`
+
+	spans, err := ParseSpans(strings.NewReader(input), FormatAuto)
+	require.NoError(t, err)
+	require.Len(t, spans, 1)
+
+	s := spans[0]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", s.TraceID)
+	assert.Equal(t, "0102030405060708", s.SpanID)
+	assert.Equal(t, "api-gateway", s.Service)
+	assert.Equal(t, "GET /users", s.Operation)
 	assert.Equal(t, "GET", s.Attributes["http.method"])
 }
 


### PR DESCRIPTION
## Summary

- Treat Grafana trace-viewer `batches` wrappers as OTLP during format detection.
- Decode `batches`, `instrumentationLibrarySpans`, and `instrumentationLibrary` aliases in the slim OTLP JSON parser.
- Add regression tests for detection and importing a Grafana-shaped export through `FormatAuto`.

## Validation

- `go test ./pkg/synth/traceimport`
- `make test`
- `make lint`
- `make build`

Fixes https://github.com/andrewh/motel/issues/207