### PR TITLE
Support PRODUCER span kind for async producers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `producer: true` call modifier emits a `PRODUCER` span for an asynchronous
+  enqueue/publish step, the fifth OTel span kind. It pairs with the existing
+  `async` (`CONSUMER`) calls and span links to model cross-trace messaging:
+  a producer publish span on one service and a linked consumer span on another.
+  See `docs/examples/producer-consumer.yaml`. (#214)
+
 - Reader-based replay entry points `ScanRecordingFrom(io.Reader)` and
   `ReplayRecordingFrom(ctx, io.Reader, …)` so non-filesystem callers (such as
   `pkg/synth` compiled to `js/wasm`) can replay in-memory recordings. The

--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -165,6 +165,7 @@ or a full mapping.
 | `retries`      | int    | Retry count on child failure |
 | `retry_backoff`| string | Constant delay between retries (Go duration) |
 | `async`        | bool   | Fire-and-forget: child runs independently, parent does not wait. Child span kind is CONSUMER instead of CLIENT. Errors do not cascade to parent. Cannot combine with `retries` or `timeout` |
+| `producer`     | bool   | Messaging enqueue/publish step: child span kind is PRODUCER instead of CLIENT. The publish is synchronous (parent waits). Pair with an `async` consumer and a span link for cross-trace messaging. Cannot combine with `async` |
 
 ```yaml
 calls:

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -23,6 +23,7 @@ motel run --stdout --duration 5s docs/examples/basic-topology.yaml
 | `async-calls.yaml` | Async fire-and-forget calls with trace propagation for audit logging and notification dispatch. |
 | `span-events.yaml` | Span events emitted at an offset within operations (cache misses, query starts). |
 | `span-links.yaml` | Cross-trace span links between producer and consumer, modelling a message queue. |
+| `producer-consumer.yaml` | Messaging `PRODUCER`/`CONSUMER` span kinds: a `producer: true` publish span paired with an async consumer that links back across traces. |
 | `attribute-placement.yaml` | Resource attributes vs span attributes on the same service. |
 | `resource-attributes.yaml` | Per-service resource attributes (`deployment.environment`, `service.version`, etc.). |
 | `topology-driven-metrics.yaml` | All four metric instrument types at both service and operation level. |

--- a/docs/examples/producer-consumer.yaml
+++ b/docs/examples/producer-consumer.yaml
@@ -1,0 +1,59 @@
+# Messaging producer/consumer spans with cross-trace links
+#
+# Models the two halves of an asynchronous messaging interaction per the OTel
+# messaging semantic conventions:
+#
+#   * The publishing service emits a PRODUCER span for the enqueue/publish step.
+#     A call marked `producer: true` makes its callee a PRODUCER span. The
+#     publish is synchronous from the caller's perspective (the parent waits for
+#     the enqueue to complete) but represents handing work off to a queue.
+#
+#   * The processing service emits a CONSUMER span (via `async: true`) that
+#     lives in a separate trace and links back to the producer's publish span,
+#     the non-parent-child relationship typical of message queues.
+#
+# Run the first trace to populate the link registry; subsequent consumer traces
+# link to the most recent producer span (see span-links.yaml for the mechanics).
+
+version: 1
+
+services:
+  api:
+    operations:
+      handle:
+        duration: 12ms +/- 4ms
+        calls:
+          # PRODUCER span: enqueue the message onto the queue.
+          - target: queue.publish
+            producer: true
+
+  queue:
+    operations:
+      publish:
+        duration: 4ms +/- 1ms
+        error_rate: 0.1%
+
+  worker:
+    operations:
+      poll:
+        duration: 1ms
+        calls:
+          # CONSUMER span: process the dequeued message asynchronously.
+          - target: worker.process
+            async: true
+      process:
+        duration: 25ms +/- 8ms
+        error_rate: 0.5%
+        links:
+          # Join the consumer's processing span back to the producer's publish.
+          - ref: queue.publish
+            attributes:
+              messaging.message.id:
+                value: "msg-001"
+              messaging.operation.name:
+                value: "process"
+              link.relationship:
+                value: "async-produce"
+
+traffic:
+  rate: 10/s

--- a/pkg/synth/benchmark_test.go
+++ b/pkg/synth/benchmark_test.go
@@ -95,14 +95,14 @@ func BenchmarkWalkTrace(b *testing.B) {
 	for range b.N {
 		var stats Stats
 		spanCount := 0
-		engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, &spanCount, DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, &spanCount, DefaultMaxSpansPerTrace, false, false)
 	}
 	b.StopTimer()
 
 	// Report spans per iteration for reference
 	var stats Stats
 	spanCount := 0
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, &spanCount, DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, &spanCount, DefaultMaxSpansPerTrace, false, false)
 	b.ReportMetric(float64(stats.Spans), "spans/trace")
 }
 

--- a/pkg/synth/check.go
+++ b/pkg/synth/check.go
@@ -335,7 +335,7 @@ func sampleTracesWith(topo *Topology, n int, seed uint64, maxSpansPerTrace int, 
 		root := topo.Roots[rng.IntN(len(topo.Roots))]
 		var stats Stats
 		spanCount := 0
-		engine.walkTrace(context.Background(), root, nil, time.Now(), 0, overrides, nil, &stats, &spanCount, maxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), root, nil, time.Now(), 0, overrides, nil, &stats, &spanCount, maxSpansPerTrace, false, false)
 		_ = tp.ForceFlush(context.Background())
 
 		spans := exporter.GetSpans()

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -123,6 +123,7 @@ type CallConfig struct {
 	Retries      int     `yaml:"retries,omitempty"`
 	RetryBackoff string  `yaml:"retry_backoff,omitempty"`
 	Async        bool    `yaml:"async,omitempty"`
+	Producer     bool    `yaml:"producer,omitempty"`
 }
 
 // UnmarshalYAML handles both scalar string and mapping forms for call config.
@@ -726,6 +727,9 @@ func ValidateConfig(cfg *Config) error {
 				if call.Async && call.Timeout != "" {
 					return fmt.Errorf("service %q operation %q: call %q: async calls cannot have a timeout", svc.Name, op.Name, call.Target)
 				}
+				if call.Producer && call.Async {
+					return fmt.Errorf("service %q operation %q: call %q: a call cannot be both producer and async", svc.Name, op.Name, call.Target)
+				}
 			}
 		}
 	}
@@ -893,6 +897,9 @@ func validateCallConfig(call CallConfig, knownOps map[string]bool) error {
 	}
 	if call.Async && call.Timeout != "" {
 		return fmt.Errorf("target %q: async calls cannot have a timeout", call.Target)
+	}
+	if call.Producer && call.Async {
+		return fmt.Errorf("target %q: a call cannot be both producer and async", call.Target)
 	}
 	return nil
 }

--- a/pkg/synth/config_test.go
+++ b/pkg/synth/config_test.go
@@ -1945,6 +1945,37 @@ func TestValidateAsyncWithTimeoutRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "async calls cannot have a timeout")
 }
 
+func TestValidateProducerWithAsyncRejected(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "svc",
+				Operations: []OperationConfig{{
+					Name:     "op",
+					Duration: "10ms",
+					Calls: []CallConfig{
+						{Target: "svc2.op2", Producer: true, Async: true},
+					},
+				}},
+			},
+			{
+				Name: "svc2",
+				Operations: []OperationConfig{{
+					Name:     "op2",
+					Duration: "10ms",
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "10/s"},
+	}
+
+	err := ValidateConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be both producer and async")
+}
+
 func TestLoadConfigEvents(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -191,7 +191,7 @@ func (e *Engine) Run(ctx context.Context) (*Stats, error) {
 		spanStart := now.Add(e.TimeOffset)
 		spanLimit := e.maxSpansPerTrace()
 		spanCount := 0
-		_, rootErr := e.walkTrace(ctx, root, nil, spanStart, elapsed, overrides, scenarioNames, &stats, &spanCount, spanLimit, false)
+		_, rootErr := e.walkTrace(ctx, root, nil, spanStart, elapsed, overrides, scenarioNames, &stats, &spanCount, spanLimit, false, false)
 		stats.Traces++
 		if rootErr {
 			stats.FailedTraces++
@@ -350,7 +350,7 @@ func (e *Engine) runRealtime(ctx context.Context) (*Stats, error) {
 		// QueueRejections, and CircuitBreakerTrips which are plan-phase
 		// decisions.
 		var plans []SpanPlan
-		_, rootErr := e.planTrace(root, -1, spanStart, elapsed, overrides, scenarioNames, &stats, &plans, &spanCount, spanLimit, false)
+		_, rootErr := e.planTrace(root, -1, spanStart, elapsed, overrides, scenarioNames, &stats, &plans, &spanCount, spanLimit, false, false)
 		stats.Traces++
 		if rootErr {
 			stats.FailedTraces++
@@ -401,7 +401,8 @@ func (e *Engine) maxSpansPerTrace() int {
 // spanCount tracks the number of spans generated in this trace; no new spans are created once it reaches spanLimit.
 // elapsed is the simulation wall-clock time since engine start, used for state tracking.
 // isAsync indicates the span was invoked via an async call and should use CONSUMER span kind.
-func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, spanCount *int, spanLimit int, isAsync bool) (time.Time, bool) {
+// isProducer indicates the span was invoked via a producer call and should use PRODUCER span kind.
+func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, spanCount *int, spanLimit int, isAsync, isProducer bool) (time.Time, bool) {
 	if *spanCount >= spanLimit {
 		return startTime, false
 	}
@@ -437,7 +438,7 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 				stats.CircuitBreakerTrips++
 				notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventCircuitBreakerTrip, Service: op.Service.Name, Operation: op.Name, Timestamp: startTime})
 			}
-			return e.emitRejectionSpan(ctx, op, parent, startTime, reason, scenarioNames, stats, isAsync)
+			return e.emitRejectionSpan(ctx, op, parent, startTime, reason, scenarioNames, stats, isAsync, isProducer)
 		}
 		if durationMult > 1.0 {
 			duration.Mean = time.Duration(float64(duration.Mean) * durationMult)
@@ -446,13 +447,9 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 		opState.Enter()
 	}
 
-	// Determine span kind: SERVER for roots, CONSUMER for async callees, CLIENT otherwise
-	kind := trace.SpanKindClient
-	if isRoot(e.Topology, op) {
-		kind = trace.SpanKindServer
-	} else if isAsync {
-		kind = trace.SpanKindConsumer
-	}
+	// Determine span kind: SERVER for roots, PRODUCER for producer callees,
+	// CONSUMER for async callees, CLIENT otherwise.
+	kind := spanKindFor(e.Topology, op, isAsync, isProducer)
 
 	startAttrs := []attribute.KeyValue{
 		attribute.String("synth.service", op.Service.Name),
@@ -648,16 +645,11 @@ func parentNames(parent *Operation) (string, string) {
 // emitRejectionSpan creates a short error span for a rejected request.
 // The caller (walkTrace) has already counted this span against the trace's
 // span limit, so spanCount is not incremented here.
-func (e *Engine) emitRejectionSpan(ctx context.Context, op, parent *Operation, startTime time.Time, reason string, scenarioNames []string, stats *Stats, isAsync bool) (time.Time, bool) {
+func (e *Engine) emitRejectionSpan(ctx context.Context, op, parent *Operation, startTime time.Time, reason string, scenarioNames []string, stats *Stats, isAsync, isProducer bool) (time.Time, bool) {
 	tracer := e.Tracers(op.Service.Name)
 	endTime := startTime.Add(rejectionDuration)
 
-	kind := trace.SpanKindClient
-	if isRoot(e.Topology, op) {
-		kind = trace.SpanKindServer
-	} else if isAsync {
-		kind = trace.SpanKindConsumer
-	}
+	kind := spanKindFor(e.Topology, op, isAsync, isProducer)
 
 	rejAttrs := []attribute.KeyValue{
 		attribute.String("synth.service", op.Service.Name),
@@ -717,7 +709,7 @@ func (e *Engine) executeCall(ctx context.Context, active activeCall, parent *Ope
 	attemptStart := callStart
 
 	for attempt := range maxAttempts {
-		childEnd, childErr := e.walkTrace(ctx, call.Operation, parent, attemptStart, elapsed, overrides, scenarioNames, stats, spanCount, spanLimit, call.Async)
+		childEnd, childErr := e.walkTrace(ctx, call.Operation, parent, attemptStart, elapsed, overrides, scenarioNames, stats, spanCount, spanLimit, call.Async, call.Producer)
 		perceivedEnd := childEnd
 		failed := childErr
 
@@ -760,6 +752,23 @@ func activeScenariosEqual(a, b []Scenario) bool {
 // isRoot checks whether an operation is a root (entry point) in the topology.
 func isRoot(topo *Topology, op *Operation) bool {
 	return slices.Contains(topo.Roots, op)
+}
+
+// spanKindFor determines the OTel span kind for an operation given how it was
+// invoked: SERVER for trace roots, PRODUCER for the callee of a producer call
+// (an async enqueue/publish step), CONSUMER for the callee of an async call,
+// and CLIENT otherwise. Roots always win; producer takes precedence over async.
+func spanKindFor(topo *Topology, op *Operation, isAsync, isProducer bool) trace.SpanKind {
+	switch {
+	case isRoot(topo, op):
+		return trace.SpanKindServer
+	case isProducer:
+		return trace.SpanKindProducer
+	case isAsync:
+		return trace.SpanKindConsumer
+	default:
+		return trace.SpanKindClient
+	}
 }
 
 // effectiveCalls returns the call list for an operation, applying scenario add/remove overrides.

--- a/pkg/synth/engine_test.go
+++ b/pkg/synth/engine_test.go
@@ -79,7 +79,7 @@ func TestEngineWalkTrace(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	// Force flush
 	require.NoError(t, tp.ForceFlush(context.Background()))
@@ -128,7 +128,7 @@ func TestEngineErrorInjection(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -241,7 +241,7 @@ func TestEngineScenarioOverrides(t *testing.T) {
 
 	// Walk trace with overrides active at elapsed=0
 	overrides := ResolveOverrides(ActiveScenarios(scenarios, 0))
-	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -305,7 +305,7 @@ func TestEngineScenarioAttributeOverrides(t *testing.T) {
 	}
 
 	overrides := ResolveOverrides(ActiveScenarios(scenarios, 0))
-	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -488,7 +488,7 @@ func TestEngineOperationAttributes(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -532,7 +532,7 @@ func TestEngineSequentialCallStyle(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -583,7 +583,7 @@ func TestEngineParallelCallStyle(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -668,7 +668,7 @@ func TestEngineSpanAttributes(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -720,7 +720,7 @@ func TestEngineProbabilisticCall(t *testing.T) {
 
 	for range trials {
 		exporter.Reset()
-		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 
 		spans := exporter.GetSpans()
@@ -765,7 +765,7 @@ func TestEngineOnErrorCondition(t *testing.T) {
 		t.Parallel()
 		engine, exporter, tp := newTestEngine(t, makeConfig("100%"))
 		rootOp := engine.Topology.Roots[0]
-		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 		spans := exporter.GetSpans()
 		assert.Len(t, spans, 2, "on-error child should be present when parent errors")
@@ -775,7 +775,7 @@ func TestEngineOnErrorCondition(t *testing.T) {
 		t.Parallel()
 		engine, exporter, tp := newTestEngine(t, makeConfig("0%"))
 		rootOp := engine.Topology.Roots[0]
-		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 		spans := exporter.GetSpans()
 		assert.Len(t, spans, 1, "on-error child should be absent when parent succeeds")
@@ -813,7 +813,7 @@ func TestEngineOnSuccessCondition(t *testing.T) {
 		t.Parallel()
 		engine, exporter, tp := newTestEngine(t, makeConfig("0%"))
 		rootOp := engine.Topology.Roots[0]
-		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 		spans := exporter.GetSpans()
 		assert.Len(t, spans, 2, "on-success child should be present when parent succeeds")
@@ -823,7 +823,7 @@ func TestEngineOnSuccessCondition(t *testing.T) {
 		t.Parallel()
 		engine, exporter, tp := newTestEngine(t, makeConfig("100%"))
 		rootOp := engine.Topology.Roots[0]
-		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 		spans := exporter.GetSpans()
 		assert.Len(t, spans, 1, "on-success child should be absent when parent errors")
@@ -856,7 +856,7 @@ func TestEngineFanOutCount(t *testing.T) {
 
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -898,7 +898,7 @@ func TestEngineFanOutSequential(t *testing.T) {
 
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -953,7 +953,7 @@ func TestEngineFanOutParallel(t *testing.T) {
 
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1002,7 +1002,7 @@ func TestEngineCallTimeout(t *testing.T) {
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1060,7 +1060,7 @@ func TestEngineCallNoTimeout(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1110,7 +1110,7 @@ func TestEngineCallTimeoutSequential(t *testing.T) {
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1168,7 +1168,7 @@ func TestEngineCascadingError(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1216,7 +1216,7 @@ func TestEngineCascadingErrorPreservesConditions(t *testing.T) {
 
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1254,7 +1254,7 @@ func TestEngineRetryOnError(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1300,7 +1300,7 @@ func TestEngineRetrySuccess(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1347,7 +1347,7 @@ func TestEngineRetryBackoff(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1398,7 +1398,7 @@ func TestEngineRetryWithTimeout(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1437,7 +1437,7 @@ func TestEngineRetryStats(t *testing.T) {
 	engine, _, _ := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	assert.Equal(t, int64(3), stats.Retries, "should retry 3 times")
 	// 1 parent + 4 child = 5 spans, all errored (child 100%, parent cascaded)
@@ -1473,7 +1473,7 @@ func TestEngineNoRetryWithoutConfig(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1519,14 +1519,14 @@ func TestEngineSpanBound(t *testing.T) {
 	rootOp := engine.Topology.Roots[0]
 
 	// Without bound: 1 + 5 + 25 = 31 spans
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 	assert.Equal(t, 31, len(exporter.GetSpans()))
 
 	// With bound of 10 spans
 	exporter.Reset()
 	spanCount := 0
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, &spanCount, 10, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, &spanCount, 10, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 	assert.LessOrEqual(t, len(exporter.GetSpans()), 10, "span count should be bounded")
 	assert.Greater(t, len(exporter.GetSpans()), 0, "should produce at least some spans")
@@ -1791,7 +1791,7 @@ func TestEngineWalkTraceWithAddCalls(t *testing.T) {
 	gatewayOp := topo.Services["gateway"].Operations["request"]
 
 	var stats Stats
-	engine.walkTrace(context.Background(), gatewayOp, nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), gatewayOp, nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1848,7 +1848,7 @@ func TestEngineWalkTraceWithRemoveCalls(t *testing.T) {
 	}
 
 	var stats Stats
-	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -1995,7 +1995,7 @@ func TestEngineLabelScenarios(t *testing.T) {
 		scenarioNames[i] = s.Name
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, scenarioNames, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, scenarioNames, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2030,7 +2030,7 @@ func TestEngineLabelScenariosEmpty(t *testing.T) {
 	engine.LabelScenarios = true
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2065,7 +2065,7 @@ func TestEngineLabelScenariosDisabled(t *testing.T) {
 	// LabelScenarios defaults to false
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2133,7 +2133,7 @@ func TestPerServiceResource(t *testing.T) {
 	}
 
 	rootOp := topo.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	for _, tp := range providers {
 		require.NoError(t, tp.ForceFlush(context.Background()))
@@ -2303,7 +2303,7 @@ func TestAsyncCallParentDoesNotWait(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2357,7 +2357,7 @@ func TestSyncCallSpanKindIsClient(t *testing.T) {
 	engine, exporter, tp := newTestEngine(t, cfg)
 
 	rootOp := engine.Topology.Roots[0]
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2375,6 +2375,169 @@ func TestSyncCallSpanKindIsClient(t *testing.T) {
 
 	assert.Equal(t, trace.SpanKindServer, parentSpan.SpanKind, "root span should be SERVER")
 	assert.Equal(t, trace.SpanKindClient, childSpan.SpanKind, "sync callee should be CLIENT")
+}
+
+// TestProducerCallSpanKind pins that a call marked producer:true emits a
+// PRODUCER span for the enqueue/publish step, distinct from the CONSUMER kind
+// used for async callees. The producer enqueue is synchronous, so the parent
+// waits for it to finish.
+func TestProducerCallSpanKind(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "api",
+				Operations: []OperationConfig{{
+					Name:     "submit",
+					Duration: "10ms",
+					Calls: []CallConfig{
+						{Target: "queue.publish", Producer: true},
+					},
+				}},
+			},
+			{
+				Name: "queue",
+				Operations: []OperationConfig{{
+					Name:     "publish",
+					Duration: "5ms",
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "100/s"},
+	}
+
+	engine, exporter, tp := newTestEngine(t, cfg)
+
+	rootOp := engine.Topology.Roots[0]
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 2, "should have parent + producer child span")
+
+	var parentSpan, childSpan tracetest.SpanStub
+	for _, s := range spans {
+		switch s.Name {
+		case "submit":
+			parentSpan = s
+		case "publish":
+			childSpan = s
+		}
+	}
+
+	assert.Equal(t, parentSpan.SpanContext.TraceID(), childSpan.SpanContext.TraceID(),
+		"producer child should be in the same trace as its caller")
+	assert.Equal(t, parentSpan.SpanContext.SpanID(), childSpan.Parent.SpanID(),
+		"producer child should be parented under the caller")
+	assert.Equal(t, trace.SpanKindServer, parentSpan.SpanKind, "root span should be SERVER")
+	assert.Equal(t, trace.SpanKindProducer, childSpan.SpanKind, "producer callee should be PRODUCER")
+
+	// Producer enqueue is synchronous: the parent ends no earlier than the child.
+	assert.False(t, parentSpan.EndTime.Before(childSpan.EndTime),
+		"parent (end=%v) should not end before synchronous producer child (end=%v)", parentSpan.EndTime, childSpan.EndTime)
+}
+
+// TestProducerConsumerComposeWithSpanLinks exercises the realistic messaging
+// pattern: a PRODUCER span on the publishing service and a CONSUMER span on the
+// processing service, living in separate traces joined by a span link from the
+// consumer back to the producer.
+func TestProducerConsumerComposeWithSpanLinks(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "api",
+				Operations: []OperationConfig{{
+					Name:     "handle",
+					Duration: "10ms",
+					Calls: []CallConfig{
+						{Target: "queue.publish", Producer: true},
+					},
+				}},
+			},
+			{
+				Name: "queue",
+				Operations: []OperationConfig{{
+					Name:     "publish",
+					Duration: "3ms",
+				}},
+			},
+			{
+				Name: "worker",
+				Operations: []OperationConfig{
+					{
+						Name:     "poll",
+						Duration: "1ms",
+						Calls: []CallConfig{
+							{Target: "worker.process", Async: true},
+						},
+					},
+					{
+						Name:     "process",
+						Duration: "20ms",
+						Links:    []LinkConfig{{Ref: "queue.publish"}},
+					},
+				},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "100/s"},
+	}
+
+	engine, exporter, tp := newTestEngine(t, cfg)
+	engine.linkRegistry = newSpanContextRegistry(engine.Topology)
+
+	now := time.Now()
+	stats := &Stats{}
+
+	// Roots are the api and worker entrypoints (publish/process are callees).
+	var apiRoot, workerRoot *Operation
+	for _, r := range engine.Topology.Roots {
+		switch r.Service.Name {
+		case "api":
+			apiRoot = r
+		case "worker":
+			workerRoot = r
+		}
+	}
+	require.NotNil(t, apiRoot)
+	require.NotNil(t, workerRoot)
+
+	// Producer trace first to populate the link registry.
+	engine.walkTrace(context.Background(), apiRoot, nil, now, 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	producerSpans := exporter.GetSpans()
+	var publishSpan tracetest.SpanStub
+	for _, s := range producerSpans {
+		if s.Name == "publish" {
+			publishSpan = s
+		}
+	}
+	require.NotZero(t, publishSpan.SpanContext.SpanID(), "publish span should exist")
+	assert.Equal(t, trace.SpanKindProducer, publishSpan.SpanKind, "publish should be PRODUCER")
+
+	// Consumer trace second — its process span should be CONSUMER and link back.
+	exporter.Reset()
+	engine.walkTrace(context.Background(), workerRoot, nil, now.Add(100*time.Millisecond), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	consumerSpans := exporter.GetSpans()
+	var processSpan tracetest.SpanStub
+	for _, s := range consumerSpans {
+		if s.Name == "process" {
+			processSpan = s
+		}
+	}
+	require.NotZero(t, processSpan.SpanContext.SpanID(), "process span should exist")
+	assert.Equal(t, trace.SpanKindConsumer, processSpan.SpanKind, "process should be CONSUMER")
+
+	assert.NotEqual(t, publishSpan.SpanContext.TraceID(), processSpan.SpanContext.TraceID(),
+		"producer and consumer should live in separate traces")
+	require.Len(t, processSpan.Links, 1, "consumer should link back to the producer")
+	assert.Equal(t, publishSpan.SpanContext.TraceID(), processSpan.Links[0].SpanContext.TraceID())
+	assert.Equal(t, publishSpan.SpanContext.SpanID(), processSpan.Links[0].SpanContext.SpanID())
 }
 
 func TestAsyncCallErrorsDoNotCascade(t *testing.T) {
@@ -2408,7 +2571,7 @@ func TestAsyncCallErrorsDoNotCascade(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2469,7 +2632,7 @@ func TestAsyncSequentialDoesNotBlock(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2531,7 +2694,7 @@ func TestAsyncCallViaScenarioAddCalls(t *testing.T) {
 	rootOp := engine.Topology.Services["gateway"].Operations["handle"]
 	now := time.Now()
 	overrides := ResolveOverrides(ActiveScenarios(engine.Scenarios, 0))
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, overrides, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2585,7 +2748,7 @@ func TestSpanEvents(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	now := time.Now()
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2730,7 +2893,7 @@ func TestEngineSpanLinks(t *testing.T) {
 	require.NotNil(t, consumerRoot)
 
 	// Run producer first to populate the registry
-	engine.walkTrace(context.Background(), producerRoot, nil, now, 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), producerRoot, nil, now, 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	producerSpans := exporter.GetSpans()
@@ -2739,7 +2902,7 @@ func TestEngineSpanLinks(t *testing.T) {
 
 	// Run consumer — should link to producer
 	exporter.Reset()
-	engine.walkTrace(context.Background(), consumerRoot, nil, now.Add(100*time.Millisecond), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), consumerRoot, nil, now.Add(100*time.Millisecond), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	consumerSpans := exporter.GetSpans()
@@ -2797,11 +2960,11 @@ func TestEngineSpanLinkAttributes(t *testing.T) {
 	require.NotNil(t, producerRoot)
 	require.NotNil(t, consumerRoot)
 
-	engine.walkTrace(context.Background(), producerRoot, nil, now, 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), producerRoot, nil, now, 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	exporter.Reset()
-	engine.walkTrace(context.Background(), consumerRoot, nil, now.Add(100*time.Millisecond), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), consumerRoot, nil, now.Add(100*time.Millisecond), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2853,7 +3016,7 @@ func TestEngineSpanLinksFirstTraceEmpty(t *testing.T) {
 	}
 	require.NotNil(t, consumerRoot)
 
-	engine.walkTrace(context.Background(), consumerRoot, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), consumerRoot, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -2913,7 +3076,7 @@ func TestSeededRunsFullyDeterministic(t *testing.T) {
 
 		base := time.UnixMilli(0)
 		for range 50 {
-			engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, base, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+			engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, base, 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 		}
 		require.NoError(t, tp.ForceFlush(context.Background()))
 

--- a/pkg/synth/observer_test.go
+++ b/pkg/synth/observer_test.go
@@ -78,7 +78,7 @@ func TestObserverCalledPerSpan(t *testing.T) {
 		Observers: []SpanObserver{obs},
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records := obs.get()
@@ -126,7 +126,7 @@ func TestObserverReceivesCorrectMetadata(t *testing.T) {
 		Observers: []SpanObserver{obs},
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records := obs.get()
@@ -188,7 +188,7 @@ func TestObserverDurationIsWallClock(t *testing.T) {
 		Observers: []SpanObserver{obs},
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records := obs.get()
@@ -224,7 +224,7 @@ func TestObserverNotCalledWhenNone(t *testing.T) {
 	}
 
 	engine, exporter, tp := newTestEngine(t, cfg)
-	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -264,7 +264,7 @@ func TestMultipleObservers(t *testing.T) {
 		Observers: []SpanObserver{obs1, obs2},
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	assert.Len(t, obs1.get(), 1)
@@ -304,7 +304,7 @@ func TestObserverAttrsCopyIsolation(t *testing.T) {
 		Observers: []SpanObserver{obs},
 	}
 
-	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records := obs.get()
@@ -317,7 +317,7 @@ func TestObserverAttrsCopyIsolation(t *testing.T) {
 
 	// Generate another span and verify attrs are not corrupted
 	exporter.Reset()
-	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records2 := obs.get()
@@ -386,7 +386,7 @@ func TestObserverReceivesParentAttribution(t *testing.T) {
 	obs := &recordingObserver{}
 	engine.Observers = []SpanObserver{obs}
 
-	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	records := obs.get()
@@ -414,7 +414,7 @@ func TestFinishSpanParentAttribution(t *testing.T) {
 
 	var plans []SpanPlan
 	now := time.Now()
-	engine.planTrace(engine.Topology.Roots[0], -1, now, 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false)
+	engine.planTrace(engine.Topology.Roots[0], -1, now, 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.Len(t, plans, 2)
 
 	var rstats realtimeStats
@@ -440,7 +440,7 @@ func TestPlanEventObserverRetries(t *testing.T) {
 	obs := &planEventRecorder{}
 	engine.Observers = []SpanObserver{obs}
 
-	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	events := obs.getEvents()
@@ -462,7 +462,7 @@ func TestPlanEventObserverTimeouts(t *testing.T) {
 	engine.Observers = []SpanObserver{obs}
 
 	stats := &Stats{}
-	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	events := obs.getEvents()
@@ -481,7 +481,7 @@ func TestPlanTracePlanEvents(t *testing.T) {
 	engine.Observers = []SpanObserver{obs}
 
 	var plans []SpanPlan
-	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false)
+	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	events := obs.getEvents()
 	require.Len(t, events, 2)

--- a/pkg/synth/pipeline_test.go
+++ b/pkg/synth/pipeline_test.go
@@ -210,7 +210,7 @@ func generateAndSend(t testingT, topo *Topology, endpoint string, n int, seed ui
 		}
 		root := topo.Roots[rng.IntN(len(topo.Roots))]
 		var stats Stats
-		engine.walkTrace(ctx, root, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(ctx, root, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	}
 	if err := tp.ForceFlush(ctx); err != nil {
 		t.Fatalf("ForceFlush: %v", err)

--- a/pkg/synth/plan.go
+++ b/pkg/synth/plan.go
@@ -41,7 +41,7 @@ type SpanPlan struct {
 // mutations, same timing logic. The only difference is that it appends to plans
 // instead of creating OTel spans.
 // Returns the span end time and whether the span errored.
-func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, plans *[]SpanPlan, spanCount *int, spanLimit int, isAsync bool) (time.Time, bool) {
+func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, plans *[]SpanPlan, spanCount *int, spanLimit int, isAsync, isProducer bool) (time.Time, bool) {
 	if *spanCount >= spanLimit {
 		return startTime, false
 	}
@@ -76,7 +76,7 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 				stats.CircuitBreakerTrips++
 				notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventCircuitBreakerTrip, Service: op.Service.Name, Operation: op.Name, Timestamp: startTime})
 			}
-			return e.planRejectionSpan(op, parentIndex, startTime, reason, scenarioNames, plans, isAsync)
+			return e.planRejectionSpan(op, parentIndex, startTime, reason, scenarioNames, plans, isAsync, isProducer)
 		}
 		if durationMult > 1.0 {
 			duration.Mean = time.Duration(float64(duration.Mean) * durationMult)
@@ -85,12 +85,7 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 		opState.Enter()
 	}
 
-	kind := trace.SpanKindClient
-	if isRoot(e.Topology, op) {
-		kind = trace.SpanKindServer
-	} else if isAsync {
-		kind = trace.SpanKindConsumer
-	}
+	kind := spanKindFor(e.Topology, op, isAsync, isProducer)
 
 	startAttrs := []attribute.KeyValue{
 		attribute.String("synth.service", op.Service.Name),
@@ -226,15 +221,10 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 // planRejectionSpan mirrors emitRejectionSpan but appends to plans.
 // The caller (planTrace) has already counted this span against the trace's
 // span limit, so spanCount is not incremented here.
-func (e *Engine) planRejectionSpan(op *Operation, parentIndex int, startTime time.Time, reason string, scenarioNames []string, plans *[]SpanPlan, isAsync bool) (time.Time, bool) {
+func (e *Engine) planRejectionSpan(op *Operation, parentIndex int, startTime time.Time, reason string, scenarioNames []string, plans *[]SpanPlan, isAsync, isProducer bool) (time.Time, bool) {
 	endTime := startTime.Add(rejectionDuration)
 
-	kind := trace.SpanKindClient
-	if isRoot(e.Topology, op) {
-		kind = trace.SpanKindServer
-	} else if isAsync {
-		kind = trace.SpanKindConsumer
-	}
+	kind := spanKindFor(e.Topology, op, isAsync, isProducer)
 
 	rejAttrs := []attribute.KeyValue{
 		attribute.String("synth.service", op.Service.Name),
@@ -272,7 +262,7 @@ func (e *Engine) executePlanCall(active activeCall, parent *Operation, parentInd
 	attemptStart := callStart
 
 	for attempt := range maxAttempts {
-		childEnd, childErr := e.planTrace(call.Operation, parentIndex, attemptStart, elapsed, overrides, scenarioNames, stats, plans, spanCount, spanLimit, call.Async)
+		childEnd, childErr := e.planTrace(call.Operation, parentIndex, attemptStart, elapsed, overrides, scenarioNames, stats, plans, spanCount, spanLimit, call.Async, call.Producer)
 		perceivedEnd := childEnd
 		failed := childErr
 

--- a/pkg/synth/plan_test.go
+++ b/pkg/synth/plan_test.go
@@ -46,7 +46,7 @@ func TestPlanTraceBasic(t *testing.T) {
 	spanCount := 0
 
 	engine.Rng = rand.New(rand.NewPCG(42, 0))
-	endTime, isError := engine.planTrace(rootOp, -1, now, 0, nil, nil, &stats, &plans, &spanCount, DefaultMaxSpansPerTrace, false)
+	endTime, isError := engine.planTrace(rootOp, -1, now, 0, nil, nil, &stats, &plans, &spanCount, DefaultMaxSpansPerTrace, false, false)
 
 	require.Len(t, plans, 2)
 
@@ -125,7 +125,7 @@ func TestPlanTraceMatchesWalkTrace(t *testing.T) {
 	planSpanCount := 0
 	planEnd, planErr := planEngine.planTrace(
 		planEngine.Topology.Roots[0], -1, now, 0, nil, nil,
-		&planStats, &plans, &planSpanCount, DefaultMaxSpansPerTrace, false,
+		&planStats, &plans, &planSpanCount, DefaultMaxSpansPerTrace, false, false,
 	)
 
 	// Run walkTrace with the same seed
@@ -135,7 +135,7 @@ func TestPlanTraceMatchesWalkTrace(t *testing.T) {
 	walkSpanCount := 0
 	walkEnd, walkErr := walkEngine.walkTrace(
 		context.Background(), walkEngine.Topology.Roots[0], nil, now, 0, nil, nil,
-		&walkStats, &walkSpanCount, DefaultMaxSpansPerTrace, false,
+		&walkStats, &walkSpanCount, DefaultMaxSpansPerTrace, false, false,
 	)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
@@ -203,7 +203,7 @@ func TestPlanTraceSpanLimit(t *testing.T) {
 	spanCount := 0
 
 	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil,
-		&stats, &plans, &spanCount, 2, false)
+		&stats, &plans, &spanCount, 2, false, false)
 
 	assert.Equal(t, 2, len(plans), "should stop at span limit")
 }
@@ -232,7 +232,7 @@ func TestPlanTraceRejection(t *testing.T) {
 	var stats1 Stats
 	var plans1 []SpanPlan
 	sc1 := 0
-	engine.planTrace(rootOp, -1, time.Now(), 0, nil, nil, &stats1, &plans1, &sc1, DefaultMaxSpansPerTrace, false)
+	engine.planTrace(rootOp, -1, time.Now(), 0, nil, nil, &stats1, &plans1, &sc1, DefaultMaxSpansPerTrace, false, false)
 
 	// Manually bump active requests to trigger queue full
 	opState := engine.State.Get(rootOp.Ref)
@@ -241,7 +241,7 @@ func TestPlanTraceRejection(t *testing.T) {
 	var stats2 Stats
 	var plans2 []SpanPlan
 	sc2 := 0
-	engine.planTrace(rootOp, -1, time.Now(), time.Second, nil, nil, &stats2, &plans2, &sc2, DefaultMaxSpansPerTrace, false)
+	engine.planTrace(rootOp, -1, time.Now(), time.Second, nil, nil, &stats2, &plans2, &sc2, DefaultMaxSpansPerTrace, false, false)
 
 	require.Len(t, plans2, 1)
 	assert.True(t, plans2[0].Rejected)
@@ -283,7 +283,7 @@ func TestPlanTraceSequentialCalls(t *testing.T) {
 	var plans []SpanPlan
 	psc := 0
 	planEngine.planTrace(planEngine.Topology.Roots[0], -1, now, 0, nil, nil,
-		&planStats, &plans, &psc, DefaultMaxSpansPerTrace, false)
+		&planStats, &plans, &psc, DefaultMaxSpansPerTrace, false, false)
 
 	// Walk path with same seed
 	walkEngine, exporter, tp := newTestEngine(t, cfg)
@@ -291,7 +291,7 @@ func TestPlanTraceSequentialCalls(t *testing.T) {
 	var walkStats Stats
 	wsc := 0
 	walkEngine.walkTrace(context.Background(), walkEngine.Topology.Roots[0], nil, now, 0, nil, nil,
-		&walkStats, &wsc, DefaultMaxSpansPerTrace, false)
+		&walkStats, &wsc, DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -352,7 +352,7 @@ func TestPlanTraceRetries(t *testing.T) {
 	var plans []SpanPlan
 	psc := 0
 	planEngine.planTrace(planEngine.Topology.Roots[0], -1, now, 0, nil, nil,
-		&planStats, &plans, &psc, DefaultMaxSpansPerTrace, false)
+		&planStats, &plans, &psc, DefaultMaxSpansPerTrace, false, false)
 
 	// Walk
 	walkEngine, exporter, tp := newTestEngine(t, cfg)
@@ -360,7 +360,7 @@ func TestPlanTraceRetries(t *testing.T) {
 	var walkStats Stats
 	wsc := 0
 	walkEngine.walkTrace(context.Background(), walkEngine.Topology.Roots[0], nil, now, 0, nil, nil,
-		&walkStats, &wsc, DefaultMaxSpansPerTrace, false)
+		&walkStats, &wsc, DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -408,7 +408,7 @@ func TestPlanTraceSpanLinkAttributes(t *testing.T) {
 	require.NotNil(t, consumerRoot)
 
 	var plans []SpanPlan
-	engine.planTrace(consumerRoot, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false)
+	engine.planTrace(consumerRoot, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	require.Len(t, plans, 1)
 	require.Len(t, plans[0].LinkRefs, 1)
@@ -461,7 +461,7 @@ func TestRejectionSpanCountedOnce(t *testing.T) {
 		engine.State.Get("backend.handle").Enter() // queue now full
 
 		spanCount := 0
-		engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, &spanCount, DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), engine.Topology.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, &spanCount, DefaultMaxSpansPerTrace, false, false)
 		require.NoError(t, tp.ForceFlush(context.Background()))
 
 		assert.Equal(t, 2, spanCount, "root span plus one rejected span")
@@ -476,7 +476,7 @@ func TestRejectionSpanCountedOnce(t *testing.T) {
 
 		spanCount := 0
 		var plans []SpanPlan
-		engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, &spanCount, DefaultMaxSpansPerTrace, false)
+		engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, &spanCount, DefaultMaxSpansPerTrace, false, false)
 
 		assert.Equal(t, 2, spanCount, "root span plus one rejected span")
 		assert.Len(t, plans, 2, "span count matches planned spans")
@@ -511,7 +511,7 @@ func TestPlanTraceAsyncConsumerKind(t *testing.T) {
 	engine, _, _ := newTestEngine(t, cfg)
 
 	var plans []SpanPlan
-	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false)
+	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	require.Len(t, plans, 2)
 	byOp := map[string]SpanPlan{}
@@ -520,4 +520,43 @@ func TestPlanTraceAsyncConsumerKind(t *testing.T) {
 	}
 	assert.Equal(t, trace.SpanKindServer, byOp["submit"].Kind)
 	assert.Equal(t, trace.SpanKindConsumer, byOp["publish"].Kind, "async callee is a CONSUMER span in realtime mode")
+}
+
+// TestPlanTraceProducerKind pins that realtime planning marks producer
+// callees as PRODUCER spans, mirroring walkTrace.
+func TestPlanTraceProducerKind(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "api",
+				Operations: []OperationConfig{{
+					Name:     "submit",
+					Duration: "10ms",
+					Calls:    []CallConfig{{Target: "queue.publish", Producer: true}},
+				}},
+			},
+			{
+				Name: "queue",
+				Operations: []OperationConfig{{
+					Name:     "publish",
+					Duration: "2ms",
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "10/s"},
+	}
+	engine, _, _ := newTestEngine(t, cfg)
+
+	var plans []SpanPlan
+	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
+
+	require.Len(t, plans, 2)
+	byOp := map[string]SpanPlan{}
+	for _, p := range plans {
+		byOp[p.Operation] = p
+	}
+	assert.Equal(t, trace.SpanKindServer, byOp["submit"].Kind)
+	assert.Equal(t, trace.SpanKindProducer, byOp["publish"].Kind, "producer callee is a PRODUCER span in realtime mode")
 }

--- a/pkg/synth/property_test.go
+++ b/pkg/synth/property_test.go
@@ -133,7 +133,7 @@ func walkOnce(t *rapid.T, cfg *Config) (*Topology, []tracetest.SpanStub, *Stats)
 	rootOp := topo.Roots[rng.IntN(len(topo.Roots))]
 	now := time.Now().Add(offset)
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, now, 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	if err := tp.ForceFlush(context.Background()); err != nil {
 		t.Fatalf("ForceFlush: %v", err)
@@ -722,7 +722,7 @@ func TestProperty_Engine_ScenarioOverrideApplied(t *testing.T) {
 		}
 
 		var stats Stats
-		engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 
 		if err := tp.ForceFlush(context.Background()); err != nil {
 			t.Fatalf("ForceFlush: %v", err)
@@ -779,7 +779,7 @@ func TestProperty_Engine_ScenarioErrorRateOverride(t *testing.T) {
 		}
 
 		var stats Stats
-		engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, overrides, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 
 		if err := tp.ForceFlush(context.Background()); err != nil {
 			t.Fatalf("ForceFlush: %v", err)

--- a/pkg/synth/scenario.go
+++ b/pkg/synth/scenario.go
@@ -107,6 +107,7 @@ func BuildScenarios(cfgs []ScenarioConfig, topo *Topology) ([]Scenario, error) {
 					Count:       callCfg.Count,
 					Retries:     callCfg.Retries,
 					Async:       callCfg.Async,
+					Producer:    callCfg.Producer,
 				}
 				if callCfg.Timeout != "" {
 					call.Timeout, err = time.ParseDuration(callCfg.Timeout)

--- a/pkg/synth/state_test.go
+++ b/pkg/synth/state_test.go
@@ -297,7 +297,7 @@ func TestEngineQueueDepthRejection(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()
@@ -351,14 +351,14 @@ func TestEngineCircuitBreakerIntegration(t *testing.T) {
 	require.NotNil(t, opState)
 
 	for range opState.FailureThreshold {
-		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+		engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	}
 
 	assert.Equal(t, CircuitOpen, opState.Circuit, "circuit should be open after threshold failures")
 
 	// Third call should be rejected (circuit is open)
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), time.Second, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), time.Second, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	assert.Equal(t, int64(1), stats.CircuitBreakerTrips)
@@ -400,7 +400,7 @@ func TestEngineBackpressureIntegration(t *testing.T) {
 	rootOp := engine.Topology.Roots[0]
 
 	// First call: 10ms duration > 5ms threshold → backpressure activates
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans1 := exporter.GetSpans()
@@ -409,7 +409,7 @@ func TestEngineBackpressureIntegration(t *testing.T) {
 
 	// Second call: backpressure should be active, amplifying duration
 	exporter.Reset()
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), time.Second, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), time.Second, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans2 := exporter.GetSpans()
@@ -440,7 +440,7 @@ func TestEngineStateNotCreatedWithoutConfig(t *testing.T) {
 
 	rootOp := engine.Topology.Roots[0]
 	var stats Stats
-	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false)
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exporter.GetSpans()

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -107,6 +107,7 @@ type Call struct {
 	Retries      int
 	RetryBackoff time.Duration
 	Async        bool
+	Producer     bool
 }
 
 // DomainResolver maps a domain identifier to attribute generators.
@@ -297,6 +298,7 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 					Count:       callCfg.Count,
 					Retries:     callCfg.Retries,
 					Async:       callCfg.Async,
+					Producer:    callCfg.Producer,
 				}
 				if callCfg.Timeout != "" {
 					call.Timeout, err = time.ParseDuration(callCfg.Timeout)


### PR DESCRIPTION
Closes #214.

## What

motel emitted `CONSUMER` for async children but never `PRODUCER`, the fifth OTel span kind. This adds a `producer: true` call modifier that emits a `PRODUCER` span for an asynchronous enqueue/publish step.

```yaml
api:
  operations:
    handle:
      calls:
        - target: queue.publish
          producer: true   # → PRODUCER span on queue.publish
```

A producer call's callee is given span kind `PRODUCER`. Unlike `async` (which is fire-and-forget and yields `CONSUMER`), a producer enqueue is **synchronous** from the caller's perspective — the parent waits for the publish to complete. `producer` and `async` are mutually exclusive; validation rejects combining them.

## How it composes with span links

The realistic messaging pattern — a `PRODUCER` publish span on the publishing service and a (separate-trace, linked) `CONSUMER` span on the processing service — falls out of combining the new `producer` flag with the existing `async` (`CONSUMER`) calls and span links. See `docs/examples/producer-consumer.yaml`:

- `api.handle` → `queue.publish` with `producer: true` ⇒ `PRODUCER`
- `worker.poll` → `worker.process` with `async: true` ⇒ `CONSUMER`, in its own trace, linked back to `queue.publish`

## Implementation notes

The span-kind decision (SERVER for roots, PRODUCER for producer callees, CONSUMER for async callees, CLIENT otherwise) is unified into a single `spanKindFor` helper shared by `walkTrace`, `planTrace`, and both rejection-span paths, so realtime and non-realtime modes stay in lockstep. Roots always win; producer takes precedence over async.

## Acceptance criteria

- [x] Topology can produce explicit `PRODUCER` spans for async producers
- [x] Existing `CONSUMER` behaviour preserved
- [x] Producer/consumer pairing composes with span links
- [x] Unit coverage + an example under `docs/examples/`

## Tests

- `TestProducerCallSpanKind` — PRODUCER on the publish side, synchronous wait
- `TestProducerConsumerComposeWithSpanLinks` — PRODUCER + CONSUMER across separate traces joined by a span link
- `TestPlanTraceProducerKind` — realtime plan-path parity
- `TestValidateProducerWithAsyncRejected` — producer + async rejected

Full suite passes; `docs/examples/producer-consumer.yaml` validates and checks cleanly, and a `--stdout` run shows the expected SERVER/PRODUCER/CONSUMER kinds with consumer links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnSaVjfvkXwuRVX8wwaDsw)_