### PR TITLE
refactor: harden and generalise sampling integrity harness

### DIFF
--- a/docs/how-to/test-sampling-integrity.md
+++ b/docs/how-to/test-sampling-integrity.md
@@ -23,12 +23,13 @@ hand-written test traces miss. Three invariants pin the correct behaviour:
   produces the same keep/drop decision. This holds for any deterministic
   sampler, such as `probabilistic_sampler` in `hash_seed` mode.
 
-The invariants are implemented in `pkg/synth/pipeline_sampling_test.go` as
-`assertParentsKept`, `assertWholeTraces`, and `assertNoFabrication` (received
-spans must be a subset of sent spans), plus a replay test for consistency.
-motel generates the traces — varying depth, fan-out, and error mix — and
-[rapid](https://github.com/flyingmutant/rapid) shrinks any violation to the
-minimal trace shape that triggers it.
+The invariants are exported from `pkg/pipelinetest` as `CheckParentsKept`,
+`CheckWholeTraces`, and `CheckNoFabrication` (received spans must be a subset of
+sent spans), so any test — ours or yours — can assert them over a sink's output;
+`pkg/synth/pipeline_sampling_test.go` drives them against a real collector, plus
+a replay test for consistency. motel generates the traces — varying depth,
+fan-out, and error mix — and [rapid](https://github.com/flyingmutant/rapid)
+shrinks any violation to the minimal trace shape that triggers it.
 
 ## What you need
 
@@ -68,11 +69,12 @@ The suite contains:
 
 ## Example collector configs
 
-The tests render these configs themselves (filling in ports and the sink URL),
-but the processor blocks are what you would deploy. The head-sampling tests
-use `probabilistic_sampler` pinned to `hash_seed` mode, which makes the
-decision a pure function of the trace ID — deterministic across runs and
-identical for every span of a trace:
+The tests build these configs with `pipelinetest.TracesConfig`, which wraps a
+processors block in the shared receiver/exporter/health-check skeleton and fills
+in ports and the sink URL. The processor blocks below are what you would deploy.
+The head-sampling tests use `probabilistic_sampler` pinned to `hash_seed` mode,
+which makes the decision a pure function of the trace ID — deterministic across
+runs and identical for every span of a trace:
 
 ```yaml
 processors:
@@ -111,23 +113,64 @@ service:
 
 ## 3. Check your own sampling config
 
-`pipelinetest.Start` takes the collector config as a template, so a test for
-your production sampling policy is the existing test with a different
-processor block. Copy one of the pipeline constants from
-`pkg/synth/pipeline_sampling_test.go`, substitute your `tail_sampling`
-policies or sampler settings, and keep the assertions:
+The harness and the invariant checks are exported from `pkg/pipelinetest`, so a
+test for your own sampling policy composes them directly — no need to fork the
+motel test files. `pipelinetest.TracesConfig` builds a single-pipeline config
+from a processors block; `pipelinetest.Start` runs a collector against it and
+points it at a `Sink`; the `Check*` functions assert the invariants over the
+sink's output against a `pipelinetest.Sent` set you build while generating:
 
 ```go
-sink, collector := startPipeline(t, myProductionPipeline)
+sink := pipelinetest.NewSink()
+defer sink.Close()
 
-topo := loadTopology(t, passthroughTopology)
-sent := generateAndCapture(t, topo, collector.OTLPEndpoint, 40, 7, nil)
-spans := sink.WaitSettled(2*time.Second, 30*time.Second)
-received := receivedKeys(spans)
+// Your sampling policy is the only thing that changes.
+config := pipelinetest.TracesConfig(`  tail_sampling:
+    decision_wait: 5s
+    policies:
+      - name: errors
+        type: status_code
+        status_code:
+          status_codes: [ERROR]
+`, "tail_sampling")
 
-assertNoFabrication(t, sentKeys(sent), received)
-assertParentsKept(t, spans)
-assertWholeTraces(t, sent, received)
+collector, err := pipelinetest.Start(sink, config)
+if err != nil {
+	t.Fatal(err)
+}
+defer func() { _ = collector.Stop() }()
+
+// Generate traces through an OTLP exporter aimed at the collector, and record
+// their identities from a second in-memory exporter on the same provider.
+captured := tracetest.NewInMemoryExporter()
+otlp, _ := otlptracehttp.New(ctx,
+	otlptracehttp.WithEndpoint(collector.OTLPEndpoint),
+	otlptracehttp.WithInsecure())
+tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(otlp), sdktrace.WithSyncer(captured))
+if _, err := synth.GenerateTraces(ctx, topo, synth.TracerProviderSource(tp),
+	synth.GenerateOptions{Traces: 40, Seed: 7}); err != nil {
+	t.Fatal(err)
+}
+_ = tp.ForceFlush(ctx)
+
+sent := pipelinetest.NewSent()
+for _, s := range captured.GetSpans() {
+	tid, sid := s.SpanContext.TraceID(), s.SpanContext.SpanID()
+	sent.Add(tid[:], sid[:])
+}
+
+// A sampler drops spans, so wait for the pipeline to settle rather than for a
+// fixed count, then assert the invariants over the survivors.
+spans := sink.WaitSettled(6*time.Second, 30*time.Second)
+for _, check := range []error{
+	pipelinetest.CheckNoFabrication(sent, spans),
+	pipelinetest.CheckParentsKept(spans),
+	pipelinetest.CheckWholeTraces(sent, spans),
+} {
+	if check != nil {
+		t.Fatal(check)
+	}
+}
 ```
 
 Two details matter when adapting this:
@@ -137,8 +180,10 @@ Two details matter when adapting this:
   the bounded "eventually received" assertion: it returns once no new span has
   arrived for `idle`, capped at `max`.
 - **Choose `idle` longer than the pipeline's largest internal delay.** A tail
-  sampler is silent for `decision_wait` while traces sit in its buffer; an
-  `idle` shorter than that mistakes deciding for drained.
+  sampler is silent while traces sit in its buffer for `decision_wait` plus its
+  internal policy-evaluation tick (~1s); an `idle` shorter than that total
+  mistakes deciding for drained. Leave headroom for scheduling jitter — the
+  suite waits 4s against a 1s `decision_wait`.
 
 Policies that key on trace properties rather than the trace ID — latency,
 status code, attributes — still satisfy all three invariants: the decision is

--- a/pkg/pipelinetest/collector.go
+++ b/pkg/pipelinetest/collector.go
@@ -65,13 +65,15 @@ var (
 )
 
 // componentNames returns the set of component names the binary advertises,
-// unioned across every component kind, caching the result per binary path.
+// unioned across every component kind, caching the result per binary path. The
+// returned set is shared and must not be mutated. The collector subprocess runs
+// without the lock held, so a slow probe does not block other callers.
 func componentNames(bin string) (map[string]struct{}, error) {
 	componentsMu.Lock()
-	defer componentsMu.Unlock()
-
-	if set, ok := componentsCache[bin]; ok {
-		return set, nil
+	cached, ok := componentsCache[bin]
+	componentsMu.Unlock()
+	if ok {
+		return cached, nil
 	}
 
 	out, err := exec.Command(bin, "components").Output() //nolint:gosec // binary path is operator-controlled
@@ -101,7 +103,10 @@ func componentNames(bin string) (map[string]struct{}, error) {
 			}
 		}
 	}
+
+	componentsMu.Lock()
 	componentsCache[bin] = set
+	componentsMu.Unlock()
 	return set, nil
 }
 

--- a/pkg/pipelinetest/collector.go
+++ b/pkg/pipelinetest/collector.go
@@ -8,10 +8,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // BinaryEnv names the environment variable that overrides the collector
@@ -38,32 +40,81 @@ func CollectorBinary() (string, bool) {
 	return "", false
 }
 
-// SupportsComponent reports whether the collector binary advertises the named
-// component (for example "tail_sampling") in its `components` output. It
-// returns false when no binary is available or the subcommand fails, so tests
-// can skip cleanly on collector builds that lack an optional component.
+// SupportsComponent reports whether the collector binary advertises a
+// component with the given name in its `components` output (for example
+// "tail_sampling"), so tests can skip cleanly on builds that lack an optional
+// component. It parses the output structurally and matches component names
+// only, not module paths, and returns false when no binary is available or the
+// subcommand fails. The component set is resolved once per binary path.
 func SupportsComponent(name string) bool {
 	bin, ok := CollectorBinary()
 	if !ok {
 		return false
 	}
-	out, err := exec.Command(bin, "components").Output() //nolint:gosec // binary path is operator-controlled
+	names, err := componentNames(bin)
 	if err != nil {
 		return false
 	}
-	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
-	return re.Match(out)
+	_, ok = names[name]
+	return ok
 }
 
-// passthroughConfig is the default pipeline: OTLP in, OTLP out, no processors.
-// It exercises the harness end to end without changing the signal, so the only
-// invariant it can break is span loss.
-const passthroughConfig = `receivers:
+var (
+	componentsMu    sync.Mutex
+	componentsCache = map[string]map[string]struct{}{}
+)
+
+// componentNames returns the set of component names the binary advertises,
+// unioned across every component kind, caching the result per binary path.
+func componentNames(bin string) (map[string]struct{}, error) {
+	componentsMu.Lock()
+	defer componentsMu.Unlock()
+
+	if set, ok := componentsCache[bin]; ok {
+		return set, nil
+	}
+
+	out, err := exec.Command(bin, "components").Output() //nolint:gosec // binary path is operator-controlled
+	if err != nil {
+		return nil, err
+	}
+
+	type entry struct {
+		Name string `yaml:"name"`
+	}
+	var doc struct {
+		Receivers  []entry `yaml:"receivers"`
+		Processors []entry `yaml:"processors"`
+		Exporters  []entry `yaml:"exporters"`
+		Connectors []entry `yaml:"connectors"`
+		Extensions []entry `yaml:"extensions"`
+	}
+	if err := yaml.Unmarshal(out, &doc); err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]struct{})
+	for _, kind := range [][]entry{doc.Receivers, doc.Processors, doc.Exporters, doc.Connectors, doc.Extensions} {
+		for _, e := range kind {
+			if e.Name != "" {
+				set[e.Name] = struct{}{}
+			}
+		}
+	}
+	componentsCache[bin] = set
+	return set, nil
+}
+
+// tracesConfigTemplate is the shared skeleton for a single-traces-pipeline
+// collector config: OTLP in, OTLP out, a health check. TracesConfig injects
+// the processor stage into the {{.ProcessorsBlock}} and {{.ProcessorsList}}
+// slots; Start fills in the remaining connection fields.
+const tracesConfigTemplate = `receivers:
   otlp:
     protocols:
       http:
         endpoint: 127.0.0.1:{{.OTLPHTTPPort}}
-exporters:
+{{.ProcessorsBlock}}exporters:
   otlphttp:
     endpoint: {{.SinkURL}}
     compression: none
@@ -75,13 +126,39 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlphttp]
+{{.ProcessorsList}}      exporters: [otlphttp]
   telemetry:
     metrics:
       level: none
     logs:
       level: warn
 `
+
+// TracesConfig renders a collector config for a single traces pipeline whose
+// processor stage is defs and names. defs is the YAML body of the top-level
+// `processors:` map, indented two spaces as it appears under that key (empty
+// for a pass-through pipeline); names are the processors the pipeline
+// references, in order. The result is a text/template Start renders with the
+// connection details (OTLPHTTPPort, HealthPort, SinkURL), so it is suitable to
+// pass straight to Start. Callers that vary only the processor stage share one
+// skeleton instead of copying the whole config.
+func TracesConfig(defs string, names ...string) string {
+	var block string
+	if strings.TrimSpace(defs) != "" {
+		block = "processors:\n" + defs
+		if !strings.HasSuffix(block, "\n") {
+			block += "\n"
+		}
+	}
+	var list string
+	if len(names) > 0 {
+		list = "      processors: [" + strings.Join(names, ", ") + "]\n"
+	}
+	return strings.NewReplacer(
+		"{{.ProcessorsBlock}}", block,
+		"{{.ProcessorsList}}", list,
+	).Replace(tracesConfigTemplate)
+}
 
 // configParams are the template fields the harness fills in. A custom config
 // passed to Start may reference any of them.
@@ -115,7 +192,7 @@ func Start(sink *Sink, config string) (*Collector, error) {
 		return nil, ErrNoCollector
 	}
 	if config == "" {
-		config = passthroughConfig
+		config = TracesConfig("")
 	}
 
 	otlpPort, err := freePort()

--- a/pkg/pipelinetest/invariants.go
+++ b/pkg/pipelinetest/invariants.go
@@ -60,8 +60,11 @@ func ReceivedKeys(received []*tracepb.Span) map[string]struct{} {
 	return keys
 }
 
-// CheckNoFabrication reports a received span that was never sent. A sampler
-// may only drop spans; it must never invent or duplicate identities.
+// CheckNoFabrication reports a received span whose identity was never sent: a
+// sampler may drop spans but must never invent new ones. It is deliberately a
+// subset check, not an exactly-once check — OTLP delivery is at-least-once, so
+// a correct pipeline may redeliver a span on retry, and that is not a
+// fabrication.
 func CheckNoFabrication(sent *Sent, received []*tracepb.Span) error {
 	for _, s := range received {
 		key := SpanKey(s.GetTraceId(), s.GetSpanId())
@@ -111,9 +114,11 @@ func CheckWholeTraces(sent *Sent, received []*tracepb.Span) error {
 	return nil
 }
 
-// CheckConservation reports any discrepancy between the spans sent and the
-// spans received: a pass-through pipeline must deliver every sent span exactly
-// once and fabricate none. This is the conservation invariant.
+// CheckConservation reports any discrepancy between the identities sent and the
+// identities received: a pass-through pipeline must deliver every sent span and
+// fabricate none. It compares identity sets, not raw counts, so redelivery of a
+// span (OTLP is at-least-once) is not a violation; only a missing or fabricated
+// identity is. This is the conservation invariant.
 func CheckConservation(sent *Sent, received []*tracepb.Span) error {
 	got := ReceivedKeys(received)
 	if len(got) != sent.Len() {

--- a/pkg/pipelinetest/invariants.go
+++ b/pkg/pipelinetest/invariants.go
@@ -1,0 +1,139 @@
+package pipelinetest
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// SpanKey is the hex-encoded (trace ID, span ID) identity of a span. It is the
+// join key between the spans a test sent into a pipeline and the spans the
+// Sink received, so invariant checks can compare the two sets.
+func SpanKey(traceID, spanID []byte) string {
+	return hex.EncodeToString(traceID) + ":" + hex.EncodeToString(spanID)
+}
+
+// Sent records the span identities a test pushed into a pipeline, grouped so
+// the invariant checks can compare them against what the Sink received. The
+// harness is agnostic to how a caller generates spans: translate each sent
+// span into its raw trace and span ID bytes and call Add.
+type Sent struct {
+	keys    map[string]struct{}
+	byTrace map[string][]string
+}
+
+// NewSent returns an empty Sent ready for Add.
+func NewSent() *Sent {
+	return &Sent{
+		keys:    make(map[string]struct{}),
+		byTrace: make(map[string][]string),
+	}
+}
+
+// Add records one sent span. Repeated identities are recorded once.
+func (s *Sent) Add(traceID, spanID []byte) {
+	key := SpanKey(traceID, spanID)
+	if _, ok := s.keys[key]; ok {
+		return
+	}
+	s.keys[key] = struct{}{}
+	tid := hex.EncodeToString(traceID)
+	s.byTrace[tid] = append(s.byTrace[tid], key)
+}
+
+// Has reports whether key was recorded by Add.
+func (s *Sent) Has(key string) bool {
+	_, ok := s.keys[key]
+	return ok
+}
+
+// Len returns the number of distinct spans recorded.
+func (s *Sent) Len() int { return len(s.keys) }
+
+// ReceivedKeys reduces captured spans to their identity set.
+func ReceivedKeys(received []*tracepb.Span) map[string]struct{} {
+	keys := make(map[string]struct{}, len(received))
+	for _, s := range received {
+		keys[SpanKey(s.GetTraceId(), s.GetSpanId())] = struct{}{}
+	}
+	return keys
+}
+
+// CheckNoFabrication reports a received span that was never sent. A sampler
+// may only drop spans; it must never invent or duplicate identities.
+func CheckNoFabrication(sent *Sent, received []*tracepb.Span) error {
+	for _, s := range received {
+		key := SpanKey(s.GetTraceId(), s.GetSpanId())
+		if !sent.Has(key) {
+			return fmt.Errorf("received span %s that was never sent", key)
+		}
+	}
+	return nil
+}
+
+// CheckParentsKept reports an orphaned span: a received span whose parent span
+// was dropped. Root spans (a zero parent ID) are exempt. This is the
+// parent-child preservation invariant.
+func CheckParentsKept(received []*tracepb.Span) error {
+	kept := ReceivedKeys(received)
+	for _, s := range received {
+		parent := s.GetParentSpanId()
+		if !validParentID(parent) {
+			continue
+		}
+		parentKey := SpanKey(s.GetTraceId(), parent)
+		if _, ok := kept[parentKey]; !ok {
+			return fmt.Errorf("orphaned span: %s was kept but its parent %s was dropped",
+				SpanKey(s.GetTraceId(), s.GetSpanId()), parentKey)
+		}
+	}
+	return nil
+}
+
+// CheckWholeTraces reports a partially sampled trace: a trace with at least one
+// received span but some sent span missing. This is the trace completeness
+// invariant. Traces the pipeline dropped entirely are exempt.
+func CheckWholeTraces(sent *Sent, received []*tracepb.Span) error {
+	kept := make(map[string]struct{}, len(received))
+	keptTraces := make(map[string]struct{})
+	for _, s := range received {
+		kept[SpanKey(s.GetTraceId(), s.GetSpanId())] = struct{}{}
+		keptTraces[hex.EncodeToString(s.GetTraceId())] = struct{}{}
+	}
+	for tid := range keptTraces {
+		for _, key := range sent.byTrace[tid] {
+			if _, ok := kept[key]; !ok {
+				return fmt.Errorf("partially sampled trace %s: span %s was dropped while other spans of the trace were kept", tid, key)
+			}
+		}
+	}
+	return nil
+}
+
+// CheckConservation reports any discrepancy between the spans sent and the
+// spans received: a pass-through pipeline must deliver every sent span exactly
+// once and fabricate none. This is the conservation invariant.
+func CheckConservation(sent *Sent, received []*tracepb.Span) error {
+	got := ReceivedKeys(received)
+	if len(got) != sent.Len() {
+		return fmt.Errorf("span count mismatch: sent %d, received %d", sent.Len(), len(got))
+	}
+	for key := range sent.keys {
+		if _, ok := got[key]; !ok {
+			return fmt.Errorf("span %s sent but not received", key)
+		}
+	}
+	return nil
+}
+
+// validParentID reports whether a parent span ID is present and non-zero. OTLP
+// encodes a root span's missing parent as an empty or all-zero span ID.
+func validParentID(id []byte) bool {
+	for _, b := range id {
+		if b != 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/pipelinetest/invariants_test.go
+++ b/pkg/pipelinetest/invariants_test.go
@@ -1,0 +1,102 @@
+package pipelinetest
+
+import (
+	"testing"
+
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// These tests feed hand-crafted violations to each invariant check and confirm
+// it trips, then confirm clean data passes. A correct collector never
+// exercises the failure paths, so this is the only always-on coverage the
+// checks get; it needs no collector binary.
+
+// traceID builds a 16-byte trace ID whose last byte is b.
+func traceID(b byte) []byte {
+	id := make([]byte, 16)
+	id[15] = b
+	return id
+}
+
+// spanID builds an 8-byte span ID whose last byte is b.
+func spanID(b byte) []byte {
+	id := make([]byte, 8)
+	id[7] = b
+	return id
+}
+
+// span builds an OTLP span; a parent of 0 means a root span.
+func span(tid []byte, sid, parent byte) *tracepb.Span {
+	s := &tracepb.Span{TraceId: tid, SpanId: spanID(sid)}
+	if parent != 0 {
+		s.ParentSpanId = spanID(parent)
+	}
+	return s
+}
+
+func TestCheckParentsKept(t *testing.T) {
+	tid := traceID(1)
+	root := span(tid, 1, 0)
+	child := span(tid, 2, 1)
+	grandchild := span(tid, 3, 2)
+
+	if err := CheckParentsKept([]*tracepb.Span{root, grandchild}); err == nil {
+		t.Fatal("CheckParentsKept accepted a span whose parent was dropped")
+	}
+	if err := CheckParentsKept([]*tracepb.Span{root, child, grandchild}); err != nil {
+		t.Fatalf("CheckParentsKept rejected complete lineage: %v", err)
+	}
+}
+
+func TestCheckWholeTraces(t *testing.T) {
+	tid := traceID(1)
+	root := span(tid, 1, 0)
+	child := span(tid, 2, 1)
+
+	sent := NewSent()
+	sent.Add(tid, spanID(1))
+	sent.Add(tid, spanID(2))
+
+	if err := CheckWholeTraces(sent, []*tracepb.Span{root}); err == nil {
+		t.Fatal("CheckWholeTraces accepted a partially kept trace")
+	}
+	if err := CheckWholeTraces(sent, []*tracepb.Span{root, child}); err != nil {
+		t.Fatalf("CheckWholeTraces rejected a whole trace: %v", err)
+	}
+	if err := CheckWholeTraces(sent, nil); err != nil {
+		t.Fatalf("CheckWholeTraces rejected a fully dropped trace: %v", err)
+	}
+}
+
+func TestCheckNoFabrication(t *testing.T) {
+	tid := traceID(1)
+	sent := NewSent()
+	sent.Add(tid, spanID(1))
+
+	if err := CheckNoFabrication(sent, []*tracepb.Span{span(tid, 1, 0)}); err != nil {
+		t.Fatalf("CheckNoFabrication rejected a sent span: %v", err)
+	}
+	if err := CheckNoFabrication(sent, []*tracepb.Span{span(tid, 2, 1)}); err == nil {
+		t.Fatal("CheckNoFabrication accepted a span that was never sent")
+	}
+}
+
+func TestCheckConservation(t *testing.T) {
+	tid := traceID(1)
+	root := span(tid, 1, 0)
+	child := span(tid, 2, 1)
+
+	sent := NewSent()
+	sent.Add(tid, spanID(1))
+	sent.Add(tid, spanID(2))
+
+	if err := CheckConservation(sent, []*tracepb.Span{root, child}); err != nil {
+		t.Fatalf("CheckConservation rejected an exact round-trip: %v", err)
+	}
+	if err := CheckConservation(sent, []*tracepb.Span{root}); err == nil {
+		t.Fatal("CheckConservation accepted a dropped span")
+	}
+	if err := CheckConservation(sent, []*tracepb.Span{root, child, span(tid, 3, 1)}); err == nil {
+		t.Fatal("CheckConservation accepted a fabricated span")
+	}
+}

--- a/pkg/synth/pipeline_sampling_test.go
+++ b/pkg/synth/pipeline_sampling_test.go
@@ -2,18 +2,13 @@ package synth
 
 import (
 	"context"
-	"encoding/binary"
-	"encoding/hex"
-	"fmt"
 	"math/rand/v2"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/andrewh/motel/pkg/pipelinetest"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"pgregory.net/rapid"
@@ -21,12 +16,12 @@ import (
 
 // Sampling trace integrity invariants (issue 74). Sampling processors decide
 // which traces survive a pipeline; these tests assert the decisions never
-// break trace structure:
+// break trace structure, using the checks in pkg/pipelinetest:
 //
 //   - Parent-child preservation: if a child span is kept, its parent is kept
-//     (no orphaned spans) — assertParentsKept.
+//     (no orphaned spans) — CheckParentsKept.
 //   - Trace completeness: if any span from a trace is kept, all spans from
-//     that trace are kept — assertWholeTraces.
+//     that trace are kept — CheckWholeTraces.
 //   - Sampling consistency: the same trace replayed through the same sampler
 //     gets the same keep/drop decision — TestSampling_DeterministicDecisions.
 //
@@ -44,10 +39,12 @@ const (
 	// property, kept short because it is paid on every draw.
 	propertySettleIdle = 300 * time.Millisecond
 
-	// tailSettleIdle must exceed the tail sampler's decision_wait: the
-	// pipeline is silent while traces sit in the decision buffer, and a
-	// shorter idle window would mistake that silence for a drained pipeline.
-	tailSettleIdle = 2 * time.Second
+	// tailSettleIdle must exceed the tail sampler's total release latency:
+	// decision_wait (1s) plus the processor's internal policy-evaluation tick
+	// (~1s), with margin for subprocess scheduling jitter under load. A
+	// shorter window would mistake the silence while traces sit in the
+	// decision buffer for a drained pipeline.
+	tailSettleIdle = 4 * time.Second
 
 	settleMax = 30 * time.Second
 )
@@ -55,73 +52,23 @@ const (
 // headSamplerPipeline samples 50% of traces at the head. hash_seed mode makes
 // the keep/drop decision a pure function of the trace ID, so it is
 // deterministic across runs and identical for every span of a trace.
-const headSamplerPipeline = `receivers:
-  otlp:
-    protocols:
-      http:
-        endpoint: 127.0.0.1:{{.OTLPHTTPPort}}
-processors:
-  probabilistic_sampler:
+var headSamplerPipeline = pipelinetest.TracesConfig(`  probabilistic_sampler:
     sampling_percentage: 50
     mode: hash_seed
     hash_seed: 22
-exporters:
-  otlphttp:
-    endpoint: {{.SinkURL}}
-    compression: none
-extensions:
-  health_check:
-    endpoint: 127.0.0.1:{{.HealthPort}}
-service:
-  extensions: [health_check]
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [probabilistic_sampler]
-      exporters: [otlphttp]
-  telemetry:
-    metrics:
-      level: none
-    logs:
-      level: warn
-`
+`, "probabilistic_sampler")
 
 // tailSamplingPipeline buffers whole traces for decision_wait, then keeps 50%
 // of them. The tail_sampling processor ships in otelcol-contrib, not the
 // reference otelcol build, so the test using it checks SupportsComponent.
-const tailSamplingPipeline = `receivers:
-  otlp:
-    protocols:
-      http:
-        endpoint: 127.0.0.1:{{.OTLPHTTPPort}}
-processors:
-  tail_sampling:
+var tailSamplingPipeline = pipelinetest.TracesConfig(`  tail_sampling:
     decision_wait: 1s
     policies:
       - name: keep-half
         type: probabilistic
         probabilistic:
           sampling_percentage: 50
-exporters:
-  otlphttp:
-    endpoint: {{.SinkURL}}
-    compression: none
-extensions:
-  health_check:
-    endpoint: 127.0.0.1:{{.HealthPort}}
-service:
-  extensions: [health_check]
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [tail_sampling]
-      exporters: [otlphttp]
-  telemetry:
-    metrics:
-      level: none
-    logs:
-      level: warn
-`
+`, "tail_sampling")
 
 // TestSampling_TraceIntegrity drives a fixed multi-service topology through a
 // 50% head sampler and asserts all structural invariants at once: the
@@ -131,24 +78,21 @@ func TestSampling_TraceIntegrity(t *testing.T) {
 	sink, collector := startPipeline(t, headSamplerPipeline)
 
 	topo := loadTopology(t, passthroughTopology)
-	sent := generateAndCapture(t, topo, collector.OTLPEndpoint, 40, 7, nil)
+	sent := generateAndSend(t, topo, collector.OTLPEndpoint, 40, 7)
 	spans := sink.WaitSettled(samplerSettleIdle, settleMax)
-	received := receivedKeys(spans)
 
-	if len(received) == 0 || len(received) >= len(sent) {
-		t.Fatalf("expected partial sampling: sent %d, received %d", len(sent), len(received))
-	}
-	assertNoFabrication(t, sentKeys(sent), received)
-	assertParentsKept(t, spans)
-	assertWholeTraces(t, sent, received)
+	assertPartialIntegrity(t, sent, spans)
 }
 
 // TestSampling_TraceIntegrityProperty asserts the same invariants for any
 // generated topology: whatever the trace shape — depth, fan-out, error mix —
 // the sampler must keep or drop traces whole. One collector is reused across
-// all draws.
+// all draws, with sent identities accumulating rather than resetting the sink
+// between draws (see TestPipeline_AllSpansRoundTripProperty for why a reset
+// races an in-flight export).
 func TestSampling_TraceIntegrityProperty(t *testing.T) {
 	sink, collector := startPipeline(t, headSamplerPipeline)
+	sent := pipelinetest.NewSent()
 
 	rapid.Check(t, func(t *rapid.T) {
 		cfg := genSimpleConfig(t)
@@ -160,51 +104,45 @@ func TestSampling_TraceIntegrityProperty(t *testing.T) {
 			t.Skip("no root operations")
 		}
 
-		sink.Reset()
 		seed := rapid.Uint64().Draw(t, "seed")
-		sent := generateAndCapture(t, topo, collector.OTLPEndpoint, 5, seed, nil)
-		if len(sent) == 0 {
+		before := sent.Len()
+		addSent(sent, generateAndCapture(t, topo, collector.OTLPEndpoint, 5, seed, nil))
+		if sent.Len() == before {
 			t.Skip("no spans generated")
 		}
 		spans := sink.WaitSettled(propertySettleIdle, settleMax)
-		received := receivedKeys(spans)
 
-		assertNoFabrication(t, sentKeys(sent), received)
-		assertParentsKept(t, spans)
-		assertWholeTraces(t, sent, received)
+		if err := pipelinetest.CheckNoFabrication(sent, spans); err != nil {
+			t.Fatal(err)
+		}
+		if err := pipelinetest.CheckParentsKept(spans); err != nil {
+			t.Fatal(err)
+		}
+		if err := pipelinetest.CheckWholeTraces(sent, spans); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 // TestSampling_DeterministicDecisions replays the identical span set through
 // the same sampler twice and asserts the keep/drop decisions match. A seeded
 // ID generator makes both runs use the same trace and span IDs, which is what
-// a hash_seed sampler decides on.
+// a hash_seed sampler decides on. Each run gets its own collector and sink, so
+// a late export from the first run cannot bleed into the second.
 func TestSampling_DeterministicDecisions(t *testing.T) {
-	sink, collector := startPipeline(t, headSamplerPipeline)
-
-	topo := loadTopology(t, passthroughTopology)
 	const genSeed, idSeed = 7, 99
 
-	first := generateAndCapture(t, topo, collector.OTLPEndpoint, 30, genSeed, newSeededIDGenerator(idSeed))
-	firstKept := receivedKeys(sink.WaitSettled(samplerSettleIdle, settleMax))
+	firstSent, firstKept := sampleWithSeed(t, genSeed, idSeed)
+	secondSent, secondKept := sampleWithSeed(t, genSeed, idSeed)
 
-	sink.Reset()
-	second := generateAndCapture(t, topo, collector.OTLPEndpoint, 30, genSeed, newSeededIDGenerator(idSeed))
-	secondKept := receivedKeys(sink.WaitSettled(samplerSettleIdle, settleMax))
-
-	// Guard the premise: both runs must have replayed the same spans.
-	assertSameSpans(t, sentKeys(first), sentKeys(second))
-
-	if len(firstKept) == 0 || len(firstKept) >= len(first) {
-		t.Fatalf("expected partial sampling: sent %d, kept %d", len(first), len(firstKept))
+	if !equalKeys(firstSent, secondSent) {
+		t.Fatal("premise broken: identical seeds replayed different span identities")
 	}
-	if len(firstKept) != len(secondKept) {
-		t.Fatalf("keep set size changed between identical runs: %d then %d", len(firstKept), len(secondKept))
+	if len(firstKept) == 0 || len(firstKept) >= len(firstSent) {
+		t.Fatalf("expected partial sampling: sent %d, kept %d", len(firstSent), len(firstKept))
 	}
-	for key := range firstKept {
-		if _, ok := secondKept[key]; !ok {
-			t.Fatalf("span %s kept in first run but dropped in second", key)
-		}
+	if !equalKeys(firstKept, secondKept) {
+		t.Fatal("keep/drop decision differed between identical runs")
 	}
 }
 
@@ -213,195 +151,69 @@ func TestSampling_DeterministicDecisions(t *testing.T) {
 // buffering (evicting part of a trace, deciding before all spans arrive)
 // shows up as a partially kept trace or an orphaned span.
 func TestSampling_TailWholeTraces(t *testing.T) {
-	if _, ok := pipelinetest.CollectorBinary(); !ok {
-		t.Skipf("no collector binary (set %s or install otelcol)", pipelinetest.BinaryEnv)
-	}
 	if !pipelinetest.SupportsComponent("tail_sampling") {
-		t.Skip("collector build lacks the tail_sampling processor (use otelcol-contrib)")
+		t.Skip("no collector with the tail_sampling processor (set MOTEL_COLLECTOR_BIN to an otelcol-contrib build)")
 	}
 	sink, collector := startPipeline(t, tailSamplingPipeline)
 
 	topo := loadTopology(t, passthroughTopology)
-	sent := generateAndCapture(t, topo, collector.OTLPEndpoint, 40, 7, nil)
+	sent := generateAndSend(t, topo, collector.OTLPEndpoint, 40, 7)
 	spans := sink.WaitSettled(tailSettleIdle, settleMax)
-	received := receivedKeys(spans)
 
-	if len(received) == 0 || len(received) >= len(sent) {
-		t.Fatalf("expected partial sampling: sent %d, received %d", len(sent), len(received))
-	}
-	assertNoFabrication(t, sentKeys(sent), received)
-	assertParentsKept(t, spans)
-	assertWholeTraces(t, sent, received)
+	assertPartialIntegrity(t, sent, spans)
 }
 
-// recordingT captures Fatalf calls so the invariant helpers can be tested
-// against data that must fail them. Unlike testing.T, it does not stop the
-// caller, so helpers may record several failures; only the first matters.
-type recordingT struct {
-	failure string
-}
-
-func (r *recordingT) Helper() {}
-
-func (r *recordingT) Fatalf(format string, args ...any) {
-	if r.failure == "" {
-		r.failure = fmt.Sprintf(format, args...)
-	}
-}
-
-// TestSamplingInvariantHelpers feeds hand-crafted violations to each invariant
-// check and confirms it trips, then confirms clean data passes. A correct
-// collector never exercises the failure paths, so this is the only always-on
-// coverage they get; it needs no collector binary.
-func TestSamplingInvariantHelpers(t *testing.T) {
-	traceID := bytes16(1)
-	root := pbSpan(traceID, 1, 0)
-	child := pbSpan(traceID, 2, 1)
-	grandchild := pbSpan(traceID, 3, 2)
-
-	t.Run("orphan detected", func(t *testing.T) {
-		rec := &recordingT{}
-		assertParentsKept(rec, []*tracepb.Span{root, grandchild})
-		if rec.failure == "" {
-			t.Fatal("assertParentsKept passed a span whose parent was dropped")
-		}
-	})
-
-	t.Run("complete lineage passes", func(t *testing.T) {
-		rec := &recordingT{}
-		assertParentsKept(rec, []*tracepb.Span{root, child, grandchild})
-		if rec.failure != "" {
-			t.Fatalf("assertParentsKept failed complete lineage: %s", rec.failure)
-		}
-	})
-
-	sentStubs := []tracetest.SpanStub{stub(traceID, 1), stub(traceID, 2)}
-
-	t.Run("partial trace detected", func(t *testing.T) {
-		rec := &recordingT{}
-		assertWholeTraces(rec, sentStubs, receivedKeys([]*tracepb.Span{root}))
-		if rec.failure == "" {
-			t.Fatal("assertWholeTraces passed a partially kept trace")
-		}
-	})
-
-	t.Run("whole and dropped traces pass", func(t *testing.T) {
-		rec := &recordingT{}
-		assertWholeTraces(rec, sentStubs, receivedKeys([]*tracepb.Span{root, child}))
-		assertWholeTraces(rec, sentStubs, receivedKeys(nil))
-		if rec.failure != "" {
-			t.Fatalf("assertWholeTraces failed valid sampling: %s", rec.failure)
-		}
-	})
-
-	t.Run("fabricated span detected", func(t *testing.T) {
-		rec := &recordingT{}
-		assertNoFabrication(rec, receivedKeys([]*tracepb.Span{root}), receivedKeys([]*tracepb.Span{root, child}))
-		if rec.failure == "" {
-			t.Fatal("assertNoFabrication passed a span that was never sent")
-		}
-	})
-}
-
-// bytes16 builds a trace ID whose last byte is b.
-func bytes16(b byte) [16]byte {
-	var id [16]byte
-	id[15] = b
-	return id
-}
-
-// pbSpan builds an OTLP span with small-integer span and parent IDs; a parent
-// of 0 means a root span.
-func pbSpan(traceID [16]byte, spanID, parentID byte) *tracepb.Span {
-	s := &tracepb.Span{
-		TraceId: traceID[:],
-		SpanId:  []byte{0, 0, 0, 0, 0, 0, 0, spanID},
-	}
-	if parentID != 0 {
-		s.ParentSpanId = []byte{0, 0, 0, 0, 0, 0, 0, parentID}
-	}
-	return s
-}
-
-// stub builds a sent-span stub matching pbSpan's identity scheme.
-func stub(traceID [16]byte, spanID byte) tracetest.SpanStub {
-	return tracetest.SpanStub{
-		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
-			TraceID: traceID,
-			SpanID:  [8]byte{0, 0, 0, 0, 0, 0, 0, spanID},
-		}),
-	}
-}
-
-// assertNoFabrication checks every received span was actually sent: a
-// sampler may only drop spans, never invent or duplicate identities.
-func assertNoFabrication(t testingT, sent, received map[string]struct{}) {
+// assertPartialIntegrity checks that a sampler kept some but not all of sent,
+// and that the survivors satisfy every trace-integrity invariant.
+func assertPartialIntegrity(t *testing.T, sent *pipelinetest.Sent, spans []*tracepb.Span) {
 	t.Helper()
 
-	for key := range received {
-		if _, ok := sent[key]; !ok {
-			t.Fatalf("received span %s that was never sent", key)
-		}
+	received := pipelinetest.ReceivedKeys(spans)
+	if len(received) == 0 || len(received) >= sent.Len() {
+		t.Fatalf("expected partial sampling: sent %d, received %d", sent.Len(), len(received))
+	}
+	if err := pipelinetest.CheckNoFabrication(sent, spans); err != nil {
+		t.Fatal(err)
+	}
+	if err := pipelinetest.CheckParentsKept(spans); err != nil {
+		t.Fatal(err)
+	}
+	if err := pipelinetest.CheckWholeTraces(sent, spans); err != nil {
+		t.Fatal(err)
 	}
 }
 
-// assertParentsKept checks parent-child preservation: every received span
-// with a parent has that parent in the received set too. A root span has a
-// zero parent ID and is exempt.
-func assertParentsKept(t testingT, received []*tracepb.Span) {
+// sampleWithSeed runs one head-sampling pipeline end to end with the given
+// generation and ID seeds, returning the sent span identities and the kept
+// (received) identities. Each call starts its own collector and sink.
+func sampleWithSeed(t *testing.T, genSeed, idSeed uint64) (sent, kept map[string]struct{}) {
 	t.Helper()
 
-	keys := receivedKeys(received)
-	for _, s := range received {
-		parent := s.GetParentSpanId()
-		if !validID(parent) {
-			continue
-		}
-		parentKey := spanKey(s.GetTraceId(), parent)
-		if _, ok := keys[parentKey]; !ok {
-			t.Fatalf("orphaned span: %s was kept but its parent %s was dropped",
-				spanKey(s.GetTraceId(), s.GetSpanId()), parentKey)
-		}
-	}
-}
+	sink, collector := startPipeline(t, headSamplerPipeline)
+	topo := loadTopology(t, passthroughTopology)
 
-// assertWholeTraces checks trace completeness: for every trace with at least
-// one received span, every span sent for that trace was received.
-func assertWholeTraces(t testingT, sent []tracetest.SpanStub, received map[string]struct{}) {
-	t.Helper()
-
-	sentByTrace := make(map[string][]string)
-	for _, s := range sent {
+	stubs := generateAndCapture(t, topo, collector.OTLPEndpoint, 30, genSeed, newSeededIDGenerator(idSeed))
+	sent = make(map[string]struct{}, len(stubs))
+	for _, s := range stubs {
 		tid := s.SpanContext.TraceID()
 		sid := s.SpanContext.SpanID()
-		key := spanKey(tid[:], sid[:])
-		sentByTrace[hex.EncodeToString(tid[:])] = append(sentByTrace[hex.EncodeToString(tid[:])], key)
+		sent[pipelinetest.SpanKey(tid[:], sid[:])] = struct{}{}
 	}
-
-	keptTraces := make(map[string]struct{})
-	for key := range received {
-		tid, _, _ := strings.Cut(key, ":")
-		keptTraces[tid] = struct{}{}
-	}
-
-	for tid := range keptTraces {
-		for _, key := range sentByTrace[tid] {
-			if _, ok := received[key]; !ok {
-				t.Fatalf("partially sampled trace %s: span %s was dropped while other spans of the trace were kept", tid, key)
-			}
-		}
-	}
+	kept = pipelinetest.ReceivedKeys(sink.WaitSettled(samplerSettleIdle, settleMax))
+	return sent, kept
 }
 
-// validID reports whether an ID is present and non-zero. OTLP encodes a
-// missing parent as an empty or all-zero span ID.
-func validID(id []byte) bool {
-	for _, b := range id {
-		if b != 0 {
-			return true
+// equalKeys reports whether two identity sets contain exactly the same keys.
+func equalKeys(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // seededIDGenerator is a deterministic replacement for the SDK's random
@@ -421,25 +233,11 @@ func newSeededIDGenerator(seed uint64) sdktrace.IDGenerator {
 func (g *seededIDGenerator) NewIDs(_ context.Context) (trace.TraceID, trace.SpanID) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-
-	var tid trace.TraceID
-	for !tid.IsValid() {
-		binary.BigEndian.PutUint64(tid[:8], g.rng.Uint64())
-		binary.BigEndian.PutUint64(tid[8:], g.rng.Uint64())
-	}
-	return tid, g.newSpanIDLocked()
+	return randomTraceID(g.rng.Uint64), randomSpanID(g.rng.Uint64)
 }
 
 func (g *seededIDGenerator) NewSpanID(_ context.Context, _ trace.TraceID) trace.SpanID {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return g.newSpanIDLocked()
-}
-
-func (g *seededIDGenerator) newSpanIDLocked() trace.SpanID {
-	var sid trace.SpanID
-	for !sid.IsValid() {
-		binary.BigEndian.PutUint64(sid[:], g.rng.Uint64())
-	}
-	return sid
+	return randomSpanID(g.rng.Uint64)
 }

--- a/pkg/synth/pipeline_test.go
+++ b/pkg/synth/pipeline_test.go
@@ -2,7 +2,6 @@ package synth
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
@@ -54,9 +53,11 @@ func TestPipeline_AllSpansRoundTrip(t *testing.T) {
 
 	topo := loadTopology(t, passthroughTopology)
 	sent := generateAndSend(t, topo, collector.OTLPEndpoint, 20, 1)
-	received := waitForSpans(t, sink, len(sent))
+	received := waitForSpans(t, sink, sent.Len())
 
-	assertSameSpans(t, sent, received)
+	if err := pipelinetest.CheckConservation(sent, received); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestPipeline_AllSpansRoundTripProperty is the property-testing direction the
@@ -64,6 +65,12 @@ func TestPipeline_AllSpansRoundTrip(t *testing.T) {
 // every span. One collector is reused across all draws.
 func TestPipeline_AllSpansRoundTripProperty(t *testing.T) {
 	sink, collector := startPipeline(t, "")
+
+	// Sent identities accumulate rather than resetting the sink between draws:
+	// a reset races an in-flight export from the previous draw and can
+	// misattribute a late span to the next draw. Over a running set, a late
+	// span is still a span that was sent.
+	sent := pipelinetest.NewSent()
 
 	rapid.Check(t, func(t *rapid.T) {
 		cfg := genSimpleConfig(t)
@@ -75,49 +82,26 @@ func TestPipeline_AllSpansRoundTripProperty(t *testing.T) {
 			t.Skip("no root operations")
 		}
 
-		sink.Reset()
 		seed := rapid.Uint64().Draw(t, "seed")
-		sent := generateAndSend(t, topo, collector.OTLPEndpoint, 5, seed)
-		if len(sent) == 0 {
+		before := sent.Len()
+		addSent(sent, generateAndCapture(t, topo, collector.OTLPEndpoint, 5, seed, nil))
+		if sent.Len() == before {
 			t.Skip("no spans generated")
 		}
-		received := waitForSpans(t, sink, len(sent))
+		received := waitForSpans(t, sink, sent.Len())
 
-		assertSameSpans(t, sent, received)
+		if err := pipelinetest.CheckConservation(sent, received); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 // samplingPipeline drops roughly half of all traces. It is the negative
 // control: it proves the harness observes real pipeline behaviour rather than
 // echoing what was sent, and previews the sampling invariants of issue 74.
-const samplingPipeline = `receivers:
-  otlp:
-    protocols:
-      http:
-        endpoint: 127.0.0.1:{{.OTLPHTTPPort}}
-processors:
-  probabilistic_sampler:
+var samplingPipeline = pipelinetest.TracesConfig(`  probabilistic_sampler:
     sampling_percentage: 50
-exporters:
-  otlphttp:
-    endpoint: {{.SinkURL}}
-    compression: none
-extensions:
-  health_check:
-    endpoint: 127.0.0.1:{{.HealthPort}}
-service:
-  extensions: [health_check]
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [probabilistic_sampler]
-      exporters: [otlphttp]
-  telemetry:
-    metrics:
-      level: none
-    logs:
-      level: warn
-`
+`, "probabilistic_sampler")
 
 // TestPipeline_SamplingDropsSpans confirms the harness detects a pipeline that
 // transforms its input: a 50% sampler must keep some spans but not all, and
@@ -128,14 +112,16 @@ func TestPipeline_SamplingDropsSpans(t *testing.T) {
 	topo := loadTopology(t, passthroughTopology)
 	sent := generateAndSend(t, topo, collector.OTLPEndpoint, 40, 7)
 
-	// The sampler drops whole traces, so the sent count is never reached.
-	// Wait for the pipeline to settle, then snapshot what survived.
-	received := receivedKeys(sink.WaitSettled(time.Second, 10*time.Second))
+	// The sampler drops whole traces, so there is no exact count to wait for.
+	spans := sink.WaitSettled(time.Second, 10*time.Second)
+	received := pipelinetest.ReceivedKeys(spans)
 
-	if len(received) == 0 || len(received) >= len(sent) {
-		t.Fatalf("expected partial sampling: sent %d, received %d", len(sent), len(received))
+	if len(received) == 0 || len(received) >= sent.Len() {
+		t.Fatalf("expected partial sampling: sent %d, received %d", sent.Len(), len(received))
 	}
-	assertNoFabrication(t, sent, received)
+	if err := pipelinetest.CheckNoFabrication(sent, spans); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // startPipeline starts a sink and a collector wired to it, registering cleanup.
@@ -172,11 +158,21 @@ type testingT interface {
 }
 
 // generateAndSend emits n traces from topo into an OTLP exporter pointed at
-// the collector via the public GenerateTraces API and returns the set of span
-// identities sent.
-func generateAndSend(t testingT, topo *Topology, endpoint string, n int, seed uint64) map[string]struct{} {
+// the collector and returns the identities sent, as a pipelinetest.Sent.
+func generateAndSend(t testingT, topo *Topology, endpoint string, n int, seed uint64) *pipelinetest.Sent {
 	t.Helper()
-	return sentKeys(generateAndCapture(t, topo, endpoint, n, seed, nil))
+	sent := pipelinetest.NewSent()
+	addSent(sent, generateAndCapture(t, topo, endpoint, n, seed, nil))
+	return sent
+}
+
+// addSent records every captured span's identity into sent.
+func addSent(sent *pipelinetest.Sent, spans []tracetest.SpanStub) {
+	for _, s := range spans {
+		tid := s.SpanContext.TraceID()
+		sid := s.SpanContext.SpanID()
+		sent.Add(tid[:], sid[:])
+	}
 }
 
 // generateAndCapture emits n traces from topo into an OTLP exporter pointed at
@@ -217,51 +213,16 @@ func generateAndCapture(t testingT, topo *Topology, endpoint string, n int, seed
 	return captured.GetSpans()
 }
 
-// sentKeys reduces captured spans to their identity set.
-func sentKeys(spans []tracetest.SpanStub) map[string]struct{} {
-	sent := make(map[string]struct{}, len(spans))
-	for _, s := range spans {
-		tid := s.SpanContext.TraceID()
-		sid := s.SpanContext.SpanID()
-		sent[spanKey(tid[:], sid[:])] = struct{}{}
-	}
-	return sent
-}
-
-// receivedKeys reduces the sink's captured spans to their identity set.
-func receivedKeys(spans []*tracepb.Span) map[string]struct{} {
-	received := make(map[string]struct{}, len(spans))
-	for _, s := range spans {
-		received[spanKey(s.GetTraceId(), s.GetSpanId())] = struct{}{}
-	}
-	return received
-}
-
-// waitForSpans blocks until the sink holds at least want spans or a timeout
-// elapses, then returns the identities of everything received.
-func waitForSpans(t testingT, sink *pipelinetest.Sink, want int) map[string]struct{} {
+// waitForSpans blocks until the sink holds at least want spans, failing the
+// test if that count is not reached within the timeout, and returns every span
+// received.
+func waitForSpans(t testingT, sink *pipelinetest.Sink, want int) []*tracepb.Span {
 	t.Helper()
 
-	sink.WaitFor(want, 10*time.Second)
-	return receivedKeys(sink.Spans())
-}
-
-// assertSameSpans checks that the received identities are exactly the sent set.
-func assertSameSpans(t testingT, sent, received map[string]struct{}) {
-	t.Helper()
-
-	if len(received) != len(sent) {
-		t.Fatalf("span count mismatch: sent %d, received %d", len(sent), len(received))
+	if !sink.WaitFor(want, 10*time.Second) {
+		t.Fatalf("timed out waiting for %d spans; sink holds %d", want, sink.Count())
 	}
-	for key := range sent {
-		if _, ok := received[key]; !ok {
-			t.Fatalf("span %s sent but not received", key)
-		}
-	}
-}
-
-func spanKey(traceID, spanID []byte) string {
-	return hex.EncodeToString(traceID) + ":" + hex.EncodeToString(spanID)
+	return sink.Spans()
 }
 
 // loadTopology writes a topology to a temp file and builds it.

--- a/pkg/synth/replay.go
+++ b/pkg/synth/replay.go
@@ -228,12 +228,13 @@ func randomReplaySpanID() trace.SpanID {
 
 // randomTraceID draws a valid (non-zero) trace ID, sourcing its 128 bits from
 // next. Callers supply the randomness — package rand for live generation, a
-// seeded generator for reproducible replays.
+// seeded generator for reproducible replays. The byte layout uses a fixed
+// endianness so a seeded source yields the same IDs on any architecture.
 func randomTraceID(next func() uint64) trace.TraceID {
 	tid := trace.TraceID{}
 	for {
-		binary.NativeEndian.PutUint64(tid[:traceIDHalfSize], next())
-		binary.NativeEndian.PutUint64(tid[traceIDHalfSize:], next())
+		binary.BigEndian.PutUint64(tid[:traceIDHalfSize], next())
+		binary.BigEndian.PutUint64(tid[traceIDHalfSize:], next())
 		if tid.IsValid() {
 			break
 		}
@@ -245,7 +246,7 @@ func randomTraceID(next func() uint64) trace.TraceID {
 func randomSpanID(next func() uint64) trace.SpanID {
 	sid := trace.SpanID{}
 	for {
-		binary.NativeEndian.PutUint64(sid[:], next())
+		binary.BigEndian.PutUint64(sid[:], next())
 		if sid.IsValid() {
 			break
 		}

--- a/pkg/synth/replay.go
+++ b/pkg/synth/replay.go
@@ -219,21 +219,33 @@ func (*ReplayIDGenerator) NewSpanID(ctx context.Context, _ trace.TraceID) trace.
 }
 
 func randomReplayIDs() (trace.TraceID, trace.SpanID) {
+	return randomTraceID(rand.Uint64), randomSpanID(rand.Uint64)
+}
+
+func randomReplaySpanID() trace.SpanID {
+	return randomSpanID(rand.Uint64)
+}
+
+// randomTraceID draws a valid (non-zero) trace ID, sourcing its 128 bits from
+// next. Callers supply the randomness — package rand for live generation, a
+// seeded generator for reproducible replays.
+func randomTraceID(next func() uint64) trace.TraceID {
 	tid := trace.TraceID{}
 	for {
-		binary.NativeEndian.PutUint64(tid[:traceIDHalfSize], rand.Uint64())
-		binary.NativeEndian.PutUint64(tid[traceIDHalfSize:], rand.Uint64())
+		binary.NativeEndian.PutUint64(tid[:traceIDHalfSize], next())
+		binary.NativeEndian.PutUint64(tid[traceIDHalfSize:], next())
 		if tid.IsValid() {
 			break
 		}
 	}
-	return tid, randomReplaySpanID()
+	return tid
 }
 
-func randomReplaySpanID() trace.SpanID {
+// randomSpanID draws a valid (non-zero) span ID from next, like randomTraceID.
+func randomSpanID(next func() uint64) trace.SpanID {
 	sid := trace.SpanID{}
 	for {
-		binary.NativeEndian.PutUint64(sid[:], rand.Uint64())
+		binary.NativeEndian.PutUint64(sid[:], next())
 		if sid.IsValid() {
 			break
 		}


### PR DESCRIPTION
Follow-up to the merged issue-74 work (#235), applying an adversarial review of commit `54b4d0f` that was skipped before merge. Fixes two flake windows in the timing design, moves the invariant checks to the right altitude, and clears the cleanup findings. Verified against a real `otelcol` build with the sampler processors: the sampling suite, the conservation round-trip suite, `make test`, and `make lint` all pass.

## Correctness and flakiness

- **Cross-draw contamination.** Both reused-collector property tests (sampling integrity and conservation round-trip) now accumulate sent identities instead of resetting the sink between draws. A reset races an in-flight export from the previous draw; a late span could land after the reset and be misattributed to the next draw, failing `CheckNoFabrication` as a load-dependent flake. Over a running set, a late span is still a span that was sent.
- **Deterministic test isolation.** `TestSampling_DeterministicDecisions` now runs each of its two identical passes against its own collector and sink, so a late export from the first pass cannot bleed into the second. It compares full span-id sets (premise and keep/drop), not just counts.
- **Tail-sampling settle margin.** Raised `tailSettleIdle` from 2s to 4s: the tail sampler's release latency is `decision_wait` (1s) plus its internal policy tick (~1s), so 2s left no margin for scheduler jitter and could truncate the capture on a loaded machine.
- **Timeout signal.** `waitForSpans` now fails the test on a `WaitFor` timeout instead of silently returning a short read, so a hang is distinguishable from span loss.

## Altitude and reuse

- Moved the invariant checks into `pkg/pipelinetest` as exported, framework-agnostic functions returning errors: `CheckNoFabrication`, `CheckParentsKept`, `CheckWholeTraces`, plus `CheckConservation` for the round-trip tests, keyed by `SpanKey` and a `Sent` accumulator. External users can now compose their own pipeline tests on the harness — which the design doc promised — instead of the assertions living unexported in `package synth` test files. The always-on unit coverage moved with them to `invariants_test.go`. `CheckWholeTraces` derives trace grouping straight from received spans rather than re-parsing composite keys, and no caller rebuilds a received-key map the check also builds.
- Added `pipelinetest.TracesConfig`, a shared config skeleton parameterised by the processors block. The four hand-copied collector configs (pass-through, and the three samplers) now derive from it.
- Extracted `randomTraceID`/`randomSpanID` in `replay.go` over a `next func() uint64` source; the replay generator and the test's seeded generator share the validity-retry loop instead of duplicating it.

## Robustness

- `SupportsComponent` now parses the collector's `components` output as YAML and matches component names only (not module paths), caching the set per binary path instead of spawning the binary and recompiling a regexp on every call.

## Docs

The how-to's worked example now uses the exported `pipelinetest` API and `synth.GenerateTraces`, so it is composable outside `package synth`; config-building and tail-timing notes updated to match.

## Known limitation

The residual intra-draw stall risk (a span delayed mid-delivery past the idle window) is inherent to a settle-based wait and now documented on `WaitSettled` and in the how-to. It is far rarer than the cross-draw case fixed here, since the head sampler decides synchronously with no batching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017mb8JHoaMXNfA6f7sncP4A)_