### PR TITLE
fix(traceimport): decode hex-encoded OTLP trace/span IDs

### DIFF
--- a/pkg/synth/traceimport/span.go
+++ b/pkg/synth/traceimport/span.go
@@ -652,6 +652,19 @@ func (id *otlpID) UnmarshalJSON(data []byte) error {
 		*id = nil
 		return nil
 	}
+	// OTLP/JSON nominally base64-encodes IDs, but many real exporters (and
+	// Jaeger/Tempo-derived JSON) emit hex. A canonical hex trace ID (32 chars)
+	// or span ID (16 chars) is also valid base64 over the same alphabet, so
+	// "try base64 first" silently mis-decodes hex into 24/12 bytes. Decode hex
+	// first when the string is a canonical-length hex ID. This is unambiguous:
+	// OTLP IDs are only ever 8 or 16 bytes, and their base64 forms are never 16
+	// or 32 chars, so a 16/32-char all-hex string is always hex.
+	if len(s) == 16 || len(s) == 32 {
+		if b, err := hex.DecodeString(s); err == nil {
+			*id = b
+			return nil
+		}
+	}
 	for _, enc := range []*base64.Encoding{
 		base64.StdEncoding, base64.RawStdEncoding,
 		base64.URLEncoding, base64.RawURLEncoding,

--- a/pkg/synth/traceimport/span_test.go
+++ b/pkg/synth/traceimport/span_test.go
@@ -110,6 +110,38 @@ func TestParseOTLP_Basic(t *testing.T) {
 	assert.Equal(t, "GET", s.Attributes["http.method"])
 }
 
+// TestParseOTLP_HexEncodedIDs covers exporters that emit trace/span IDs as hex
+// rather than the OTLP/JSON-canonical base64. Hex is a subset of the base64
+// alphabet, so a 32-char hex trace ID would otherwise be mis-decoded as base64
+// into 24 bytes, corrupting the ID (and later breaking --preserve-ids replay,
+// which requires a 32-char hex trace ID).
+func TestParseOTLP_HexEncodedIDs(t *testing.T) {
+	input := `{
+		"resourceSpans": [{
+			"resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "api"}}]},
+			"scopeSpans": [{"scope": {"name": "api"}, "spans": [{
+				"traceId": "9da7c5910d265353de4ae5973ea6b727",
+				"spanId": "b86a4a145c519715",
+				"parentSpanId": "0312e23151fd56ee",
+				"name": "GET /users",
+				"startTimeUnixNano": "1700000000000000000",
+				"endTimeUnixNano": "1700000000030000000",
+				"status": {}
+			}]}]
+		}]
+	}`
+
+	spans, err := ParseSpans(strings.NewReader(input), FormatOTLP)
+	require.NoError(t, err)
+	require.Len(t, spans, 1)
+
+	s := spans[0]
+	assert.Equal(t, "9da7c5910d265353de4ae5973ea6b727", s.TraceID)
+	assert.Len(t, s.TraceID, 32)
+	assert.Equal(t, "b86a4a145c519715", s.SpanID)
+	assert.Equal(t, "0312e23151fd56ee", s.ParentID)
+}
+
 func TestParseOTLP_GrafanaTempoExport(t *testing.T) {
 	input := `{
 		"batches": [{


### PR DESCRIPTION
## Problem

OTLP/JSON nominally base64-encodes trace and span IDs, but many real exporters (and Jaeger/Tempo-derived JSON) emit **hex**. Hex digits `[0-9a-f]` are a subset of the base64 alphabet, so the OTLP ID decoder's "try base64 first" path silently mis-decoded a 32-char hex trace ID into 24 bytes, corrupting it:

```
9da7c5910d265353de4ae5973ea6b727   (valid 16-byte ID, 32 hex chars)
        ↓ wrongly base64-decoded → 24 bytes ↓
f5d6bb739f75d1ddbae77e7775ee1a7b9f7bdde6ba6fbdbb   (48 hex chars)
```

Topology inference tolerated this (IDs are only used to group spans, and the corruption was consistent), so it only surfaced on the replay path: importing with a recording and replaying with `--preserve-ids` failed with `invalid recorded trace ID "...": hex encoded trace-id must have length equals to 32`.

## Fix

Decode hex first when the string is a canonical-length hex ID (16 or 32 chars), falling back to base64 otherwise. This is unambiguous: OTLP IDs are only ever 8 or 16 bytes, and their base64 forms are never 16 or 32 chars, so there is no collision with legitimately base64-encoded IDs (existing base64 fixtures are 12/24 chars and are unaffected).

## Verification

- A 250-span hex-ID OTLP trace now records the correct 32-char `trace_id`, and `--preserve-ids --verbatim` replay emits all spans with the original ID and no error.
- New regression test `TestParseOTLP_HexEncodedIDs`.
- Full `go test ./...`, `go vet`, and `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WE3qpE4o2B3prT9zuatxB8)_