### PR TITLE
feat: emit INTERNAL span kind for same-service sync calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `INTERNAL` spans instead of `CLIENT`, matching the OTel SpanKind spec: an
   in-process sub-operation crosses no remote boundary. Cross-service sync
   calls still emit `CLIENT`, and `async`/`producer` callees keep
-  `CONSUMER`/`PRODUCER` regardless of service. (#213)
+  `CONSUMER`/`PRODUCER` regardless of service. Replay mode derives kinds by
+  the same rule: a recorded child span on its parent's service replays as
+  `INTERNAL`. (#213)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Sync calls that target an operation on the caller's own service now emit
+  `INTERNAL` spans instead of `CLIENT`, matching the OTel SpanKind spec: an
+  in-process sub-operation crosses no remote boundary. Cross-service sync
+  calls still emit `CLIENT`, and `async`/`producer` callees keep
+  `CONSUMER`/`PRODUCER` regardless of service. (#213)
+
 ### Added
 
 - `producer: true` call modifier emits a `PRODUCER` span for an asynchronous

--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -167,6 +167,21 @@ or a full mapping.
 | `async`        | bool   | Fire-and-forget: child runs independently, parent does not wait. Child span kind is CONSUMER instead of CLIENT. Errors do not cascade to parent. Cannot combine with `retries` or `timeout` |
 | `producer`     | bool   | Messaging enqueue/publish step: child span kind is PRODUCER instead of CLIENT. The publish is synchronous (parent waits). Pair with an `async` consumer and a span link for cross-trace messaging. Cannot combine with `async` |
 
+Span kinds are derived from an operation's position in the topology and how it
+was invoked:
+
+- Root operations (not targeted by any call) emit `SERVER` spans.
+- `producer: true` callees emit `PRODUCER` spans; `async: true` callees emit
+  `CONSUMER` spans — regardless of which service they live on.
+- Sync callees on the **same service** as their caller emit `INTERNAL` spans:
+  an in-process sub-operation that crosses no remote boundary.
+- All other sync callees (cross-service calls) emit `CLIENT` spans.
+
+To model an internal sub-operation, point a call at another operation on the
+same service (e.g. `checkout.validate` calling `checkout.reserve-stock`). It
+behaves like any other call — duration, error rates, retries, and downstream
+calls all apply — but the span is tagged `INTERNAL` instead of `CLIENT`.
+
 ```yaml
 calls:
   # String shorthand

--- a/docs/explanation/property-testing.md
+++ b/docs/explanation/property-testing.md
@@ -51,7 +51,8 @@ real operations.
 
 **Span structure (5 tests).** Children start after their parent, parents end
 after their children, durations are positive. Root spans are SERVER kind,
-non-root spans are CLIENT kind. All spans in a trace share the same trace ID.
+non-root spans are CLIENT kind (the generator only produces cross-service sync
+calls). All spans in a trace share the same trace ID.
 
 **Call graph (1 test).** Every parent-child span pair corresponds to a valid
 call edge in the topology.

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -769,7 +769,7 @@ func spanKindFor(topo *Topology, op, parent *Operation, isAsync, isProducer bool
 		return trace.SpanKindProducer
 	case isAsync:
 		return trace.SpanKindConsumer
-	case parent != nil && parent.Service.Name == op.Service.Name:
+	case parent != nil && parent.Service == op.Service:
 		return trace.SpanKindInternal
 	default:
 		return trace.SpanKindClient

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -350,7 +350,7 @@ func (e *Engine) runRealtime(ctx context.Context) (*Stats, error) {
 		// QueueRejections, and CircuitBreakerTrips which are plan-phase
 		// decisions.
 		var plans []SpanPlan
-		_, rootErr := e.planTrace(root, -1, spanStart, elapsed, overrides, scenarioNames, &stats, &plans, &spanCount, spanLimit, false, false)
+		_, rootErr := e.planTrace(root, nil, -1, spanStart, elapsed, overrides, scenarioNames, &stats, &plans, &spanCount, spanLimit, false, false)
 		stats.Traces++
 		if rootErr {
 			stats.FailedTraces++
@@ -448,8 +448,9 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 	}
 
 	// Determine span kind: SERVER for roots, PRODUCER for producer callees,
-	// CONSUMER for async callees, CLIENT otherwise.
-	kind := spanKindFor(e.Topology, op, isAsync, isProducer)
+	// CONSUMER for async callees, INTERNAL for same-service sync callees,
+	// CLIENT otherwise.
+	kind := spanKindFor(e.Topology, op, parent, isAsync, isProducer)
 
 	startAttrs := []attribute.KeyValue{
 		attribute.String("synth.service", op.Service.Name),
@@ -649,7 +650,7 @@ func (e *Engine) emitRejectionSpan(ctx context.Context, op, parent *Operation, s
 	tracer := e.Tracers(op.Service.Name)
 	endTime := startTime.Add(rejectionDuration)
 
-	kind := spanKindFor(e.Topology, op, isAsync, isProducer)
+	kind := spanKindFor(e.Topology, op, parent, isAsync, isProducer)
 
 	rejAttrs := []attribute.KeyValue{
 		attribute.String("synth.service", op.Service.Name),
@@ -757,8 +758,10 @@ func isRoot(topo *Topology, op *Operation) bool {
 // spanKindFor determines the OTel span kind for an operation given how it was
 // invoked: SERVER for trace roots, PRODUCER for the callee of a producer call
 // (an async enqueue/publish step), CONSUMER for the callee of an async call,
-// and CLIENT otherwise. Roots always win; producer takes precedence over async.
-func spanKindFor(topo *Topology, op *Operation, isAsync, isProducer bool) trace.SpanKind {
+// INTERNAL for a sync callee on the same service as its caller (an in-process
+// sub-operation with no remote hop), and CLIENT for cross-service sync calls.
+// Roots always win; producer takes precedence over async.
+func spanKindFor(topo *Topology, op, parent *Operation, isAsync, isProducer bool) trace.SpanKind {
 	switch {
 	case isRoot(topo, op):
 		return trace.SpanKindServer
@@ -766,6 +769,8 @@ func spanKindFor(topo *Topology, op *Operation, isAsync, isProducer bool) trace.
 		return trace.SpanKindProducer
 	case isAsync:
 		return trace.SpanKindConsumer
+	case parent != nil && parent.Service.Name == op.Service.Name:
+		return trace.SpanKindInternal
 	default:
 		return trace.SpanKindClient
 	}

--- a/pkg/synth/engine_test.go
+++ b/pkg/synth/engine_test.go
@@ -2377,14 +2377,11 @@ func TestSyncCallSpanKindIsClient(t *testing.T) {
 	assert.Equal(t, trace.SpanKindClient, childSpan.SpanKind, "sync callee should be CLIENT")
 }
 
-// TestSameServiceSyncCallSpanKindIsInternal pins that a sync call to another
-// operation on the same service emits an INTERNAL span (an in-process
-// sub-operation, no remote hop), while a cross-service sync call made by that
-// sub-operation still emits CLIENT.
-func TestSameServiceSyncCallSpanKindIsInternal(t *testing.T) {
-	t.Parallel()
-
-	cfg := &Config{
+// sameServiceCallConfig builds a topology exercising the same-service span
+// kind rule: gateway.handle sync-calls gateway.validate (same service, so
+// INTERNAL), which sync-calls backend.process (cross-service, so CLIENT).
+func sameServiceCallConfig() *Config {
+	return &Config{
 		Services: []ServiceConfig{
 			{
 				Name: "gateway",
@@ -2411,8 +2408,16 @@ func TestSameServiceSyncCallSpanKindIsInternal(t *testing.T) {
 		},
 		Traffic: TrafficConfig{Rate: "100/s"},
 	}
+}
 
-	engine, exporter, tp := newTestEngine(t, cfg)
+// TestSameServiceSyncCallSpanKindIsInternal pins that a sync call to another
+// operation on the same service emits an INTERNAL span (an in-process
+// sub-operation, no remote hop), while a cross-service sync call made by that
+// sub-operation still emits CLIENT.
+func TestSameServiceSyncCallSpanKindIsInternal(t *testing.T) {
+	t.Parallel()
+
+	engine, exporter, tp := newTestEngine(t, sameServiceCallConfig())
 
 	rootOp := engine.Topology.Roots[0]
 	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)

--- a/pkg/synth/engine_test.go
+++ b/pkg/synth/engine_test.go
@@ -2377,6 +2377,102 @@ func TestSyncCallSpanKindIsClient(t *testing.T) {
 	assert.Equal(t, trace.SpanKindClient, childSpan.SpanKind, "sync callee should be CLIENT")
 }
 
+// TestSameServiceSyncCallSpanKindIsInternal pins that a sync call to another
+// operation on the same service emits an INTERNAL span (an in-process
+// sub-operation, no remote hop), while a cross-service sync call made by that
+// sub-operation still emits CLIENT.
+func TestSameServiceSyncCallSpanKindIsInternal(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "gateway",
+				Operations: []OperationConfig{
+					{
+						Name:     "handle",
+						Duration: "10ms",
+						Calls:    []CallConfig{{Target: "gateway.validate"}},
+					},
+					{
+						Name:     "validate",
+						Duration: "5ms",
+						Calls:    []CallConfig{{Target: "backend.process"}},
+					},
+				},
+			},
+			{
+				Name: "backend",
+				Operations: []OperationConfig{{
+					Name:     "process",
+					Duration: "5ms",
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "100/s"},
+	}
+
+	engine, exporter, tp := newTestEngine(t, cfg)
+
+	rootOp := engine.Topology.Roots[0]
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 3)
+
+	kinds := make(map[string]trace.SpanKind, len(spans))
+	for _, s := range spans {
+		kinds[s.Name] = s.SpanKind
+	}
+
+	assert.Equal(t, trace.SpanKindServer, kinds["handle"], "root span should be SERVER")
+	assert.Equal(t, trace.SpanKindInternal, kinds["validate"], "same-service sync callee should be INTERNAL")
+	assert.Equal(t, trace.SpanKindClient, kinds["process"], "cross-service sync callee should be CLIENT")
+}
+
+// TestSameServiceAsyncCallSpanKindIsConsumer pins that async takes precedence
+// over the same-service INTERNAL rule: a fire-and-forget callee is CONSUMER
+// even when it lives on the caller's service.
+func TestSameServiceAsyncCallSpanKindIsConsumer(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{{
+			Name: "gateway",
+			Operations: []OperationConfig{
+				{
+					Name:     "handle",
+					Duration: "10ms",
+					Calls:    []CallConfig{{Target: "gateway.flush", Async: true}},
+				},
+				{
+					Name:     "flush",
+					Duration: "5ms",
+				},
+			},
+		}},
+		Traffic: TrafficConfig{Rate: "100/s"},
+	}
+
+	engine, exporter, tp := newTestEngine(t, cfg)
+
+	rootOp := engine.Topology.Roots[0]
+	engine.walkTrace(context.Background(), rootOp, nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 2)
+
+	kinds := make(map[string]trace.SpanKind, len(spans))
+	for _, s := range spans {
+		kinds[s.Name] = s.SpanKind
+	}
+
+	assert.Equal(t, trace.SpanKindServer, kinds["handle"], "root span should be SERVER")
+	assert.Equal(t, trace.SpanKindConsumer, kinds["flush"], "same-service async callee should be CONSUMER")
+}
+
 // TestProducerCallSpanKind pins that a call marked producer:true emits a
 // PRODUCER span for the enqueue/publish step, distinct from the CONSUMER kind
 // used for async callees. The producer enqueue is synchronous, so the parent

--- a/pkg/synth/observer_test.go
+++ b/pkg/synth/observer_test.go
@@ -414,7 +414,7 @@ func TestFinishSpanParentAttribution(t *testing.T) {
 
 	var plans []SpanPlan
 	now := time.Now()
-	engine.planTrace(engine.Topology.Roots[0], -1, now, 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
+	engine.planTrace(engine.Topology.Roots[0], nil, -1, now, 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
 	require.Len(t, plans, 2)
 
 	var rstats realtimeStats
@@ -481,7 +481,7 @@ func TestPlanTracePlanEvents(t *testing.T) {
 	engine.Observers = []SpanObserver{obs}
 
 	var plans []SpanPlan
-	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
+	engine.planTrace(engine.Topology.Roots[0], nil, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	events := obs.getEvents()
 	require.Len(t, events, 2)

--- a/pkg/synth/plan.go
+++ b/pkg/synth/plan.go
@@ -40,8 +40,10 @@ type SpanPlan struct {
 // It mirrors walkTrace exactly: same RNG consumption order, same SimulationState
 // mutations, same timing logic. The only difference is that it appends to plans
 // instead of creating OTel spans.
+// parent is the calling operation, nil for roots; it determines the span kind
+// for same-service sync callees.
 // Returns the span end time and whether the span errored.
-func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, plans *[]SpanPlan, spanCount *int, spanLimit int, isAsync, isProducer bool) (time.Time, bool) {
+func (e *Engine) planTrace(op, parent *Operation, parentIndex int, startTime time.Time, elapsed time.Duration, overrides map[string]Override, scenarioNames []string, stats *Stats, plans *[]SpanPlan, spanCount *int, spanLimit int, isAsync, isProducer bool) (time.Time, bool) {
 	if *spanCount >= spanLimit {
 		return startTime, false
 	}
@@ -76,7 +78,7 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 				stats.CircuitBreakerTrips++
 				notifyPlanEvent(e.Observers, PlanEvent{Kind: PlanEventCircuitBreakerTrip, Service: op.Service.Name, Operation: op.Name, Timestamp: startTime})
 			}
-			return e.planRejectionSpan(op, parentIndex, startTime, reason, scenarioNames, plans, isAsync, isProducer)
+			return e.planRejectionSpan(op, parent, parentIndex, startTime, reason, scenarioNames, plans, isAsync, isProducer)
 		}
 		if durationMult > 1.0 {
 			duration.Mean = time.Duration(float64(duration.Mean) * durationMult)
@@ -85,7 +87,7 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 		opState.Enter()
 	}
 
-	kind := spanKindFor(e.Topology, op, isAsync, isProducer)
+	kind := spanKindFor(e.Topology, op, parent, isAsync, isProducer)
 
 	startAttrs := []attribute.KeyValue{
 		attribute.String("synth.service", op.Service.Name),
@@ -221,10 +223,10 @@ func (e *Engine) planTrace(op *Operation, parentIndex int, startTime time.Time, 
 // planRejectionSpan mirrors emitRejectionSpan but appends to plans.
 // The caller (planTrace) has already counted this span against the trace's
 // span limit, so spanCount is not incremented here.
-func (e *Engine) planRejectionSpan(op *Operation, parentIndex int, startTime time.Time, reason string, scenarioNames []string, plans *[]SpanPlan, isAsync, isProducer bool) (time.Time, bool) {
+func (e *Engine) planRejectionSpan(op, parent *Operation, parentIndex int, startTime time.Time, reason string, scenarioNames []string, plans *[]SpanPlan, isAsync, isProducer bool) (time.Time, bool) {
 	endTime := startTime.Add(rejectionDuration)
 
-	kind := spanKindFor(e.Topology, op, isAsync, isProducer)
+	kind := spanKindFor(e.Topology, op, parent, isAsync, isProducer)
 
 	rejAttrs := []attribute.KeyValue{
 		attribute.String("synth.service", op.Service.Name),
@@ -262,7 +264,7 @@ func (e *Engine) executePlanCall(active activeCall, parent *Operation, parentInd
 	attemptStart := callStart
 
 	for attempt := range maxAttempts {
-		childEnd, childErr := e.planTrace(call.Operation, parentIndex, attemptStart, elapsed, overrides, scenarioNames, stats, plans, spanCount, spanLimit, call.Async, call.Producer)
+		childEnd, childErr := e.planTrace(call.Operation, parent, parentIndex, attemptStart, elapsed, overrides, scenarioNames, stats, plans, spanCount, spanLimit, call.Async, call.Producer)
 		perceivedEnd := childEnd
 		failed := childErr
 

--- a/pkg/synth/plan_test.go
+++ b/pkg/synth/plan_test.go
@@ -46,7 +46,7 @@ func TestPlanTraceBasic(t *testing.T) {
 	spanCount := 0
 
 	engine.Rng = rand.New(rand.NewPCG(42, 0))
-	endTime, isError := engine.planTrace(rootOp, -1, now, 0, nil, nil, &stats, &plans, &spanCount, DefaultMaxSpansPerTrace, false, false)
+	endTime, isError := engine.planTrace(rootOp, nil, -1, now, 0, nil, nil, &stats, &plans, &spanCount, DefaultMaxSpansPerTrace, false, false)
 
 	require.Len(t, plans, 2)
 
@@ -124,7 +124,7 @@ func TestPlanTraceMatchesWalkTrace(t *testing.T) {
 	var plans []SpanPlan
 	planSpanCount := 0
 	planEnd, planErr := planEngine.planTrace(
-		planEngine.Topology.Roots[0], -1, now, 0, nil, nil,
+		planEngine.Topology.Roots[0], nil, -1, now, 0, nil, nil,
 		&planStats, &plans, &planSpanCount, DefaultMaxSpansPerTrace, false, false,
 	)
 
@@ -202,7 +202,7 @@ func TestPlanTraceSpanLimit(t *testing.T) {
 	var plans []SpanPlan
 	spanCount := 0
 
-	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil,
+	engine.planTrace(engine.Topology.Roots[0], nil, -1, time.Now(), 0, nil, nil,
 		&stats, &plans, &spanCount, 2, false, false)
 
 	assert.Equal(t, 2, len(plans), "should stop at span limit")
@@ -232,7 +232,7 @@ func TestPlanTraceRejection(t *testing.T) {
 	var stats1 Stats
 	var plans1 []SpanPlan
 	sc1 := 0
-	engine.planTrace(rootOp, -1, time.Now(), 0, nil, nil, &stats1, &plans1, &sc1, DefaultMaxSpansPerTrace, false, false)
+	engine.planTrace(rootOp, nil, -1, time.Now(), 0, nil, nil, &stats1, &plans1, &sc1, DefaultMaxSpansPerTrace, false, false)
 
 	// Manually bump active requests to trigger queue full
 	opState := engine.State.Get(rootOp.Ref)
@@ -241,7 +241,7 @@ func TestPlanTraceRejection(t *testing.T) {
 	var stats2 Stats
 	var plans2 []SpanPlan
 	sc2 := 0
-	engine.planTrace(rootOp, -1, time.Now(), time.Second, nil, nil, &stats2, &plans2, &sc2, DefaultMaxSpansPerTrace, false, false)
+	engine.planTrace(rootOp, nil, -1, time.Now(), time.Second, nil, nil, &stats2, &plans2, &sc2, DefaultMaxSpansPerTrace, false, false)
 
 	require.Len(t, plans2, 1)
 	assert.True(t, plans2[0].Rejected)
@@ -282,7 +282,7 @@ func TestPlanTraceSequentialCalls(t *testing.T) {
 	var planStats Stats
 	var plans []SpanPlan
 	psc := 0
-	planEngine.planTrace(planEngine.Topology.Roots[0], -1, now, 0, nil, nil,
+	planEngine.planTrace(planEngine.Topology.Roots[0], nil, -1, now, 0, nil, nil,
 		&planStats, &plans, &psc, DefaultMaxSpansPerTrace, false, false)
 
 	// Walk path with same seed
@@ -351,7 +351,7 @@ func TestPlanTraceRetries(t *testing.T) {
 	var planStats Stats
 	var plans []SpanPlan
 	psc := 0
-	planEngine.planTrace(planEngine.Topology.Roots[0], -1, now, 0, nil, nil,
+	planEngine.planTrace(planEngine.Topology.Roots[0], nil, -1, now, 0, nil, nil,
 		&planStats, &plans, &psc, DefaultMaxSpansPerTrace, false, false)
 
 	// Walk
@@ -408,7 +408,7 @@ func TestPlanTraceSpanLinkAttributes(t *testing.T) {
 	require.NotNil(t, consumerRoot)
 
 	var plans []SpanPlan
-	engine.planTrace(consumerRoot, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
+	engine.planTrace(consumerRoot, nil, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	require.Len(t, plans, 1)
 	require.Len(t, plans[0].LinkRefs, 1)
@@ -420,6 +420,57 @@ func TestPlanTraceSpanLinkAttributes(t *testing.T) {
 	}
 	assert.Equal(t, attribute.StringValue("msg-42"), linkAttrs["messaging.message.id"])
 	assert.Equal(t, attribute.IntValue(7), linkAttrs["messaging.batch.message.index"])
+}
+
+// TestPlanTraceSameServiceSyncCallKind pins that plan mode assigns INTERNAL to
+// same-service sync callees and CLIENT to cross-service sync callees, matching
+// walkTrace.
+func TestPlanTraceSameServiceSyncCallKind(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Services: []ServiceConfig{
+			{
+				Name: "gateway",
+				Operations: []OperationConfig{
+					{
+						Name:     "handle",
+						Duration: "10ms",
+						Calls:    []CallConfig{{Target: "gateway.validate"}},
+					},
+					{
+						Name:     "validate",
+						Duration: "5ms",
+						Calls:    []CallConfig{{Target: "backend.process"}},
+					},
+				},
+			},
+			{
+				Name: "backend",
+				Operations: []OperationConfig{{
+					Name:     "process",
+					Duration: "5ms",
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "10/s"},
+	}
+
+	engine, _, _ := newTestEngine(t, cfg)
+
+	var plans []SpanPlan
+	engine.planTrace(engine.Topology.Roots[0], nil, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
+
+	require.Len(t, plans, 3)
+
+	kinds := make(map[string]trace.SpanKind, len(plans))
+	for _, p := range plans {
+		kinds[p.Operation] = p.Kind
+	}
+
+	assert.Equal(t, trace.SpanKindServer, kinds["handle"], "root span should be SERVER")
+	assert.Equal(t, trace.SpanKindInternal, kinds["validate"], "same-service sync callee should be INTERNAL")
+	assert.Equal(t, trace.SpanKindClient, kinds["process"], "cross-service sync callee should be CLIENT")
 }
 
 // twoTierStateConfig builds a gateway->backend topology where backend has a
@@ -476,7 +527,7 @@ func TestRejectionSpanCountedOnce(t *testing.T) {
 
 		spanCount := 0
 		var plans []SpanPlan
-		engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, &spanCount, DefaultMaxSpansPerTrace, false, false)
+		engine.planTrace(engine.Topology.Roots[0], nil, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, &spanCount, DefaultMaxSpansPerTrace, false, false)
 
 		assert.Equal(t, 2, spanCount, "root span plus one rejected span")
 		assert.Len(t, plans, 2, "span count matches planned spans")
@@ -511,7 +562,7 @@ func TestPlanTraceAsyncConsumerKind(t *testing.T) {
 	engine, _, _ := newTestEngine(t, cfg)
 
 	var plans []SpanPlan
-	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
+	engine.planTrace(engine.Topology.Roots[0], nil, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	require.Len(t, plans, 2)
 	byOp := map[string]SpanPlan{}
@@ -550,7 +601,7 @@ func TestPlanTraceProducerKind(t *testing.T) {
 	engine, _, _ := newTestEngine(t, cfg)
 
 	var plans []SpanPlan
-	engine.planTrace(engine.Topology.Roots[0], -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
+	engine.planTrace(engine.Topology.Roots[0], nil, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
 
 	require.Len(t, plans, 2)
 	byOp := map[string]SpanPlan{}

--- a/pkg/synth/plan_test.go
+++ b/pkg/synth/plan_test.go
@@ -424,39 +424,11 @@ func TestPlanTraceSpanLinkAttributes(t *testing.T) {
 
 // TestPlanTraceSameServiceSyncCallKind pins that plan mode assigns INTERNAL to
 // same-service sync callees and CLIENT to cross-service sync callees, matching
-// walkTrace.
+// walkTrace. The topology is shared with TestSameServiceSyncCallSpanKindIsInternal.
 func TestPlanTraceSameServiceSyncCallKind(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{
-		Services: []ServiceConfig{
-			{
-				Name: "gateway",
-				Operations: []OperationConfig{
-					{
-						Name:     "handle",
-						Duration: "10ms",
-						Calls:    []CallConfig{{Target: "gateway.validate"}},
-					},
-					{
-						Name:     "validate",
-						Duration: "5ms",
-						Calls:    []CallConfig{{Target: "backend.process"}},
-					},
-				},
-			},
-			{
-				Name: "backend",
-				Operations: []OperationConfig{{
-					Name:     "process",
-					Duration: "5ms",
-				}},
-			},
-		},
-		Traffic: TrafficConfig{Rate: "10/s"},
-	}
-
-	engine, _, _ := newTestEngine(t, cfg)
+	engine, _, _ := newTestEngine(t, sameServiceCallConfig())
 
 	var plans []SpanPlan
 	engine.planTrace(engine.Topology.Roots[0], nil, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)

--- a/pkg/synth/replay.go
+++ b/pkg/synth/replay.go
@@ -343,9 +343,15 @@ func buildReplayPlans(t RecordedTrace, shift time.Duration, preserveIDs bool) ([
 			endT = startT
 		}
 
+		// Derive span kind from tree position and service boundaries, matching
+		// spanKindFor's rules for generated traces: roots are SERVER, children
+		// on their parent's service are INTERNAL, cross-service children CLIENT.
 		kind := trace.SpanKindClient
-		if parentIndex < 0 {
+		switch {
+		case parentIndex < 0:
 			kind = trace.SpanKindServer
+		case plans[parentIndex].Service == s.Service:
+			kind = trace.SpanKindInternal
 		}
 
 		attrs := make([]attribute.KeyValue, 0, len(s.Attributes))

--- a/pkg/synth/replay_test.go
+++ b/pkg/synth/replay_test.go
@@ -139,6 +139,35 @@ func TestBuildReplayPlansStructure(t *testing.T) {
 	}
 }
 
+// TestBuildReplayPlansSameServiceChildIsInternal pins that replay derives the
+// same span kinds as generation: a recorded child on its parent's service is
+// INTERNAL, while a cross-service child (or grandchild) is CLIENT.
+func TestBuildReplayPlansSameServiceChildIsInternal(t *testing.T) {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	rec := RecordedTrace{
+		TraceID: "trace-internal",
+		Spans: []RecordedSpan{
+			{SpanID: "a", Service: "checkout", Operation: "submit", Start: base, End: base.Add(100 * time.Millisecond)},
+			{SpanID: "b", ParentID: "a", Service: "checkout", Operation: "validate", Start: base.Add(10 * time.Millisecond), End: base.Add(50 * time.Millisecond)},
+			{SpanID: "c", ParentID: "b", Service: "inventory", Operation: "reserve", Start: base.Add(20 * time.Millisecond), End: base.Add(40 * time.Millisecond)},
+		},
+	}
+
+	plans := mustBuildReplayPlans(t, rec, 0)
+	if len(plans) != 3 {
+		t.Fatalf("got %d plans, want 3", len(plans))
+	}
+	if plans[0].Kind != trace.SpanKindServer {
+		t.Errorf("root kind = %v, want Server", plans[0].Kind)
+	}
+	if plans[1].Kind != trace.SpanKindInternal {
+		t.Errorf("same-service child kind = %v, want Internal", plans[1].Kind)
+	}
+	if plans[2].Kind != trace.SpanKindClient {
+		t.Errorf("cross-service grandchild kind = %v, want Client", plans[2].Kind)
+	}
+}
+
 func TestBuildReplayPlansShift(t *testing.T) {
 	rec := sampleRecording()
 	orig := rec.Spans[0].Start


### PR DESCRIPTION
Closes #213.

Per the [OTel SpanKind spec](https://opentelemetry.io/docs/specs/otel/trace/api/#spankind), `INTERNAL` represents an operation that does not cross a remote/process boundary. motel previously emitted `CLIENT` for every non-root sync callee, including calls to another operation on the same service.

## Changes

- `spanKindFor` now takes the parent operation and returns `SpanKindInternal` when a sync callee lives on the same service as its caller. Precedence is unchanged otherwise: roots always win as `SERVER`, then `producer` → `PRODUCER`, then `async` → `CONSUMER`, then same-service → `INTERNAL`, else `CLIENT`.
- `walkTrace` already carried the parent operation; `planTrace`/`planRejectionSpan` (realtime plan mode) gained a `parent` parameter so both paths agree, including rejection spans.
- Confirmed the topology DSL already expresses same-service operation→operation edges: cycle detection is per-operation, so `checkout.submit → checkout.validate` validates fine (verified end-to-end via `motel run --stdout`: SERVER root, INTERNAL same-service child, CLIENT cross-service grandchild).

## Tests

- `TestSameServiceSyncCallSpanKindIsInternal`: same-service sync callee is `INTERNAL`, its cross-service downstream call is still `CLIENT`, root stays `SERVER`.
- `TestSameServiceAsyncCallSpanKindIsConsumer`: async precedence pinned — a same-service fire-and-forget callee stays `CONSUMER`.
- `TestPlanTraceSameServiceSyncCallKind`: plan-mode parity for the same topology.
- Existing cross-service kind tests (`TestSyncCallSpanKindIsClient`, producer/consumer tests) unchanged and passing.

## Docs

- `cmd/motel/README.md`: kind-selection rules documented in the `calls` section, with a note on modelling in-process sub-operations.
- `CHANGELOG.md`: entry under Unreleased → Changed (behavior change for existing configs with same-service sync calls).
- `docs/explanation/property-testing.md`: clarified that the "non-root spans are CLIENT" property holds because the generator only produces cross-service calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nKG5nUHLBi6KNegsvqR1V

---
_Generated by [Claude Code](https://claude.ai/code/session_019nKG5nUHLBi6KNegsvqR1V)_