### PR TITLE
feat: add sampling trace integrity invariants (#74)

### DIFF
--- a/docs/how-to/test-sampling-integrity.md
+++ b/docs/how-to/test-sampling-integrity.md
@@ -1,0 +1,158 @@
+# Test Sampling Trace Integrity
+
+This guide shows how to verify that a sampling processor in an OpenTelemetry
+Collector pipeline never breaks trace structure — no orphaned spans, no
+partially kept traces, no unstable keep/drop decisions. The checks run as Go
+property tests that drive motel-generated traces through a real collector
+binary, using the harness described in the
+[collector pipeline testing design](../research/collector-pipeline-testing.md).
+
+## The invariants
+
+Tail-based and probabilistic sampling can break trace integrity in ways that
+depend on timing, batch boundaries, and trace shape — exactly the bugs that
+hand-written test traces miss. Three invariants pin the correct behaviour:
+
+- **Parent-child preservation.** If a child span is kept, its parent span is
+  also kept. A pipeline that keeps a child while dropping its parent produces
+  orphaned spans that render as broken traces in every backend.
+- **Trace completeness.** If any span from a trace is kept, all spans from
+  that trace are kept. Samplers that decide per trace — head samplers keyed on
+  the trace ID, and all tail samplers — must keep or drop traces whole.
+- **Sampling consistency.** Replaying the same trace through the same sampler
+  produces the same keep/drop decision. This holds for any deterministic
+  sampler, such as `probabilistic_sampler` in `hash_seed` mode.
+
+The invariants are implemented in `pkg/synth/pipeline_sampling_test.go` as
+`assertParentsKept`, `assertWholeTraces`, and `assertNoFabrication` (received
+spans must be a subset of sent spans), plus a replay test for consistency.
+motel generates the traces — varying depth, fan-out, and error mix — and
+[rapid](https://github.com/flyingmutant/rapid) shrinks any violation to the
+minimal trace shape that triggers it.
+
+## What you need
+
+- The motel repository (the checks are `go test` targets, not a CLI feature)
+- A collector binary: the reference `otelcol` build covers the head-sampling
+  tests; the tail-sampling test needs a build that includes the
+  `tail_sampling` processor, such as `otelcol-contrib`
+
+## 1. Point the tests at a collector
+
+The harness resolves the collector binary from `MOTEL_COLLECTOR_BIN`, falling
+back to `otelcol` on `PATH`. Tests skip when neither is present.
+
+```sh
+export MOTEL_COLLECTOR_BIN=/path/to/otelcol-contrib
+```
+
+## 2. Run the invariant tests
+
+```sh
+go test ./pkg/synth/ -run TestSampling -v
+```
+
+The suite contains:
+
+- **`TestSampling_TraceIntegrity`** — a fixed multi-service topology through a
+  50% head sampler: survivors are a subset of what was sent, no orphans, whole
+  traces only.
+- **`TestSampling_TraceIntegrityProperty`** — the same invariants for 100
+  rapid-generated topologies, reusing one collector.
+- **`TestSampling_DeterministicDecisions`** — replays a byte-identical span
+  set twice (a seeded ID generator fixes the trace and span IDs) and asserts
+  both runs keep exactly the same spans.
+- **`TestSampling_TailWholeTraces`** — trace completeness under
+  `tail_sampling`, where buffering bugs would surface as partially kept
+  traces. Skips unless the collector build advertises the processor.
+
+## Example collector configs
+
+The tests render these configs themselves (filling in ports and the sink URL),
+but the processor blocks are what you would deploy. The head-sampling tests
+use `probabilistic_sampler` pinned to `hash_seed` mode, which makes the
+decision a pure function of the trace ID — deterministic across runs and
+identical for every span of a trace:
+
+```yaml
+processors:
+  probabilistic_sampler:
+    sampling_percentage: 50
+    mode: hash_seed
+    hash_seed: 22
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [probabilistic_sampler]
+      exporters: [otlphttp]
+```
+
+The tail-sampling test buffers whole traces before deciding:
+
+```yaml
+processors:
+  tail_sampling:
+    decision_wait: 1s
+    policies:
+      - name: keep-half
+        type: probabilistic
+        probabilistic:
+          sampling_percentage: 50
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [tail_sampling]
+      exporters: [otlphttp]
+```
+
+## 3. Check your own sampling config
+
+`pipelinetest.Start` takes the collector config as a template, so a test for
+your production sampling policy is the existing test with a different
+processor block. Copy one of the pipeline constants from
+`pkg/synth/pipeline_sampling_test.go`, substitute your `tail_sampling`
+policies or sampler settings, and keep the assertions:
+
+```go
+sink, collector := startPipeline(t, myProductionPipeline)
+
+topo := loadTopology(t, passthroughTopology)
+sent := generateAndCapture(t, topo, collector.OTLPEndpoint, 40, 7, nil)
+spans := sink.WaitSettled(2*time.Second, 30*time.Second)
+received := receivedKeys(spans)
+
+assertNoFabrication(t, sentKeys(sent), received)
+assertParentsKept(t, spans)
+assertWholeTraces(t, sent, received)
+```
+
+Two details matter when adapting this:
+
+- **There is no exact span count to wait for.** A sampler drops spans, so the
+  sink cannot wait for "all spans arrived". `Sink.WaitSettled(idle, max)` is
+  the bounded "eventually received" assertion: it returns once no new span has
+  arrived for `idle`, capped at `max`.
+- **Choose `idle` longer than the pipeline's largest internal delay.** A tail
+  sampler is silent for `decision_wait` while traces sit in its buffer; an
+  `idle` shorter than that mistakes deciding for drained.
+
+Policies that key on trace properties rather than the trace ID — latency,
+status code, attributes — still satisfy all three invariants: the decision is
+made once per trace, so completeness and parent preservation follow, and the
+same trace always matches the same policies. Use a topology with a realistic
+mix of durations, error rates, and attributes (see
+[Test tail sampling policies](test-tail-sampling.md)) so every policy branch
+is exercised.
+
+## Further reading
+
+- [Collector pipeline testing design](../research/collector-pipeline-testing.md)
+  -- the harness architecture these checks build on
+- [Test tail sampling policies](test-tail-sampling.md) -- manually exploring
+  what a tail sampling config keeps, with a richer example topology
+- [Property testing in motel](../explanation/property-testing.md) -- rationale
+  and patterns for the rapid-based test suite

--- a/docs/research/collector-pipeline-testing.md
+++ b/docs/research/collector-pipeline-testing.md
@@ -178,10 +178,14 @@ tests and the harness can therefore live entirely outside `package synth`.
 
 ## What later issues build on
 
-- **Issue 74 (sampling trace integrity).** Invariants over trace completeness
-  under head and tail sampling — a sampled trace keeps all or none of its
-  spans; tail sampling preserves whole traces. `TestPipeline_SamplingDropsSpans`
-  is the first step.
+- **Issue 74 (sampling trace integrity).** Implemented in
+  `pkg/synth/pipeline_sampling_test.go`: parent-child preservation, trace
+  completeness, and deterministic keep/drop decisions under head sampling
+  (`probabilistic_sampler` in hash_seed mode) and tail sampling
+  (`tail_sampling`, skipped on collector builds without it). The bounded
+  "eventually received" assertion this needed is `Sink.WaitSettled` in the
+  shared harness. See [Test sampling trace
+  integrity](../how-to/test-sampling-integrity.md).
 - **Issue 75 (filtering and routing).** Needs a richer collector build (the
   reference binary lacks a routing connector) and invariants over which spans
   survive a filter and where routed spans land.
@@ -198,7 +202,9 @@ tests and the harness can therefore live entirely outside `package synth`.
 - Free-port allocation has an inherent time-of-check/time-of-use race between
   closing the probe listener and the collector binding the port. Acceptable for
   a test harness; a retry-on-bind-failure loop would remove it.
-- Conservation invariants wait until the sink reaches the expected span count.
-  Lossy or transforming pipelines have no such fixed point, so those tests wait
-  a bounded settle period instead. Later invariants should express "eventually
-  received within a bound" explicitly to stay deterministic.
+- Conservation invariants wait until the sink reaches the expected span count
+  (`Sink.WaitFor`). Lossy or transforming pipelines have no such fixed point,
+  so their tests use `Sink.WaitSettled`, which returns once no new span has
+  arrived for an idle window, bounded by a deadline. The idle window must
+  exceed the pipeline's largest internal delay (for example tail sampling's
+  `decision_wait`), or a deciding pipeline is mistaken for a drained one.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - docs/how-to/validate-collector-pipeline.md
       - docs/how-to/stress-test-collector.md
       - docs/how-to/test-tail-sampling.md
+      - docs/how-to/test-sampling-integrity.md
       - docs/how-to/test-ottl-transforms.md
       - docs/how-to/test-alert-thresholds.md
       - docs/how-to/test-backend-integration.md

--- a/pkg/pipelinetest/collector.go
+++ b/pkg/pipelinetest/collector.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -35,6 +36,23 @@ func CollectorBinary() (string, bool) {
 		return p, true
 	}
 	return "", false
+}
+
+// SupportsComponent reports whether the collector binary advertises the named
+// component (for example "tail_sampling") in its `components` output. It
+// returns false when no binary is available or the subcommand fails, so tests
+// can skip cleanly on collector builds that lack an optional component.
+func SupportsComponent(name string) bool {
+	bin, ok := CollectorBinary()
+	if !ok {
+		return false
+	}
+	out, err := exec.Command(bin, "components").Output() //nolint:gosec // binary path is operator-controlled
+	if err != nil {
+		return false
+	}
+	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
+	return re.Match(out)
 }
 
 // passthroughConfig is the default pipeline: OTLP in, OTLP out, no processors.

--- a/pkg/pipelinetest/sink.go
+++ b/pkg/pipelinetest/sink.go
@@ -15,11 +15,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"time"
 
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/proto"
 )
+
+// pollInterval is how often the wait helpers sample the sink's span count.
+const pollInterval = 20 * time.Millisecond
 
 // Sink is an in-process OTLP/HTTP trace receiver that records every span it
 // receives. A pipeline under test exports to Sink.URL; tests assert on the
@@ -98,6 +102,42 @@ func (s *Sink) Count() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.spans)
+}
+
+// WaitFor blocks until the sink holds at least want spans or timeout elapses,
+// and reports whether the count was reached. Use it when the pipeline
+// conserves spans, so an exact expected count exists.
+func (s *Sink) WaitFor(want int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for s.Count() < want {
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(pollInterval)
+	}
+	return true
+}
+
+// WaitSettled blocks until no new span has arrived for idle, or until max
+// elapses, then returns a snapshot of the spans received so far. It is the
+// bounded "eventually received" assertion for lossy or transforming
+// pipelines: a sampler drops spans, so there is no exact count to wait for,
+// and a pipeline that buffers (for example tail sampling's decision wait)
+// releases spans in bursts. Choose idle longer than the pipeline's largest
+// internal delay so a quiet period means the pipeline has drained, not that
+// it is still deciding.
+func (s *Sink) WaitSettled(idle, max time.Duration) []*tracepb.Span {
+	deadline := time.Now().Add(max)
+	last := s.Count()
+	lastChange := time.Now()
+	for time.Now().Before(deadline) && time.Since(lastChange) < idle {
+		time.Sleep(pollInterval)
+		if n := s.Count(); n != last {
+			last = n
+			lastChange = time.Now()
+		}
+	}
+	return s.Spans()
 }
 
 // Reset discards all received spans, readying the sink for reuse.

--- a/pkg/pipelinetest/sink_test.go
+++ b/pkg/pipelinetest/sink_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"testing"
+	"time"
 
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
@@ -55,5 +56,85 @@ func TestSink_CapturesExportedSpans(t *testing.T) {
 	sink.Reset()
 	if got := sink.Count(); got != 0 {
 		t.Fatalf("Count after Reset: got %d, want 0", got)
+	}
+}
+
+// postSpans exports count spans to the sink over OTLP/HTTP.
+func postSpans(t *testing.T, sink *Sink, count int) {
+	t.Helper()
+	spans := make([]*tracepb.Span, count)
+	for i := range count {
+		spans[i] = &tracepb.Span{
+			TraceId: bytes.Repeat([]byte{1}, 16),
+			SpanId:  append(bytes.Repeat([]byte{0}, 7), byte(i+1)),
+		}
+	}
+	req := &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{{
+			ScopeSpans: []*tracepb.ScopeSpans{{Spans: spans}},
+		}},
+	}
+	body, err := proto.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	resp, err := http.Post(sink.URL()+"/v1/traces", "application/x-protobuf", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+// TestSink_WaitFor checks the exact-count wait succeeds once enough spans
+// arrive and reports failure when the count is never reached.
+func TestSink_WaitFor(t *testing.T) {
+	sink := NewSink()
+	defer sink.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		time.Sleep(50 * time.Millisecond)
+		postSpans(t, sink, 3)
+	}()
+
+	if !sink.WaitFor(3, 5*time.Second) {
+		t.Fatalf("WaitFor(3): count %d never reached 3", sink.Count())
+	}
+	<-done
+
+	if sink.WaitFor(4, 100*time.Millisecond) {
+		t.Fatal("WaitFor(4) succeeded with only 3 spans received")
+	}
+}
+
+// TestSink_WaitSettled checks the bounded "eventually received" wait: it
+// returns everything that arrived once the sink goes quiet, and it returns
+// promptly (bounded by max, not hanging) when nothing arrives at all.
+func TestSink_WaitSettled(t *testing.T) {
+	sink := NewSink()
+	defer sink.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		postSpans(t, sink, 2)
+		time.Sleep(50 * time.Millisecond)
+		postSpans(t, sink, 2)
+	}()
+
+	spans := sink.WaitSettled(500*time.Millisecond, 10*time.Second)
+	<-done
+	if len(spans) != 4 {
+		t.Fatalf("WaitSettled: got %d spans, want 4", len(spans))
+	}
+
+	sink.Reset()
+	start := time.Now()
+	if spans := sink.WaitSettled(100*time.Millisecond, time.Second); len(spans) != 0 {
+		t.Fatalf("WaitSettled on idle sink: got %d spans, want 0", len(spans))
+	}
+	if elapsed := time.Since(start); elapsed > time.Second+500*time.Millisecond {
+		t.Fatalf("WaitSettled did not respect max: took %v", elapsed)
 	}
 }

--- a/pkg/synth/pipeline_sampling_test.go
+++ b/pkg/synth/pipeline_sampling_test.go
@@ -1,0 +1,445 @@
+package synth
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/andrewh/motel/pkg/pipelinetest"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"pgregory.net/rapid"
+)
+
+// Sampling trace integrity invariants (issue 74). Sampling processors decide
+// which traces survive a pipeline; these tests assert the decisions never
+// break trace structure:
+//
+//   - Parent-child preservation: if a child span is kept, its parent is kept
+//     (no orphaned spans) — assertParentsKept.
+//   - Trace completeness: if any span from a trace is kept, all spans from
+//     that trace are kept — assertWholeTraces.
+//   - Sampling consistency: the same trace replayed through the same sampler
+//     gets the same keep/drop decision — TestSampling_DeterministicDecisions.
+//
+// Like the round-trip tests in pipeline_test.go, they drive a real collector
+// subprocess through pkg/pipelinetest and skip when no binary is available.
+
+const (
+	// samplerSettleIdle is how long the sink must stay quiet before a head
+	// sampler's output is considered complete. The sampler decides
+	// synchronously in the receiver path, so only exporter queue drain
+	// remains once generation returns.
+	samplerSettleIdle = 500 * time.Millisecond
+
+	// propertySettleIdle is the per-draw settle window for the rapid
+	// property, kept short because it is paid on every draw.
+	propertySettleIdle = 300 * time.Millisecond
+
+	// tailSettleIdle must exceed the tail sampler's decision_wait: the
+	// pipeline is silent while traces sit in the decision buffer, and a
+	// shorter idle window would mistake that silence for a drained pipeline.
+	tailSettleIdle = 2 * time.Second
+
+	settleMax = 30 * time.Second
+)
+
+// headSamplerPipeline samples 50% of traces at the head. hash_seed mode makes
+// the keep/drop decision a pure function of the trace ID, so it is
+// deterministic across runs and identical for every span of a trace.
+const headSamplerPipeline = `receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 127.0.0.1:{{.OTLPHTTPPort}}
+processors:
+  probabilistic_sampler:
+    sampling_percentage: 50
+    mode: hash_seed
+    hash_seed: 22
+exporters:
+  otlphttp:
+    endpoint: {{.SinkURL}}
+    compression: none
+extensions:
+  health_check:
+    endpoint: 127.0.0.1:{{.HealthPort}}
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [probabilistic_sampler]
+      exporters: [otlphttp]
+  telemetry:
+    metrics:
+      level: none
+    logs:
+      level: warn
+`
+
+// tailSamplingPipeline buffers whole traces for decision_wait, then keeps 50%
+// of them. The tail_sampling processor ships in otelcol-contrib, not the
+// reference otelcol build, so the test using it checks SupportsComponent.
+const tailSamplingPipeline = `receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 127.0.0.1:{{.OTLPHTTPPort}}
+processors:
+  tail_sampling:
+    decision_wait: 1s
+    policies:
+      - name: keep-half
+        type: probabilistic
+        probabilistic:
+          sampling_percentage: 50
+exporters:
+  otlphttp:
+    endpoint: {{.SinkURL}}
+    compression: none
+extensions:
+  health_check:
+    endpoint: 127.0.0.1:{{.HealthPort}}
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [tail_sampling]
+      exporters: [otlphttp]
+  telemetry:
+    metrics:
+      level: none
+    logs:
+      level: warn
+`
+
+// TestSampling_TraceIntegrity drives a fixed multi-service topology through a
+// 50% head sampler and asserts all structural invariants at once: the
+// survivors are a subset of what was sent, no kept span is orphaned, and
+// every kept trace is complete.
+func TestSampling_TraceIntegrity(t *testing.T) {
+	sink, collector := startPipeline(t, headSamplerPipeline)
+
+	topo := loadTopology(t, passthroughTopology)
+	sent := generateAndCapture(t, topo, collector.OTLPEndpoint, 40, 7, nil)
+	spans := sink.WaitSettled(samplerSettleIdle, settleMax)
+	received := receivedKeys(spans)
+
+	if len(received) == 0 || len(received) >= len(sent) {
+		t.Fatalf("expected partial sampling: sent %d, received %d", len(sent), len(received))
+	}
+	assertNoFabrication(t, sentKeys(sent), received)
+	assertParentsKept(t, spans)
+	assertWholeTraces(t, sent, received)
+}
+
+// TestSampling_TraceIntegrityProperty asserts the same invariants for any
+// generated topology: whatever the trace shape — depth, fan-out, error mix —
+// the sampler must keep or drop traces whole. One collector is reused across
+// all draws.
+func TestSampling_TraceIntegrityProperty(t *testing.T) {
+	sink, collector := startPipeline(t, headSamplerPipeline)
+
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := genSimpleConfig(t)
+		topo, err := BuildTopology(cfg)
+		if err != nil {
+			t.Fatalf("BuildTopology: %v", err)
+		}
+		if len(topo.Roots) == 0 {
+			t.Skip("no root operations")
+		}
+
+		sink.Reset()
+		seed := rapid.Uint64().Draw(t, "seed")
+		sent := generateAndCapture(t, topo, collector.OTLPEndpoint, 5, seed, nil)
+		if len(sent) == 0 {
+			t.Skip("no spans generated")
+		}
+		spans := sink.WaitSettled(propertySettleIdle, settleMax)
+		received := receivedKeys(spans)
+
+		assertNoFabrication(t, sentKeys(sent), received)
+		assertParentsKept(t, spans)
+		assertWholeTraces(t, sent, received)
+	})
+}
+
+// TestSampling_DeterministicDecisions replays the identical span set through
+// the same sampler twice and asserts the keep/drop decisions match. A seeded
+// ID generator makes both runs use the same trace and span IDs, which is what
+// a hash_seed sampler decides on.
+func TestSampling_DeterministicDecisions(t *testing.T) {
+	sink, collector := startPipeline(t, headSamplerPipeline)
+
+	topo := loadTopology(t, passthroughTopology)
+	const genSeed, idSeed = 7, 99
+
+	first := generateAndCapture(t, topo, collector.OTLPEndpoint, 30, genSeed, newSeededIDGenerator(idSeed))
+	firstKept := receivedKeys(sink.WaitSettled(samplerSettleIdle, settleMax))
+
+	sink.Reset()
+	second := generateAndCapture(t, topo, collector.OTLPEndpoint, 30, genSeed, newSeededIDGenerator(idSeed))
+	secondKept := receivedKeys(sink.WaitSettled(samplerSettleIdle, settleMax))
+
+	// Guard the premise: both runs must have replayed the same spans.
+	assertSameSpans(t, sentKeys(first), sentKeys(second))
+
+	if len(firstKept) == 0 || len(firstKept) >= len(first) {
+		t.Fatalf("expected partial sampling: sent %d, kept %d", len(first), len(firstKept))
+	}
+	if len(firstKept) != len(secondKept) {
+		t.Fatalf("keep set size changed between identical runs: %d then %d", len(firstKept), len(secondKept))
+	}
+	for key := range firstKept {
+		if _, ok := secondKept[key]; !ok {
+			t.Fatalf("span %s kept in first run but dropped in second", key)
+		}
+	}
+}
+
+// TestSampling_TailWholeTraces asserts trace completeness where it actually
+// bites: a tail sampler buffers spans and decides per trace, so a bug in its
+// buffering (evicting part of a trace, deciding before all spans arrive)
+// shows up as a partially kept trace or an orphaned span.
+func TestSampling_TailWholeTraces(t *testing.T) {
+	if _, ok := pipelinetest.CollectorBinary(); !ok {
+		t.Skipf("no collector binary (set %s or install otelcol)", pipelinetest.BinaryEnv)
+	}
+	if !pipelinetest.SupportsComponent("tail_sampling") {
+		t.Skip("collector build lacks the tail_sampling processor (use otelcol-contrib)")
+	}
+	sink, collector := startPipeline(t, tailSamplingPipeline)
+
+	topo := loadTopology(t, passthroughTopology)
+	sent := generateAndCapture(t, topo, collector.OTLPEndpoint, 40, 7, nil)
+	spans := sink.WaitSettled(tailSettleIdle, settleMax)
+	received := receivedKeys(spans)
+
+	if len(received) == 0 || len(received) >= len(sent) {
+		t.Fatalf("expected partial sampling: sent %d, received %d", len(sent), len(received))
+	}
+	assertNoFabrication(t, sentKeys(sent), received)
+	assertParentsKept(t, spans)
+	assertWholeTraces(t, sent, received)
+}
+
+// recordingT captures Fatalf calls so the invariant helpers can be tested
+// against data that must fail them. Unlike testing.T, it does not stop the
+// caller, so helpers may record several failures; only the first matters.
+type recordingT struct {
+	failure string
+}
+
+func (r *recordingT) Helper() {}
+
+func (r *recordingT) Fatalf(format string, args ...any) {
+	if r.failure == "" {
+		r.failure = fmt.Sprintf(format, args...)
+	}
+}
+
+// TestSamplingInvariantHelpers feeds hand-crafted violations to each invariant
+// check and confirms it trips, then confirms clean data passes. A correct
+// collector never exercises the failure paths, so this is the only always-on
+// coverage they get; it needs no collector binary.
+func TestSamplingInvariantHelpers(t *testing.T) {
+	traceID := bytes16(1)
+	root := pbSpan(traceID, 1, 0)
+	child := pbSpan(traceID, 2, 1)
+	grandchild := pbSpan(traceID, 3, 2)
+
+	t.Run("orphan detected", func(t *testing.T) {
+		rec := &recordingT{}
+		assertParentsKept(rec, []*tracepb.Span{root, grandchild})
+		if rec.failure == "" {
+			t.Fatal("assertParentsKept passed a span whose parent was dropped")
+		}
+	})
+
+	t.Run("complete lineage passes", func(t *testing.T) {
+		rec := &recordingT{}
+		assertParentsKept(rec, []*tracepb.Span{root, child, grandchild})
+		if rec.failure != "" {
+			t.Fatalf("assertParentsKept failed complete lineage: %s", rec.failure)
+		}
+	})
+
+	sentStubs := []tracetest.SpanStub{stub(traceID, 1), stub(traceID, 2)}
+
+	t.Run("partial trace detected", func(t *testing.T) {
+		rec := &recordingT{}
+		assertWholeTraces(rec, sentStubs, receivedKeys([]*tracepb.Span{root}))
+		if rec.failure == "" {
+			t.Fatal("assertWholeTraces passed a partially kept trace")
+		}
+	})
+
+	t.Run("whole and dropped traces pass", func(t *testing.T) {
+		rec := &recordingT{}
+		assertWholeTraces(rec, sentStubs, receivedKeys([]*tracepb.Span{root, child}))
+		assertWholeTraces(rec, sentStubs, receivedKeys(nil))
+		if rec.failure != "" {
+			t.Fatalf("assertWholeTraces failed valid sampling: %s", rec.failure)
+		}
+	})
+
+	t.Run("fabricated span detected", func(t *testing.T) {
+		rec := &recordingT{}
+		assertNoFabrication(rec, receivedKeys([]*tracepb.Span{root}), receivedKeys([]*tracepb.Span{root, child}))
+		if rec.failure == "" {
+			t.Fatal("assertNoFabrication passed a span that was never sent")
+		}
+	})
+}
+
+// bytes16 builds a trace ID whose last byte is b.
+func bytes16(b byte) [16]byte {
+	var id [16]byte
+	id[15] = b
+	return id
+}
+
+// pbSpan builds an OTLP span with small-integer span and parent IDs; a parent
+// of 0 means a root span.
+func pbSpan(traceID [16]byte, spanID, parentID byte) *tracepb.Span {
+	s := &tracepb.Span{
+		TraceId: traceID[:],
+		SpanId:  []byte{0, 0, 0, 0, 0, 0, 0, spanID},
+	}
+	if parentID != 0 {
+		s.ParentSpanId = []byte{0, 0, 0, 0, 0, 0, 0, parentID}
+	}
+	return s
+}
+
+// stub builds a sent-span stub matching pbSpan's identity scheme.
+func stub(traceID [16]byte, spanID byte) tracetest.SpanStub {
+	return tracetest.SpanStub{
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: traceID,
+			SpanID:  [8]byte{0, 0, 0, 0, 0, 0, 0, spanID},
+		}),
+	}
+}
+
+// assertNoFabrication checks every received span was actually sent: a
+// sampler may only drop spans, never invent or duplicate identities.
+func assertNoFabrication(t testingT, sent, received map[string]struct{}) {
+	t.Helper()
+
+	for key := range received {
+		if _, ok := sent[key]; !ok {
+			t.Fatalf("received span %s that was never sent", key)
+		}
+	}
+}
+
+// assertParentsKept checks parent-child preservation: every received span
+// with a parent has that parent in the received set too. A root span has a
+// zero parent ID and is exempt.
+func assertParentsKept(t testingT, received []*tracepb.Span) {
+	t.Helper()
+
+	keys := receivedKeys(received)
+	for _, s := range received {
+		parent := s.GetParentSpanId()
+		if !validID(parent) {
+			continue
+		}
+		parentKey := spanKey(s.GetTraceId(), parent)
+		if _, ok := keys[parentKey]; !ok {
+			t.Fatalf("orphaned span: %s was kept but its parent %s was dropped",
+				spanKey(s.GetTraceId(), s.GetSpanId()), parentKey)
+		}
+	}
+}
+
+// assertWholeTraces checks trace completeness: for every trace with at least
+// one received span, every span sent for that trace was received.
+func assertWholeTraces(t testingT, sent []tracetest.SpanStub, received map[string]struct{}) {
+	t.Helper()
+
+	sentByTrace := make(map[string][]string)
+	for _, s := range sent {
+		tid := s.SpanContext.TraceID()
+		sid := s.SpanContext.SpanID()
+		key := spanKey(tid[:], sid[:])
+		sentByTrace[hex.EncodeToString(tid[:])] = append(sentByTrace[hex.EncodeToString(tid[:])], key)
+	}
+
+	keptTraces := make(map[string]struct{})
+	for key := range received {
+		tid, _, _ := strings.Cut(key, ":")
+		keptTraces[tid] = struct{}{}
+	}
+
+	for tid := range keptTraces {
+		for _, key := range sentByTrace[tid] {
+			if _, ok := received[key]; !ok {
+				t.Fatalf("partially sampled trace %s: span %s was dropped while other spans of the trace were kept", tid, key)
+			}
+		}
+	}
+}
+
+// validID reports whether an ID is present and non-zero. OTLP encodes a
+// missing parent as an empty or all-zero span ID.
+func validID(id []byte) bool {
+	for _, b := range id {
+		if b != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// seededIDGenerator is a deterministic replacement for the SDK's random
+// trace/span ID generator. Two generators built from the same seed hand out
+// the same ID sequence, so two generation runs with the same topology seed
+// produce byte-identical span identities — the precondition for testing
+// sampling consistency.
+type seededIDGenerator struct {
+	mu  sync.Mutex
+	rng *rand.Rand
+}
+
+func newSeededIDGenerator(seed uint64) sdktrace.IDGenerator {
+	return &seededIDGenerator{rng: rand.New(rand.NewPCG(seed, 0))} //nolint:gosec // not security-sensitive
+}
+
+func (g *seededIDGenerator) NewIDs(_ context.Context) (trace.TraceID, trace.SpanID) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	var tid trace.TraceID
+	for !tid.IsValid() {
+		binary.BigEndian.PutUint64(tid[:8], g.rng.Uint64())
+		binary.BigEndian.PutUint64(tid[8:], g.rng.Uint64())
+	}
+	return tid, g.newSpanIDLocked()
+}
+
+func (g *seededIDGenerator) NewSpanID(_ context.Context, _ trace.TraceID) trace.SpanID {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.newSpanIDLocked()
+}
+
+func (g *seededIDGenerator) newSpanIDLocked() trace.SpanID {
+	var sid trace.SpanID
+	for !sid.IsValid() {
+		binary.BigEndian.PutUint64(sid[:], g.rng.Uint64())
+	}
+	return sid
+}

--- a/pkg/synth/pipeline_test.go
+++ b/pkg/synth/pipeline_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"pgregory.net/rapid"
 )
 
@@ -128,21 +129,13 @@ func TestPipeline_SamplingDropsSpans(t *testing.T) {
 	sent := generateAndSend(t, topo, collector.OTLPEndpoint, 40, 7)
 
 	// The sampler drops whole traces, so the sent count is never reached.
-	// Let the pipeline settle, then snapshot what survived.
-	time.Sleep(2 * time.Second)
-	received := make(map[string]struct{})
-	for _, s := range sink.Spans() {
-		received[spanKey(s.GetTraceId(), s.GetSpanId())] = struct{}{}
-	}
+	// Wait for the pipeline to settle, then snapshot what survived.
+	received := receivedKeys(sink.WaitSettled(time.Second, 10*time.Second))
 
 	if len(received) == 0 || len(received) >= len(sent) {
 		t.Fatalf("expected partial sampling: sent %d, received %d", len(sent), len(received))
 	}
-	for key := range received {
-		if _, ok := sent[key]; !ok {
-			t.Fatalf("received span %s that was never sent", key)
-		}
-	}
+	assertNoFabrication(t, sent, received)
 }
 
 // startPipeline starts a sink and a collector wired to it, registering cleanup.
@@ -180,9 +173,19 @@ type testingT interface {
 
 // generateAndSend emits n traces from topo into an OTLP exporter pointed at
 // the collector via the public GenerateTraces API and returns the set of span
-// identities sent. Identities come from a second in-memory exporter so the
-// test knows exactly what it pushed.
+// identities sent.
 func generateAndSend(t testingT, topo *Topology, endpoint string, n int, seed uint64) map[string]struct{} {
+	t.Helper()
+	return sentKeys(generateAndCapture(t, topo, endpoint, n, seed, nil))
+}
+
+// generateAndCapture emits n traces from topo into an OTLP exporter pointed at
+// the collector via the public GenerateTraces API and returns the spans sent.
+// The spans come from a second in-memory exporter attached to the same
+// TracerProvider, so the test knows exactly what it pushed, including parent
+// relationships. A non-nil idGen overrides the SDK's random trace/span ID
+// generator, letting tests replay the exact same span identities.
+func generateAndCapture(t testingT, topo *Topology, endpoint string, n int, seed uint64, idGen sdktrace.IDGenerator) []tracetest.SpanStub {
 	t.Helper()
 
 	ctx := context.Background()
@@ -194,10 +197,14 @@ func generateAndSend(t testingT, topo *Topology, endpoint string, n int, seed ui
 		t.Fatalf("otlptracehttp.New: %v", err)
 	}
 	captured := tracetest.NewInMemoryExporter()
-	tp := sdktrace.NewTracerProvider(
+	opts := []sdktrace.TracerProviderOption{
 		sdktrace.WithSyncer(otlp),
 		sdktrace.WithSyncer(captured),
-	)
+	}
+	if idGen != nil {
+		opts = append(opts, sdktrace.WithIDGenerator(idGen))
+	}
+	tp := sdktrace.NewTracerProvider(opts...)
 	defer func() { _ = tp.Shutdown(ctx) }()
 
 	if _, err := GenerateTraces(ctx, topo, TracerProviderSource(tp), GenerateOptions{Traces: n, Seed: seed}); err != nil {
@@ -207,8 +214,13 @@ func generateAndSend(t testingT, topo *Topology, endpoint string, n int, seed ui
 		t.Fatalf("ForceFlush: %v", err)
 	}
 
-	sent := make(map[string]struct{})
-	for _, s := range captured.GetSpans() {
+	return captured.GetSpans()
+}
+
+// sentKeys reduces captured spans to their identity set.
+func sentKeys(spans []tracetest.SpanStub) map[string]struct{} {
+	sent := make(map[string]struct{}, len(spans))
+	for _, s := range spans {
 		tid := s.SpanContext.TraceID()
 		sid := s.SpanContext.SpanID()
 		sent[spanKey(tid[:], sid[:])] = struct{}{}
@@ -216,21 +228,22 @@ func generateAndSend(t testingT, topo *Topology, endpoint string, n int, seed ui
 	return sent
 }
 
-// waitForSpans polls the sink until it holds at least want spans or a timeout
+// receivedKeys reduces the sink's captured spans to their identity set.
+func receivedKeys(spans []*tracepb.Span) map[string]struct{} {
+	received := make(map[string]struct{}, len(spans))
+	for _, s := range spans {
+		received[spanKey(s.GetTraceId(), s.GetSpanId())] = struct{}{}
+	}
+	return received
+}
+
+// waitForSpans blocks until the sink holds at least want spans or a timeout
 // elapses, then returns the identities of everything received.
 func waitForSpans(t testingT, sink *pipelinetest.Sink, want int) map[string]struct{} {
 	t.Helper()
 
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) && sink.Count() < want {
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	received := make(map[string]struct{})
-	for _, s := range sink.Spans() {
-		received[spanKey(s.GetTraceId(), s.GetSpanId())] = struct{}{}
-	}
-	return received
+	sink.WaitFor(want, 10*time.Second)
+	return receivedKeys(sink.Spans())
 }
 
 // assertSameSpans checks that the received identities are exactly the sent set.


### PR DESCRIPTION
Implement the three sampling invariants from issue 74 against the
pipeline-testing harness from issue 73, driving motel-generated traces
through a real collector subprocess:

- Parent-child preservation: a kept span's parent is also kept
  (assertParentsKept, checked over the sink's received spans).
- Trace completeness: a trace is kept whole or dropped whole
  (assertWholeTraces, comparing received spans against the sent set
  grouped by trace ID).
- Sampling consistency: replaying a byte-identical span set through the
  same sampler yields identical keep/drop decisions
  (TestSampling_DeterministicDecisions, using a seeded IDGenerator so
  both runs share trace/span IDs).

Tests in pkg/synth/pipeline_sampling_test.go cover a fixed topology and
a rapid property over generated topologies through a 50% hash_seed
probabilistic_sampler, plus trace completeness under tail_sampling
(skipped when the collector build lacks the processor). An always-on
unit test feeds hand-crafted violations to each invariant helper to
prove the failure paths fire without needing a collector.

Harness additions in pkg/pipelinetest:

- Sink.WaitSettled(idle, max): the bounded "eventually received"
  assertion flagged in the issue — lossy pipelines have no exact span
  count to wait for, so settle on an idle window instead. Used to
  replace the fixed sleep in TestPipeline_SamplingDropsSpans.
- Sink.WaitFor(want, timeout): the exact-count wait, extracted from the
  round-trip tests.
- SupportsComponent(name): probes the binary's `components` output so
  tests skip cleanly on builds without an optional processor.

pipeline_test.go's generateAndSend is refactored into
generateAndCapture, which returns the sent span stubs (parent links
included) and accepts an optional ID generator.

Documentation: new how-to (docs/how-to/test-sampling-integrity.md) with
the example collector configs the checks run, added to the mkdocs nav;
the design doc's issue-74 and settle-period notes updated to point at
the implementation.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017mb8JHoaMXNfA6f7sncP4A