### PR TITLE
feat: expose public trace-generation API in pkg/synth (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Public trace-generation API in `pkg/synth`: `GenerateTraces` emits N traces
+  from a `*Topology` with a given seed and span limit through any
+  caller-provided `TracerProvider` (adapted with `TracerProviderSource`), so
+  collector pipeline tests and other embedders can drive generation without
+  reaching into the unexported engine internals. The pipeline-testing
+  proof-of-concept now generates through it. (#199)
+
 - `producer: true` call modifier emits a `PRODUCER` span for an asynchronous
   enqueue/publish step, the fifth OTel span kind. It pairs with the existing
   `async` (`CONSUMER`) calls and span links to model cross-trace messaging:

--- a/docs/research/collector-pipeline-testing.md
+++ b/docs/research/collector-pipeline-testing.md
@@ -169,12 +169,12 @@ always-on coverage.
 
 ## Productionisation note
 
-The PoC drives generation from inside `package synth` because it reuses the
-unexported `walkTrace`. To let invariants and the harness live entirely outside
-`package synth` (which the later sub-issues will want), motel should expose a
-small public generation API — for example, emitting a topology's traces into a
-caller-provided `TracerProvider`. That is the natural next step and is tracked
-with the invariant work rather than this design.
+The PoC originally drove generation from inside `package synth` because it
+reused the unexported `walkTrace`. Issue 199 resolved this: `pkg/synth` now
+exposes `GenerateTraces`, a public, exporter-agnostic API that emits a
+topology's traces through a caller-provided `TracerProvider` (via
+`TracerProviderSource`), and the PoC drives generation through it. Invariant
+tests and the harness can therefore live entirely outside `package synth`.
 
 ## What later issues build on
 

--- a/pkg/synth/generate.go
+++ b/pkg/synth/generate.go
@@ -1,0 +1,96 @@
+// Public trace-generation API
+// Emits a topology's traces through a caller-provided TracerProvider so
+// pipeline tests and other embedders can drive generation without the engine.
+package synth
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// GenerateOptions configures GenerateTraces.
+type GenerateOptions struct {
+	// Traces is the number of traces to generate. Zero generates nothing.
+	Traces int
+
+	// Seed makes generation reproducible: trace i derives its RNG from
+	// Seed+i, so the same seed replays the same root choices and span
+	// structure. Zero picks a random seed.
+	Seed uint64
+
+	// MaxSpansPerTrace bounds the spans emitted per trace.
+	// Zero applies DefaultMaxSpansPerTrace.
+	MaxSpansPerTrace int
+}
+
+// TracerProviderSource adapts a trace.TracerProvider into a TracerSource that
+// names each tracer after the service it emits spans for. It accepts the API
+// interface rather than the SDK type, so any provider works — an SDK provider
+// wired to OTLP, an in-memory test exporter, or a no-op.
+func TracerProviderSource(tp trace.TracerProvider) TracerSource {
+	return func(serviceName string) trace.Tracer { return tp.Tracer(serviceName) }
+}
+
+// GenerateTraces emits opts.Traces traces from topo through tracers and
+// returns generation statistics. It is exporter-agnostic: the caller owns the
+// TracerProvider behind tracers and is responsible for flushing and shutting
+// it down after generation. Use TracerProviderSource to wrap a TracerProvider.
+//
+// Traces are generated back-to-back with no traffic pacing, scenarios, or
+// simulation state; each starts from a root chosen by the trace's own
+// seed-derived RNG. Generation stops early when ctx is cancelled, returning
+// the statistics accumulated so far alongside the context's error.
+func GenerateTraces(ctx context.Context, topo *Topology, tracers TracerSource, opts GenerateOptions) (*Stats, error) {
+	if tracers == nil {
+		return nil, fmt.Errorf("no tracer source provided")
+	}
+	if len(topo.Roots) == 0 {
+		return nil, fmt.Errorf("no root operations to generate traces from")
+	}
+
+	seed := opts.Seed
+	if seed == 0 {
+		seed = rand.Uint64() //nolint:gosec // not security-sensitive
+	}
+	spanLimit := opts.MaxSpansPerTrace
+	if spanLimit <= 0 {
+		spanLimit = DefaultMaxSpansPerTrace
+	}
+
+	engine := &Engine{
+		Topology:     topo,
+		Tracers:      tracers,
+		linkRegistry: newSpanContextRegistry(topo),
+	}
+
+	var stats Stats
+	startTime := time.Now()
+	for i := range opts.Traces {
+		select {
+		case <-ctx.Done():
+			engine.finaliseStats(&stats, startTime)
+			return &stats, ctx.Err()
+		default:
+		}
+
+		engine.Rng = rand.New(rand.NewPCG(seed+uint64(i), 0)) //nolint:gosec // not security-sensitive
+		root := topo.Roots[engine.Rng.IntN(len(topo.Roots))]
+
+		spanCount := 0
+		_, rootErr := engine.walkTrace(ctx, root, nil, time.Now(), 0, nil, nil, &stats, &spanCount, spanLimit, false, false)
+		stats.Traces++
+		if rootErr {
+			stats.FailedTraces++
+		}
+		if spanCount >= spanLimit {
+			stats.SpansBounded++
+		}
+	}
+
+	engine.finaliseStats(&stats, startTime)
+	return &stats, nil
+}

--- a/pkg/synth/generate.go
+++ b/pkg/synth/generate.go
@@ -30,8 +30,12 @@ type GenerateOptions struct {
 // TracerProviderSource adapts a trace.TracerProvider into a TracerSource that
 // names each tracer after the service it emits spans for. It accepts the API
 // interface rather than the SDK type, so any provider works — an SDK provider
-// wired to OTLP, an in-memory test exporter, or a no-op.
+// wired to OTLP, an in-memory test exporter, or a no-op. A nil provider yields
+// a nil TracerSource, which GenerateTraces rejects with an error.
 func TracerProviderSource(tp trace.TracerProvider) TracerSource {
+	if tp == nil {
+		return nil
+	}
 	return func(serviceName string) trace.Tracer { return tp.Tracer(serviceName) }
 }
 
@@ -47,6 +51,9 @@ func TracerProviderSource(tp trace.TracerProvider) TracerSource {
 func GenerateTraces(ctx context.Context, topo *Topology, tracers TracerSource, opts GenerateOptions) (*Stats, error) {
 	if tracers == nil {
 		return nil, fmt.Errorf("no tracer source provided")
+	}
+	if topo == nil {
+		return nil, fmt.Errorf("no topology provided")
 	}
 	if len(topo.Roots) == 0 {
 		return nil, fmt.Errorf("no root operations to generate traces from")

--- a/pkg/synth/generate_test.go
+++ b/pkg/synth/generate_test.go
@@ -162,6 +162,24 @@ func TestGenerateTraces_NilTracerSource(t *testing.T) {
 	}
 }
 
+func TestGenerateTraces_NilTopology(t *testing.T) {
+	_, tp := newCapturingProvider(t)
+
+	if _, err := GenerateTraces(context.Background(), nil, TracerProviderSource(tp), GenerateOptions{Traces: 1}); err == nil {
+		t.Fatal("expected error for nil topology")
+	}
+}
+
+func TestTracerProviderSource_NilProvider(t *testing.T) {
+	if src := TracerProviderSource(nil); src != nil {
+		t.Fatal("expected nil TracerSource for nil provider")
+	}
+
+	if _, err := GenerateTraces(context.Background(), generateTestChain(), TracerProviderSource(nil), GenerateOptions{Traces: 1}); err == nil {
+		t.Fatal("expected error when generating with a nil provider source")
+	}
+}
+
 func TestGenerateTraces_ZeroTraces(t *testing.T) {
 	exporter, tp := newCapturingProvider(t)
 

--- a/pkg/synth/generate_test.go
+++ b/pkg/synth/generate_test.go
@@ -1,0 +1,193 @@
+package synth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// generateTestChain builds a three-operation chain across three services:
+// gateway.handle -> backend.read -> db.query. Every trace emits exactly
+// three spans because no calls are probabilistic or conditional.
+func generateTestChain() *Topology {
+	gateway := &Service{Name: "gateway", Operations: make(map[string]*Operation)}
+	backend := &Service{Name: "backend", Operations: make(map[string]*Operation)}
+	db := &Service{Name: "db", Operations: make(map[string]*Operation)}
+
+	query := &Operation{Service: db, Name: "query", Ref: "db.query",
+		Duration: Distribution{Mean: time.Millisecond}}
+	read := &Operation{Service: backend, Name: "read", Ref: "backend.read",
+		Duration: Distribution{Mean: 2 * time.Millisecond},
+		Calls:    []Call{{Operation: query}}}
+	handle := &Operation{Service: gateway, Name: "handle", Ref: "gateway.handle",
+		Duration: Distribution{Mean: 5 * time.Millisecond},
+		Calls:    []Call{{Operation: read}}}
+
+	gateway.Operations["handle"] = handle
+	backend.Operations["read"] = read
+	db.Operations["query"] = query
+
+	return &Topology{
+		Services: map[string]*Service{"gateway": gateway, "backend": backend, "db": db},
+		Roots:    []*Operation{handle},
+	}
+}
+
+// newCapturingProvider returns an in-memory exporter and a TracerProvider
+// that writes every span to it synchronously.
+func newCapturingProvider(t *testing.T) (*tracetest.InMemoryExporter, *sdktrace.TracerProvider) {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return exporter, tp
+}
+
+func TestGenerateTraces_EmitsExpectedSpans(t *testing.T) {
+	topo := generateTestChain()
+	exporter, tp := newCapturingProvider(t)
+
+	const n = 5
+	stats, err := GenerateTraces(context.Background(), topo, TracerProviderSource(tp), GenerateOptions{Traces: n, Seed: 42})
+	if err != nil {
+		t.Fatalf("GenerateTraces: %v", err)
+	}
+
+	if stats.Traces != n {
+		t.Fatalf("expected %d traces, got %d", n, stats.Traces)
+	}
+	if stats.Spans != 3*n {
+		t.Fatalf("expected %d spans in stats, got %d", 3*n, stats.Spans)
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 3*n {
+		t.Fatalf("expected %d exported spans, got %d", 3*n, len(spans))
+	}
+
+	scopeByName := map[string]string{"handle": "gateway", "read": "backend", "query": "db"}
+	counts := make(map[string]int)
+	for _, s := range spans {
+		counts[s.Name]++
+		if want := scopeByName[s.Name]; s.InstrumentationScope.Name != want {
+			t.Fatalf("span %q has scope %q, want %q", s.Name, s.InstrumentationScope.Name, want)
+		}
+	}
+	for name := range scopeByName {
+		if counts[name] != n {
+			t.Fatalf("expected %d %q spans, got %d", n, name, counts[name])
+		}
+	}
+}
+
+func TestGenerateTraces_ReproducibleWithSeed(t *testing.T) {
+	run := func() (*Stats, []tracetest.SpanStub) {
+		topo := generateTestChain()
+		topo.Services["backend"].Operations["read"].ErrorRate = 0.5
+		exporter, tp := newCapturingProvider(t)
+		stats, err := GenerateTraces(context.Background(), topo, TracerProviderSource(tp), GenerateOptions{Traces: 20, Seed: 7})
+		if err != nil {
+			t.Fatalf("GenerateTraces: %v", err)
+		}
+		return stats, exporter.GetSpans()
+	}
+
+	first, firstSpans := run()
+	second, secondSpans := run()
+
+	if first.Spans != second.Spans || first.Errors != second.Errors || first.FailedTraces != second.FailedTraces {
+		t.Fatalf("same seed produced different stats: %+v vs %+v", first, second)
+	}
+	if len(firstSpans) != len(secondSpans) {
+		t.Fatalf("same seed produced %d vs %d spans", len(firstSpans), len(secondSpans))
+	}
+	for i := range firstSpans {
+		if firstSpans[i].Name != secondSpans[i].Name {
+			t.Fatalf("span %d name mismatch: %q vs %q", i, firstSpans[i].Name, secondSpans[i].Name)
+		}
+		if firstSpans[i].Status.Code != secondSpans[i].Status.Code {
+			t.Fatalf("span %d status mismatch: %v vs %v", i, firstSpans[i].Status.Code, secondSpans[i].Status.Code)
+		}
+	}
+}
+
+func TestGenerateTraces_BoundsSpansPerTrace(t *testing.T) {
+	// root fans out to A three times and each A calls B, so an unbounded
+	// trace emits 7 spans; a limit of 5 must cap every trace.
+	s := &Service{Name: "s", Operations: make(map[string]*Operation)}
+	opB := &Operation{Service: s, Name: "B", Ref: "s.B",
+		Duration: Distribution{Mean: time.Millisecond}}
+	opA := &Operation{Service: s, Name: "A", Ref: "s.A",
+		Duration: Distribution{Mean: time.Millisecond},
+		Calls:    []Call{{Operation: opB}}}
+	root := &Operation{Service: s, Name: "root", Ref: "s.root",
+		Duration: Distribution{Mean: time.Millisecond},
+		Calls:    []Call{{Operation: opA, Count: 3}}}
+	s.Operations["root"] = root
+	s.Operations["A"] = opA
+	s.Operations["B"] = opB
+	topo := &Topology{Services: map[string]*Service{"s": s}, Roots: []*Operation{root}}
+
+	exporter, tp := newCapturingProvider(t)
+
+	const n = 4
+	stats, err := GenerateTraces(context.Background(), topo, TracerProviderSource(tp), GenerateOptions{Traces: n, Seed: 42, MaxSpansPerTrace: 5})
+	if err != nil {
+		t.Fatalf("GenerateTraces: %v", err)
+	}
+
+	if got := len(exporter.GetSpans()); got != 5*n {
+		t.Fatalf("expected %d spans with cap 5, got %d", 5*n, got)
+	}
+	if stats.SpansBounded != n {
+		t.Fatalf("expected %d bounded traces, got %d", n, stats.SpansBounded)
+	}
+}
+
+func TestGenerateTraces_NoRoots(t *testing.T) {
+	topo := &Topology{Services: map[string]*Service{}}
+	_, tp := newCapturingProvider(t)
+
+	if _, err := GenerateTraces(context.Background(), topo, TracerProviderSource(tp), GenerateOptions{Traces: 1}); err == nil {
+		t.Fatal("expected error for topology without roots")
+	}
+}
+
+func TestGenerateTraces_NilTracerSource(t *testing.T) {
+	if _, err := GenerateTraces(context.Background(), generateTestChain(), nil, GenerateOptions{Traces: 1}); err == nil {
+		t.Fatal("expected error for nil tracer source")
+	}
+}
+
+func TestGenerateTraces_ZeroTraces(t *testing.T) {
+	exporter, tp := newCapturingProvider(t)
+
+	stats, err := GenerateTraces(context.Background(), generateTestChain(), TracerProviderSource(tp), GenerateOptions{})
+	if err != nil {
+		t.Fatalf("GenerateTraces: %v", err)
+	}
+	if stats.Traces != 0 || stats.Spans != 0 {
+		t.Fatalf("expected zero stats, got %+v", stats)
+	}
+	if got := len(exporter.GetSpans()); got != 0 {
+		t.Fatalf("expected no spans, got %d", got)
+	}
+}
+
+func TestGenerateTraces_CancelledContext(t *testing.T) {
+	_, tp := newCapturingProvider(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stats, err := GenerateTraces(ctx, generateTestChain(), TracerProviderSource(tp), GenerateOptions{Traces: 10, Seed: 42})
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if stats.Traces != 0 {
+		t.Fatalf("expected no traces after immediate cancellation, got %d", stats.Traces)
+	}
+}

--- a/pkg/synth/pipeline_test.go
+++ b/pkg/synth/pipeline_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"go.opentelemetry.io/otel/trace"
 	"pgregory.net/rapid"
 )
 
@@ -180,9 +178,10 @@ type testingT interface {
 	Fatalf(format string, args ...any)
 }
 
-// generateAndSend walks n traces from topo into an OTLP exporter pointed at the
-// collector and returns the set of span identities sent. Identities come from a
-// second in-memory exporter so the test knows exactly what it pushed.
+// generateAndSend emits n traces from topo into an OTLP exporter pointed at
+// the collector via the public GenerateTraces API and returns the set of span
+// identities sent. Identities come from a second in-memory exporter so the
+// test knows exactly what it pushed.
 func generateAndSend(t testingT, topo *Topology, endpoint string, n int, seed uint64) map[string]struct{} {
 	t.Helper()
 
@@ -201,16 +200,8 @@ func generateAndSend(t testingT, topo *Topology, endpoint string, n int, seed ui
 	)
 	defer func() { _ = tp.Shutdown(ctx) }()
 
-	for i := range n {
-		rng := rand.New(rand.NewPCG(seed+uint64(i), 0)) //nolint:gosec // not security-sensitive
-		engine := &Engine{
-			Topology: topo,
-			Tracers:  func(string) trace.Tracer { return tp.Tracer("github.com/andrewh/motel") },
-			Rng:      rng,
-		}
-		root := topo.Roots[rng.IntN(len(topo.Roots))]
-		var stats Stats
-		engine.walkTrace(ctx, root, nil, time.Now(), 0, nil, nil, &stats, new(int), DefaultMaxSpansPerTrace, false, false)
+	if _, err := GenerateTraces(ctx, topo, TracerProviderSource(tp), GenerateOptions{Traces: n, Seed: seed}); err != nil {
+		t.Fatalf("GenerateTraces: %v", err)
 	}
 	if err := tp.ForceFlush(ctx); err != nil {
 		t.Fatalf("ForceFlush: %v", err)


### PR DESCRIPTION
Add GenerateTraces, a public, exporter-agnostic API that emits N traces from a *Topology with a given seed and span limit through any caller-provided TracerProvider, plus TracerProviderSource to adapt a trace.TracerProvider into a TracerSource that names tracers after the service they emit for.

Generation is reproducible: trace i derives its RNG from Seed+i, the same derivation SampleTraces and the pipeline proof-of-concept already used, so a fixed seed replays the same root choices and span structure. A zero seed picks a random one and a zero span limit applies DefaultMaxSpansPerTrace, matching engine defaults. The span-link registry is initialised so topologies with links emit them, and cancelling the context stops generation early with partial stats.

Rework the pipeline-testing proof-of-concept (pipeline_test.go) to drive generation through GenerateTraces instead of the unexported walkTrace, as required by the acceptance criteria, and update the productionisation note in docs/research/collector-pipeline-testing.md to record that invariant tests can now live outside package synth.

Add unit coverage in generate_test.go that the API emits the expected spans into an in-memory exporter: span counts and instrumentation scopes, seed reproducibility, span-limit bounding, error cases (no roots, nil tracer source), zero traces, and context cancellation.