### PR TITLE
feat: support attributes on span links

### DIFF
--- a/docs/examples/span-links.yaml
+++ b/docs/examples/span-links.yaml
@@ -19,7 +19,13 @@ services:
         duration: 15ms +/- 5ms
         error_rate: 0.5%
         links:
-          - producer.enqueue
+          # Bare-string form (no attributes):
+          # - producer.enqueue
+          # Structured form with link attributes:
+          - ref: producer.enqueue
+            attributes:
+              messaging.message.id: "msg-001"
+              link.relationship: "async-produce"
 
 traffic:
   rate: 10/s

--- a/docs/examples/span-links.yaml
+++ b/docs/examples/span-links.yaml
@@ -24,8 +24,12 @@ services:
           # Structured form with link attributes:
           - ref: producer.enqueue
             attributes:
-              messaging.message.id: "msg-001"
-              link.relationship: "async-produce"
+              messaging.message.id:
+                value: "msg-001"
+              messaging.batch.message.index:
+                value: 0
+              link.relationship:
+                value: "async-produce"
 
 traffic:
   rate: 10/s

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -195,10 +195,11 @@ type MetricConfig struct {
 //	links:
 //	  - ref: service.operation
 //	    attributes:
-//	      messaging.message.id: "abc"
+//	      messaging.message.id:
+//	        value: "abc"
 type LinkConfig struct {
-	Ref        string            `yaml:"ref"`
-	Attributes map[string]string `yaml:"attributes,omitempty"`
+	Ref        string                          `yaml:"ref"`
+	Attributes map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
 }
 
 // UnmarshalYAML allows LinkConfig to be specified as either a bare string
@@ -670,6 +671,11 @@ func ValidateConfig(cfg *Config) error {
 				}
 				if seenLinks[link.Ref] {
 					return fmt.Errorf("service %q operation %q: duplicate link %q", svc.Name, op.Name, link.Ref)
+				}
+				for attrName, attrCfg := range link.Attributes {
+					if _, err := NewAttributeGenerator(attrCfg); err != nil {
+						return fmt.Errorf("service %q operation %q link %q: attribute %q: %w", svc.Name, op.Name, link.Ref, attrName, err)
+					}
 				}
 				seenLinks[link.Ref] = true
 			}

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -188,6 +188,35 @@ type MetricConfig struct {
 	Attributes map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
 }
 
+// LinkConfig represents a span link target with optional attributes.
+// It supports both bare-string form ("service.operation") and structured form
+// with attributes:
+//
+//	links:
+//	  - ref: service.operation
+//	    attributes:
+//	      messaging.message.id: "abc"
+type LinkConfig struct {
+	Ref        string            `yaml:"ref"`
+	Attributes map[string]string `yaml:"attributes,omitempty"`
+}
+
+// UnmarshalYAML allows LinkConfig to be specified as either a bare string
+// ("service.operation") or a struct with ref and attributes.
+func (lc *LinkConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		lc.Ref = value.Value
+		return nil
+	}
+	type linkConfigRaw LinkConfig
+	var raw linkConfigRaw
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*lc = LinkConfig(raw)
+	return nil
+}
+
 // rawOperationConfig is the YAML representation of an operation before normalisation.
 type rawOperationConfig struct {
 	Domain         string                          `yaml:"domain,omitempty"`
@@ -197,7 +226,7 @@ type rawOperationConfig struct {
 	CallStyle      string                          `yaml:"call_style,omitempty"`
 	Attributes     map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
 	Events         []EventConfig                   `yaml:"events,omitempty"`
-	Links          []string                        `yaml:"links,omitempty"`
+	Links          []LinkConfig                    `yaml:"links,omitempty"`
 	Metrics        []MetricConfig                  `yaml:"metrics,omitempty"`
 	Logs           []LogConfig                     `yaml:"logs,omitempty"`
 	QueueDepth     int                             `yaml:"queue_depth,omitempty"`
@@ -225,7 +254,7 @@ type OperationConfig struct {
 	CallStyle      string
 	Attributes     map[string]AttributeValueConfig
 	Events         []EventConfig
-	Links          []string
+	Links          []LinkConfig
 	Metrics        []MetricConfig
 	Logs           []LogConfig
 	QueueDepth     int
@@ -627,19 +656,22 @@ func ValidateConfig(cfg *Config) error {
 			ref := svc.Name + "." + op.Name
 			seenLinks := make(map[string]bool, len(op.Links))
 			for _, link := range op.Links {
-				if !strings.Contains(link, ".") {
-					return fmt.Errorf("service %q operation %q: link %q must be in service.operation format", svc.Name, op.Name, link)
+				if link.Ref == "" {
+					return fmt.Errorf("service %q operation %q: link must have a non-empty ref", svc.Name, op.Name)
 				}
-				if !knownOps[link] {
-					return fmt.Errorf("service %q operation %q: link %q references unknown operation", svc.Name, op.Name, link)
+				if !strings.Contains(link.Ref, ".") {
+					return fmt.Errorf("service %q operation %q: link %q must be in service.operation format", svc.Name, op.Name, link.Ref)
 				}
-				if link == ref {
+				if !knownOps[link.Ref] {
+					return fmt.Errorf("service %q operation %q: link %q references unknown operation", svc.Name, op.Name, link.Ref)
+				}
+				if link.Ref == ref {
 					return fmt.Errorf("service %q operation %q: link must not reference itself", svc.Name, op.Name)
 				}
-				if seenLinks[link] {
-					return fmt.Errorf("service %q operation %q: duplicate link %q", svc.Name, op.Name, link)
+				if seenLinks[link.Ref] {
+					return fmt.Errorf("service %q operation %q: duplicate link %q", svc.Name, op.Name, link.Ref)
 				}
-				seenLinks[link] = true
+				seenLinks[link.Ref] = true
 			}
 
 			for _, call := range op.Calls {

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -1461,7 +1461,7 @@ func TestValidateConfigLinks(t *testing.T) {
 					Operations: []OperationConfig{{
 						Name:     "dequeue",
 						Duration: "10ms",
-						Links:    []string{"producer.enqueue"},
+						Links:    []LinkConfig{{Ref: "producer.enqueue"}},
 					}},
 				},
 			},
@@ -1479,7 +1479,7 @@ func TestValidateConfigLinks(t *testing.T) {
 				Operations: []OperationConfig{{
 					Name:     "op",
 					Duration: "10ms",
-					Links:    []string{"unknown.op"},
+					Links:    []LinkConfig{{Ref: "unknown.op"}},
 				}},
 			}},
 			Traffic: TrafficConfig{Rate: "10/s"},
@@ -1497,7 +1497,7 @@ func TestValidateConfigLinks(t *testing.T) {
 				Operations: []OperationConfig{{
 					Name:     "op",
 					Duration: "10ms",
-					Links:    []string{"nope"},
+					Links:    []LinkConfig{{Ref: "nope"}},
 				}},
 			}},
 			Traffic: TrafficConfig{Rate: "10/s"},
@@ -1515,7 +1515,7 @@ func TestValidateConfigLinks(t *testing.T) {
 				Operations: []OperationConfig{{
 					Name:     "op",
 					Duration: "10ms",
-					Links:    []string{"svc.op"},
+					Links:    []LinkConfig{{Ref: "svc.op"}},
 				}},
 			}},
 			Traffic: TrafficConfig{Rate: "10/s"},
@@ -1541,7 +1541,7 @@ func TestValidateConfigLinks(t *testing.T) {
 					Operations: []OperationConfig{{
 						Name:     "dequeue",
 						Duration: "10ms",
-						Links:    []string{"producer.enqueue", "producer.enqueue"},
+						Links:    []LinkConfig{{Ref: "producer.enqueue"}, {Ref: "producer.enqueue"}},
 					}},
 				},
 			},
@@ -1550,6 +1550,65 @@ func TestValidateConfigLinks(t *testing.T) {
 		err := ValidateConfig(cfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate link")
+	})
+}
+
+func TestParseLinkConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bare string form", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := ParseConfig([]byte(`
+version: 1
+services:
+  producer:
+    operations:
+      enqueue:
+        duration: 5ms
+  consumer:
+    operations:
+      dequeue:
+        duration: 10ms
+        links:
+          - producer.enqueue
+traffic:
+  rate: 1/s
+`))
+		require.NoError(t, err)
+		// Services are sorted: consumer[0], producer[1]
+		require.Len(t, cfg.Services[0].Operations[0].Links, 1)
+		assert.Equal(t, "producer.enqueue", cfg.Services[0].Operations[0].Links[0].Ref)
+		assert.Empty(t, cfg.Services[0].Operations[0].Links[0].Attributes)
+	})
+
+	t.Run("structured form with attributes", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := ParseConfig([]byte(`
+version: 1
+services:
+  producer:
+    operations:
+      enqueue:
+        duration: 5ms
+  consumer:
+    operations:
+      dequeue:
+        duration: 10ms
+        links:
+          - ref: producer.enqueue
+            attributes:
+              messaging.message.id: msg-42
+              link.type: async
+traffic:
+  rate: 1/s
+`))
+		require.NoError(t, err)
+		// Services are sorted: consumer[0], producer[1]
+		require.Len(t, cfg.Services[0].Operations[0].Links, 1)
+		lnk := cfg.Services[0].Operations[0].Links[0]
+		assert.Equal(t, "producer.enqueue", lnk.Ref)
+		assert.Equal(t, "msg-42", lnk.Attributes["messaging.message.id"])
+		assert.Equal(t, "async", lnk.Attributes["link.type"])
 	})
 }
 

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -1551,6 +1551,38 @@ func TestValidateConfigLinks(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate link")
 	})
+
+	t.Run("invalid link attribute", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Services: []ServiceConfig{
+				{
+					Name: "producer",
+					Operations: []OperationConfig{{
+						Name:     "enqueue",
+						Duration: "5ms",
+					}},
+				},
+				{
+					Name: "consumer",
+					Operations: []OperationConfig{{
+						Name:     "dequeue",
+						Duration: "10ms",
+						Links: []LinkConfig{{
+							Ref: "producer.enqueue",
+							Attributes: map[string]AttributeValueConfig{
+								"batch.position": {},
+							},
+						}},
+					}},
+				},
+			},
+			Traffic: TrafficConfig{Rate: "10/s"},
+		}
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `link "producer.enqueue": attribute "batch.position"`)
+	})
 }
 
 func TestParseLinkConfig(t *testing.T) {
@@ -1597,8 +1629,10 @@ services:
         links:
           - ref: producer.enqueue
             attributes:
-              messaging.message.id: msg-42
-              link.type: async
+              messaging.message.id:
+                value: msg-42
+              messaging.batch.message.index:
+                value: 7
 traffic:
   rate: 1/s
 `))
@@ -1607,8 +1641,8 @@ traffic:
 		require.Len(t, cfg.Services[0].Operations[0].Links, 1)
 		lnk := cfg.Services[0].Operations[0].Links[0]
 		assert.Equal(t, "producer.enqueue", lnk.Ref)
-		assert.Equal(t, "msg-42", lnk.Attributes["messaging.message.id"])
-		assert.Equal(t, "async", lnk.Attributes["link.type"])
+		assert.Equal(t, "msg-42", lnk.Attributes["messaging.message.id"].Value)
+		assert.Equal(t, 7, lnk.Attributes["messaging.batch.message.index"].Value)
 	})
 }
 

--- a/pkg/synth/emit.go
+++ b/pkg/synth/emit.go
@@ -78,9 +78,9 @@ func emitTrace(ctx context.Context, plans []SpanPlan, baseSimTime time.Time, bas
 			}
 			if len(plan.LinkRefs) > 0 && registry != nil {
 				var links []trace.Link
-				for _, ref := range plan.LinkRefs {
-					if sc, ok := registry.load(ref); ok {
-						links = append(links, trace.Link{SpanContext: sc})
+				for _, lr := range plan.LinkRefs {
+					if sc, ok := registry.load(lr.Ref); ok {
+						links = append(links, trace.Link{SpanContext: sc, Attributes: lr.Attributes})
 					}
 				}
 				if len(links) > 0 {

--- a/pkg/synth/emit_test.go
+++ b/pkg/synth/emit_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -119,6 +120,76 @@ func TestEmitTraceProducesSpans(t *testing.T) {
 	assert.Equal(t, "list", child.Name)
 	assert.Equal(t, root.SpanContext.SpanID(), child.Parent.SpanID())
 	assert.Equal(t, root.SpanContext.TraceID(), child.SpanContext.TraceID())
+}
+
+func TestEmitTraceSpanLinkAttributes(t *testing.T) {
+	t.Parallel()
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	tracers := func(name string) trace.Tracer { return tp.Tracer(name) }
+
+	now := time.Now()
+	plans := []SpanPlan{
+		{
+			Index:       0,
+			ParentIndex: -1,
+			Ref:         "producer.enqueue",
+			Service:     "producer",
+			Operation:   "enqueue",
+			Kind:        trace.SpanKindServer,
+			StartTime:   now,
+			EndTime:     now.Add(20 * time.Millisecond),
+		},
+		{
+			Index:       1,
+			ParentIndex: -1,
+			Ref:         "consumer.dequeue",
+			Service:     "consumer",
+			Operation:   "dequeue",
+			Kind:        trace.SpanKindServer,
+			StartTime:   now.Add(5 * time.Millisecond),
+			EndTime:     now.Add(15 * time.Millisecond),
+			LinkRefs: []LinkRef{{
+				Ref: "producer.enqueue",
+				Attributes: []attribute.KeyValue{
+					attribute.String("messaging.message.id", "msg-42"),
+					attribute.Int("messaging.batch.message.index", 7),
+				},
+			}},
+		},
+	}
+
+	registry := &spanContextRegistry{
+		ctx:     make(map[string]trace.SpanContext),
+		targets: map[string]bool{"producer.enqueue": true},
+	}
+
+	var rstats realtimeStats
+	emitTrace(context.Background(), plans, now, time.Now(), tracers, nil, &rstats, registry)
+
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 2)
+
+	byName := make(map[string]tracetest.SpanStub, len(spans))
+	for _, span := range spans {
+		byName[span.Name] = span
+	}
+	consumer := byName["dequeue"]
+	producer := byName["enqueue"]
+	require.Len(t, consumer.Links, 1)
+	assert.Equal(t, producer.SpanContext.SpanID(), consumer.Links[0].SpanContext.SpanID())
+
+	linkAttrs := make(map[string]attribute.Value)
+	for _, kv := range consumer.Links[0].Attributes {
+		linkAttrs[string(kv.Key)] = kv.Value
+	}
+	assert.Equal(t, attribute.StringValue("msg-42"), linkAttrs["messaging.message.id"])
+	assert.Equal(t, attribute.IntValue(7), linkAttrs["messaging.batch.message.index"])
 }
 
 func TestEmitTraceErrors(t *testing.T) {

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -54,7 +54,7 @@ func newSpanContextRegistry(topo *Topology) *spanContextRegistry {
 	for _, svc := range topo.Services {
 		for _, op := range svc.Operations {
 			for _, linked := range op.Links {
-				targets[linked.Ref] = true
+				targets[linked.Operation.Ref] = true
 			}
 		}
 	}
@@ -470,8 +470,12 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 	if len(op.Links) > 0 && e.linkRegistry != nil {
 		var links []trace.Link
 		for _, linked := range op.Links {
-			if sc, ok := e.linkRegistry.load(linked.Ref); ok {
-				links = append(links, trace.Link{SpanContext: sc})
+			if sc, ok := e.linkRegistry.load(linked.Operation.Ref); ok {
+				lnk := trace.Link{SpanContext: sc}
+				for k, v := range linked.Attributes {
+					lnk.Attributes = append(lnk.Attributes, attribute.String(k, v))
+				}
+				links = append(links, lnk)
 			}
 		}
 		if len(links) > 0 {

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -471,11 +471,10 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 		var links []trace.Link
 		for _, linked := range op.Links {
 			if sc, ok := e.linkRegistry.load(linked.Operation.Ref); ok {
-				lnk := trace.Link{SpanContext: sc}
-				for k, v := range linked.Attributes {
-					lnk.Attributes = append(lnk.Attributes, attribute.String(k, v))
-				}
-				links = append(links, lnk)
+				links = append(links, trace.Link{
+					SpanContext: sc,
+					Attributes:  attributeKeyValues(linked.Attributes, e.Rng),
+				})
 			}
 		}
 		if len(links) > 0 {
@@ -802,4 +801,15 @@ func typedAttribute(key string, value any) attribute.KeyValue {
 	default:
 		return attribute.String(key, fmt.Sprint(v))
 	}
+}
+
+func attributeKeyValues(attrs Attributes, rng *rand.Rand) []attribute.KeyValue {
+	if len(attrs) == 0 {
+		return nil
+	}
+	kvs := make([]attribute.KeyValue, 0, len(attrs))
+	for _, a := range attrs {
+		kvs = append(kvs, typedAttribute(a.Key, a.Gen.Generate(rng)))
+	}
+	return kvs
 }

--- a/pkg/synth/engine_test.go
+++ b/pkg/synth/engine_test.go
@@ -2701,7 +2701,7 @@ func TestEngineSpanLinks(t *testing.T) {
 				Operations: []OperationConfig{{
 					Name:     "dequeue",
 					Duration: "10ms",
-					Links:    []string{"producer.enqueue"},
+					Links:    []LinkConfig{{Ref: "producer.enqueue"}},
 				}},
 			},
 		},
@@ -2749,6 +2749,72 @@ func TestEngineSpanLinks(t *testing.T) {
 	assert.Equal(t, producerSpanCtx.SpanID(), consumerSpans[0].Links[0].SpanContext.SpanID())
 }
 
+func TestEngineSpanLinkAttributes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "producer",
+				Operations: []OperationConfig{{
+					Name:     "enqueue",
+					Duration: "5ms",
+				}},
+			},
+			{
+				Name: "consumer",
+				Operations: []OperationConfig{{
+					Name:     "dequeue",
+					Duration: "10ms",
+					Links: []LinkConfig{{
+						Ref: "producer.enqueue",
+						Attributes: map[string]string{
+							"messaging.message.id": "msg-42",
+							"link.type":            "async",
+						},
+					}},
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "100/s"},
+	}
+
+	engine, exporter, tp := newTestEngine(t, cfg)
+	engine.linkRegistry = newSpanContextRegistry(engine.Topology)
+
+	now := time.Now()
+	stats := &Stats{}
+
+	var producerRoot, consumerRoot *Operation
+	for _, r := range engine.Topology.Roots {
+		if r.Service.Name == "producer" {
+			producerRoot = r
+		} else {
+			consumerRoot = r
+		}
+	}
+	require.NotNil(t, producerRoot)
+	require.NotNil(t, consumerRoot)
+
+	engine.walkTrace(context.Background(), producerRoot, nil, now, 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	exporter.Reset()
+	engine.walkTrace(context.Background(), consumerRoot, nil, now.Add(100*time.Millisecond), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	require.Len(t, spans[0].Links, 1)
+
+	linkAttrs := make(map[string]string)
+	for _, kv := range spans[0].Links[0].Attributes {
+		linkAttrs[string(kv.Key)] = kv.Value.AsString()
+	}
+	assert.Equal(t, "msg-42", linkAttrs["messaging.message.id"])
+	assert.Equal(t, "async", linkAttrs["link.type"])
+}
+
 func TestEngineSpanLinksFirstTraceEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -2766,7 +2832,7 @@ func TestEngineSpanLinksFirstTraceEmpty(t *testing.T) {
 				Operations: []OperationConfig{{
 					Name:     "dequeue",
 					Duration: "10ms",
-					Links:    []string{"producer.enqueue"},
+					Links:    []LinkConfig{{Ref: "producer.enqueue"}},
 				}},
 			},
 		},

--- a/pkg/synth/engine_test.go
+++ b/pkg/synth/engine_test.go
@@ -2768,9 +2768,10 @@ func TestEngineSpanLinkAttributes(t *testing.T) {
 					Duration: "10ms",
 					Links: []LinkConfig{{
 						Ref: "producer.enqueue",
-						Attributes: map[string]string{
-							"messaging.message.id": "msg-42",
-							"link.type":            "async",
+						Attributes: map[string]AttributeValueConfig{
+							"messaging.message.id":          {Value: "msg-42"},
+							"messaging.batch.message.index": {Value: 7},
+							"messaging.duplicate":           {Value: true},
 						},
 					}},
 				}},
@@ -2807,12 +2808,13 @@ func TestEngineSpanLinkAttributes(t *testing.T) {
 	require.Len(t, spans, 1)
 	require.Len(t, spans[0].Links, 1)
 
-	linkAttrs := make(map[string]string)
+	linkAttrs := make(map[string]attribute.Value)
 	for _, kv := range spans[0].Links[0].Attributes {
-		linkAttrs[string(kv.Key)] = kv.Value.AsString()
+		linkAttrs[string(kv.Key)] = kv.Value
 	}
-	assert.Equal(t, "msg-42", linkAttrs["messaging.message.id"])
-	assert.Equal(t, "async", linkAttrs["link.type"])
+	assert.Equal(t, attribute.StringValue("msg-42"), linkAttrs["messaging.message.id"])
+	assert.Equal(t, attribute.IntValue(7), linkAttrs["messaging.batch.message.index"])
+	assert.Equal(t, attribute.BoolValue(true), linkAttrs["messaging.duplicate"])
 }
 
 func TestEngineSpanLinksFirstTraceEmpty(t *testing.T) {

--- a/pkg/synth/plan.go
+++ b/pkg/synth/plan.go
@@ -9,6 +9,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// LinkRef holds the ref string and optional attributes for a span link.
+type LinkRef struct {
+	Ref        string
+	Attributes []attribute.KeyValue
+}
+
 // SpanPlan holds pre-computed data for a single span, ready for deferred emission.
 type SpanPlan struct {
 	Index           int
@@ -27,7 +33,7 @@ type SpanPlan struct {
 	Scenarios       []string
 	Rejected        bool
 	RejectionReason string
-	LinkRefs        []string
+	LinkRefs        []LinkRef
 }
 
 // planTrace recursively plans spans for an operation and its downstream calls.
@@ -114,9 +120,13 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 	preCallDuration := ownDuration / 2
 	childStartTime := startTime.Add(preCallDuration)
 
-	var linkRefs []string
+	var linkRefs []LinkRef
 	for _, linked := range op.Links {
-		linkRefs = append(linkRefs, linked.Ref)
+		lr := LinkRef{Ref: linked.Operation.Ref}
+		for k, v := range linked.Attributes {
+			lr.Attributes = append(lr.Attributes, attribute.String(k, v))
+		}
+		linkRefs = append(linkRefs, lr)
 	}
 
 	// Append a placeholder plan entry; EndTime and IsError are filled in after children.

--- a/pkg/synth/plan.go
+++ b/pkg/synth/plan.go
@@ -122,11 +122,10 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 
 	var linkRefs []LinkRef
 	for _, linked := range op.Links {
-		lr := LinkRef{Ref: linked.Operation.Ref}
-		for k, v := range linked.Attributes {
-			lr.Attributes = append(lr.Attributes, attribute.String(k, v))
-		}
-		linkRefs = append(linkRefs, lr)
+		linkRefs = append(linkRefs, LinkRef{
+			Ref:        linked.Operation.Ref,
+			Attributes: attributeKeyValues(linked.Attributes, e.Rng),
+		})
 	}
 
 	// Append a placeholder plan entry; EndTime and IsError are filled in after children.

--- a/pkg/synth/plan_test.go
+++ b/pkg/synth/plan_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -365,6 +366,60 @@ func TestPlanTraceRetries(t *testing.T) {
 	spans := exporter.GetSpans()
 	require.Len(t, plans, len(spans), "should have same span count with retries")
 	assert.Equal(t, walkStats.Retries, planStats.Retries, "retry counts must match")
+}
+
+func TestPlanTraceSpanLinkAttributes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "producer",
+				Operations: []OperationConfig{{
+					Name:     "enqueue",
+					Duration: "5ms",
+				}},
+			},
+			{
+				Name: "consumer",
+				Operations: []OperationConfig{{
+					Name:     "dequeue",
+					Duration: "10ms",
+					Links: []LinkConfig{{
+						Ref: "producer.enqueue",
+						Attributes: map[string]AttributeValueConfig{
+							"messaging.message.id":          {Value: "msg-42"},
+							"messaging.batch.message.index": {Value: 7},
+						},
+					}},
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "10/s"},
+	}
+	engine, _, _ := newTestEngine(t, cfg)
+
+	var consumerRoot *Operation
+	for _, r := range engine.Topology.Roots {
+		if r.Ref == "consumer.dequeue" {
+			consumerRoot = r
+		}
+	}
+	require.NotNil(t, consumerRoot)
+
+	var plans []SpanPlan
+	engine.planTrace(consumerRoot, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false)
+
+	require.Len(t, plans, 1)
+	require.Len(t, plans[0].LinkRefs, 1)
+	assert.Equal(t, "producer.enqueue", plans[0].LinkRefs[0].Ref)
+
+	linkAttrs := make(map[string]attribute.Value)
+	for _, kv := range plans[0].LinkRefs[0].Attributes {
+		linkAttrs[string(kv.Key)] = kv.Value
+	}
+	assert.Equal(t, attribute.StringValue("msg-42"), linkAttrs["messaging.message.id"])
+	assert.Equal(t, attribute.IntValue(7), linkAttrs["messaging.batch.message.index"])
 }
 
 // twoTierStateConfig builds a gateway->backend topology where backend has a

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -75,7 +75,7 @@ type Event struct {
 // Link represents a resolved span link to another operation, with optional attributes.
 type Link struct {
 	Operation  *Operation
-	Attributes map[string]string
+	Attributes Attributes
 }
 
 // Operation represents a resolved operation with pointers to downstream calls.
@@ -268,9 +268,21 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 				if err != nil {
 					return nil, fmt.Errorf("service %q operation %q: link: %w", svcCfg.Name, opCfg.Name, err)
 				}
+				var attrs Attributes
+				if len(linkCfg.Attributes) > 0 {
+					gens := make(map[string]AttributeGenerator, len(linkCfg.Attributes))
+					for name, acfg := range linkCfg.Attributes {
+						gen, genErr := NewAttributeGenerator(acfg)
+						if genErr != nil {
+							return nil, fmt.Errorf("service %q operation %q link %q attribute %q: %w", svcCfg.Name, opCfg.Name, linkCfg.Ref, name, genErr)
+						}
+						gens[name] = gen
+					}
+					attrs = NewAttributes(gens)
+				}
 				op.Links = append(op.Links, Link{
 					Operation:  linkOp,
-					Attributes: linkCfg.Attributes,
+					Attributes: attrs,
 				})
 			}
 			for _, callCfg := range opCfg.Calls {

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -72,6 +72,12 @@ type Event struct {
 	Attributes Attributes
 }
 
+// Link represents a resolved span link to another operation, with optional attributes.
+type Link struct {
+	Operation  *Operation
+	Attributes map[string]string
+}
+
 // Operation represents a resolved operation with pointers to downstream calls.
 type Operation struct {
 	Service        *Service
@@ -83,7 +89,7 @@ type Operation struct {
 	CallStyle      string
 	Attributes     Attributes
 	Events         []Event
-	Links          []*Operation
+	Links          []Link
 	Metrics        []MetricDefinition
 	Logs           []LogDefinition
 	QueueDepth     int
@@ -257,12 +263,15 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 	for _, svcCfg := range cfg.Services {
 		for _, opCfg := range svcCfg.Operations {
 			op := topo.Services[svcCfg.Name].Operations[opCfg.Name]
-			for _, linkRef := range opCfg.Links {
-				_, linkOp, err := resolveRef(topo, linkRef)
+			for _, linkCfg := range opCfg.Links {
+				_, linkOp, err := resolveRef(topo, linkCfg.Ref)
 				if err != nil {
 					return nil, fmt.Errorf("service %q operation %q: link: %w", svcCfg.Name, opCfg.Name, err)
 				}
-				op.Links = append(op.Links, linkOp)
+				op.Links = append(op.Links, Link{
+					Operation:  linkOp,
+					Attributes: linkCfg.Attributes,
+				})
 			}
 			for _, callCfg := range opCfg.Calls {
 				_, targetOp, err := resolveRef(topo, callCfg.Target)

--- a/pkg/synth/topology_test.go
+++ b/pkg/synth/topology_test.go
@@ -464,7 +464,7 @@ func TestBuildTopology(t *testing.T) {
 					Operations: []OperationConfig{{
 						Name:     "dequeue",
 						Duration: "10ms",
-						Links:    []string{"producer.enqueue"},
+						Links:    []LinkConfig{{Ref: "producer.enqueue"}},
 					}},
 				},
 			},
@@ -476,8 +476,8 @@ func TestBuildTopology(t *testing.T) {
 
 		consumerOp := topo.Services["consumer"].Operations["dequeue"]
 		require.Len(t, consumerOp.Links, 1)
-		assert.Equal(t, "enqueue", consumerOp.Links[0].Name)
-		assert.Equal(t, "producer", consumerOp.Links[0].Service.Name)
+		assert.Equal(t, "enqueue", consumerOp.Links[0].Operation.Name)
+		assert.Equal(t, "producer", consumerOp.Links[0].Operation.Service.Name)
 
 		producerOp := topo.Services["producer"].Operations["enqueue"]
 		assert.Empty(t, producerOp.Links)

--- a/pkg/synth/topology_test.go
+++ b/pkg/synth/topology_test.go
@@ -464,7 +464,13 @@ func TestBuildTopology(t *testing.T) {
 					Operations: []OperationConfig{{
 						Name:     "dequeue",
 						Duration: "10ms",
-						Links:    []LinkConfig{{Ref: "producer.enqueue"}},
+						Links: []LinkConfig{{
+							Ref: "producer.enqueue",
+							Attributes: map[string]AttributeValueConfig{
+								"messaging.message.id":          {Value: "msg-42"},
+								"messaging.batch.message.index": {Value: 7},
+							},
+						}},
 					}},
 				},
 			},
@@ -478,6 +484,8 @@ func TestBuildTopology(t *testing.T) {
 		require.Len(t, consumerOp.Links, 1)
 		assert.Equal(t, "enqueue", consumerOp.Links[0].Operation.Name)
 		assert.Equal(t, "producer", consumerOp.Links[0].Operation.Service.Name)
+		assert.Equal(t, "msg-42", consumerOp.Links[0].Attributes.Get("messaging.message.id").Generate(nil))
+		assert.Equal(t, 7, consumerOp.Links[0].Attributes.Get("messaging.batch.message.index").Generate(nil))
 
 		producerOp := topo.Services["producer"].Operations["enqueue"]
 		assert.Empty(t, producerOp.Links)


### PR DESCRIPTION
## Summary

Closes #215

- Added `LinkConfig` struct with custom YAML unmarshaling so links accept both bare-string (`- producer.enqueue`) and structured form (`- ref: producer.enqueue \n attributes: ...`)
- Plumbed attributes through the full stack: `LinkConfig` → `OperationConfig` → `Link` (topology) → `LinkRef` (plan) → `trace.Link.Attributes` in both `engine.go` (walkTrace) and `emit.go` (realtime mode)
- Updated `docs/examples/span-links.yaml` to show the structured form with attributes
- Added `TestParseLinkConfig` (YAML round-trip for both forms) and `TestEngineSpanLinkAttributes` (attributes appear on emitted spans)

## Test plan

- [ ] `go test ./pkg/synth/...` — all existing tests pass, new tests cover both DSL forms and attribute propagation
- [ ] Verify bare-string links still work unchanged (existing tests cover this)
- [ ] Check `docs/examples/span-links.yaml` parses and emits correctly with link attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBAoX4p3qC5NnVg9fGhRiR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBAoX4p3qC5NnVg9fGhRiR)_