### PR TITLE
feat: support OTel baggage in topology definitions (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- OTel baggage in topology definitions. A `baggage:` map can be declared at the
+  service and/or operation level (operation entries overlay service entries).
+  When a span starts, its declared baggage is set on the trace context and
+  propagates to every descendant span, including across the simulated service
+  boundary. Set `baggage_as_attributes: true` at the service or operation level
+  (operation overrides service) to surface the baggage visible on a span —
+  inherited and declared — as `baggage.<key>` attributes, mirroring collector
+  baggage-copy processors so it is observable to a downstream OTLP consumer.
+  Baggage keys are validated as W3C baggage tokens. Works in both batch and
+  realtime emission. See `docs/examples/baggage.yaml`. (#212)
+
 ## [0.11.0] - 2026-07-08
 
 ### Changed

--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -50,6 +50,8 @@ and optional resource attributes.
 |------------------------|------|-------------|
 | `resource_attributes`  | map  | Static string key-value pairs attached to the OTel resource (not spans). Use for `deployment.environment`, `service.version`, `service.namespace`, etc. `service.name` and `motel.version` are set automatically and cannot be overridden |
 | `attributes`           | map  | Static string key-value pairs added to every span from this service |
+| `baggage`              | map  | Static string key-value pairs set as OTel baggage on every span from this service (see [baggage](#baggage)) |
+| `baggage_as_attributes`| bool | Surface baggage visible on this service's spans as `baggage.<key>` attributes (default: false; see [baggage](#baggage)) |
 | `metrics`              | list | Metric instruments emitted by this service (see [metrics](#metrics)) |
 | `logs`                 | list | Log records emitted for every span in this service (see [logs](#logs)) |
 | `operations`           | map  | Operation definitions (required) |
@@ -76,6 +78,8 @@ Each operation defines the span it produces.
 | `call_style` | string | `parallel` or `sequential` (default: parallel) |
 | `domain`     | string | Semconv shorthand (e.g. `http`) — auto-generates standard attributes |
 | `attributes` | map    | Per-span attribute generators (see below) |
+| `baggage`    | map    | Static string key-value pairs set as OTel baggage when this span starts, propagated to descendants (see [baggage](#baggage)) |
+| `baggage_as_attributes`| bool | Surface baggage visible on this span as `baggage.<key>` attributes; overrides the service-level default (see [baggage](#baggage)) |
 | `metrics`    | list   | Metric instruments scoped to this operation (see [metrics](#metrics)) |
 | `logs`       | list   | Log records scoped to this operation (see [logs](#logs)) |
 | `events`     | list   | Span events emitted during the operation (see below) |
@@ -242,6 +246,51 @@ services:
         duration: 15ms
         links:
           - producer.enqueue
+```
+
+### baggage
+
+[Baggage](https://opentelemetry.io/docs/specs/otel/baggage/api/) is a set of
+key-value pairs that travels with the trace context across service boundaries —
+distinct from span attributes, which stay on a single span. A `baggage:` map can
+be declared at the service and/or operation level. When a span starts, its
+declared baggage (service entries overlaid with operation entries, operation
+winning) is set on the context and **propagated to every descendant span**,
+including across the simulated service boundary.
+
+Keys must be valid [W3C baggage tokens](https://www.w3.org/TR/baggage/) so they
+survive propagation; values are arbitrary strings.
+
+Because motel emits spans directly to an OTLP endpoint in a single process,
+baggage is only observable to a downstream consumer when it is copied onto spans
+as attributes — which is exactly what many collector processors do in
+production. Set `baggage_as_attributes: true` (at the service or operation level)
+to surface the baggage visible on a span — inherited *and* declared — as
+`baggage.<key>` attributes. An operation-level `baggage_as_attributes` overrides
+the service-level default.
+
+```yaml
+services:
+  gateway:
+    # Every gateway span sets these; they propagate to all downstream spans.
+    baggage:
+      tenant.id: acme
+      session.plan: enterprise
+    operations:
+      GET /checkout:
+        duration: 20ms +/- 5ms
+        calls:
+          - payments.charge
+  payments:
+    # Surface inherited baggage as baggage.tenant.id / baggage.session.plan
+    # attributes on every payments span, mirroring a baggage-copy processor.
+    baggage_as_attributes: true
+    operations:
+      charge:
+        duration: 40ms +/- 10ms
+        # Operation-level baggage overrides the inherited value for descendants.
+        baggage:
+          tenant.id: acme-payments
 ```
 
 ### duration format

--- a/cmd/motel/README.md
+++ b/cmd/motel/README.md
@@ -259,7 +259,8 @@ winning) is set on the context and **propagated to every descendant span**,
 including across the simulated service boundary.
 
 Keys must be valid [W3C baggage tokens](https://www.w3.org/TR/baggage/) so they
-survive propagation; values are arbitrary strings.
+survive propagation; values may be any valid UTF-8 string (which any value read
+from a YAML topology already is).
 
 Because motel emits spans directly to an OTLP endpoint in a single process,
 baggage is only observable to a downstream consumer when it is copied onto spans

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -24,6 +24,7 @@ motel run --stdout --duration 5s docs/examples/basic-topology.yaml
 | `span-events.yaml` | Span events emitted at an offset within operations (cache misses, query starts). |
 | `span-links.yaml` | Cross-trace span links between producer and consumer, modelling a message queue. |
 | `producer-consumer.yaml` | Messaging `PRODUCER`/`CONSUMER` span kinds: a `producer: true` publish span paired with an async consumer that links back across traces. |
+| `baggage.yaml` | OTel baggage declared at service and operation level, propagated across services and surfaced as `baggage.<key>` attributes. |
 | `attribute-placement.yaml` | Resource attributes vs span attributes on the same service. |
 | `resource-attributes.yaml` | Per-service resource attributes (`deployment.environment`, `service.version`, etc.). |
 | `topology-driven-metrics.yaml` | All four metric instrument types at both service and operation level. |

--- a/docs/examples/baggage.yaml
+++ b/docs/examples/baggage.yaml
@@ -1,0 +1,52 @@
+# OTel baggage propagation across a topology
+#
+# Baggage is a set of key/value pairs that travels with the trace context across
+# service boundaries — distinct from span attributes, which stay on one span.
+# Here the gateway sets tenant/session baggage on every request; it propagates to
+# every downstream span. The payments service copies the inherited baggage onto
+# its spans as `baggage.<key>` attributes (baggage_as_attributes), mirroring a
+# collector baggage-copy processor, so it is observable to a downstream OTLP
+# consumer. The `charge` operation overrides one baggage value for its own
+# descendants.
+#
+# Run:
+#   motel run --stdout --duration 5s docs/examples/baggage.yaml
+# Look for `baggage.tenant.id` / `baggage.session.plan` attributes on the
+# payments.charge and ledger.record spans.
+
+version: 1
+
+services:
+  gateway:
+    # Declared once at the service level; propagates to the whole trace.
+    baggage:
+      tenant.id: acme
+      session.plan: enterprise
+    operations:
+      GET /checkout:
+        duration: 20ms +/- 5ms
+        calls:
+          - payments.charge
+
+  payments:
+    # Surface all baggage visible on these spans (inherited + declared) as
+    # baggage.<key> attributes, the way a baggage-copy processor would.
+    baggage_as_attributes: true
+    operations:
+      charge:
+        duration: 40ms +/- 10ms
+        error_rate: 1%
+        # Operation-level baggage overrides the inherited value for descendants.
+        baggage:
+          tenant.id: acme-payments
+        calls:
+          - ledger.record
+
+  ledger:
+    baggage_as_attributes: true
+    operations:
+      record:
+        duration: 15ms +/- 4ms
+
+traffic:
+  rate: 20/s

--- a/pkg/synth/baggage.go
+++ b/pkg/synth/baggage.go
@@ -1,0 +1,109 @@
+// OTel baggage propagation for synthetic topologies.
+//
+// Baggage is a set of key/value pairs that travels with the trace context across
+// service boundaries (parent -> children), distinct from span attributes. Services
+// and operations declare baggage in the topology DSL; the engine sets it on the
+// context when a span starts, propagates it to descendant spans, and can surface
+// the inherited set as span attributes (mirroring collector processors that copy
+// baggage onto spans) so it is observable by a downstream OTLP consumer.
+package synth
+
+import (
+	"sort"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/baggage"
+)
+
+// baggageAttributePrefix is prepended to baggage keys when an operation surfaces
+// baggage as span attributes (e.g. baggage.user.id), mirroring the common
+// real-world collector processor behaviour.
+const baggageAttributePrefix = "baggage."
+
+// mergeDeclaredBaggage returns the baggage an operation declares: service-level
+// entries overlaid with operation-level entries, with the operation winning on
+// key conflicts. Returns nil when neither level declares baggage.
+func mergeDeclaredBaggage(service, operation map[string]string) map[string]string {
+	if len(service) == 0 && len(operation) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(service)+len(operation))
+	for k, v := range service {
+		merged[k] = v
+	}
+	for k, v := range operation {
+		merged[k] = v
+	}
+	return merged
+}
+
+// overlayBaggageMap overlays an operation's declared baggage onto the baggage
+// inherited from its parent, returning the combined set visible while the span is
+// active. Declared entries win on key conflicts. Returns nil when the result is
+// empty.
+func overlayBaggageMap(inherited, declared map[string]string) map[string]string {
+	if len(inherited) == 0 && len(declared) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(inherited)+len(declared))
+	for k, v := range inherited {
+		merged[k] = v
+	}
+	for k, v := range declared {
+		merged[k] = v
+	}
+	return merged
+}
+
+// baggageAttributesFromMap renders a baggage set as span attributes keyed by
+// baggageAttributePrefix + baggage key, sorted for deterministic output.
+func baggageAttributesFromMap(m map[string]string) []attribute.KeyValue {
+	if len(m) == 0 {
+		return nil
+	}
+	attrs := make([]attribute.KeyValue, 0, len(m))
+	for _, k := range sortedKeys(m) {
+		attrs = append(attrs, attribute.String(baggageAttributePrefix+k, m[k]))
+	}
+	return attrs
+}
+
+// buildBaggage constructs an OTel baggage.Baggage from a map so it can be placed
+// on the context and propagated. Entries that fail member construction are
+// skipped; config validation rejects malformed baggage before this runs.
+func buildBaggage(m map[string]string) baggage.Baggage {
+	members := make([]baggage.Member, 0, len(m))
+	for _, k := range sortedKeys(m) {
+		mem, err := baggage.NewMemberRaw(k, m[k])
+		if err != nil {
+			continue
+		}
+		members = append(members, mem)
+	}
+	bag, _ := baggage.New(members...)
+	return bag
+}
+
+// baggageToMap converts an OTel baggage set into a plain map. The plan phase has
+// no context to carry OTel baggage, so it propagates baggage as a map instead.
+func baggageToMap(bag baggage.Baggage) map[string]string {
+	members := bag.Members()
+	if len(members) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(members))
+	for _, mem := range members {
+		m[mem.Key()] = mem.Value()
+	}
+	return m
+}
+
+// sortedKeys returns the keys of m in ascending order.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/synth/baggage_test.go
+++ b/pkg/synth/baggage_test.go
@@ -1,0 +1,298 @@
+// Tests for OTel baggage declaration, propagation, and attribute surfacing.
+package synth
+
+import (
+	"context"
+	"math/rand/v2"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// baggageAttrs extracts the baggage.<key> attributes from a captured span,
+// returning them as a plain map keyed by the bare baggage key.
+func baggageAttrs(span tracetest.SpanStub) map[string]string {
+	out := map[string]string{}
+	for _, a := range span.Attributes {
+		if k, ok := strings.CutPrefix(string(a.Key), baggageAttributePrefix); ok {
+			out[k] = a.Value.AsString()
+		}
+	}
+	return out
+}
+
+func findStub(spans []tracetest.SpanStub, name string) (tracetest.SpanStub, bool) {
+	for _, s := range spans {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return tracetest.SpanStub{}, false
+}
+
+// baggageDemoConfig models a gateway that declares baggage, a payments service
+// that surfaces it as attributes and overrides one key, and a ledger service
+// that inherits the override.
+func baggageDemoConfig() *Config {
+	surface := true
+	return &Config{
+		Services: []ServiceConfig{
+			{
+				Name:    "gateway",
+				Baggage: map[string]string{"tenant.id": "acme", "session.plan": "enterprise"},
+				Operations: []OperationConfig{{
+					Name:     "checkout",
+					Duration: "10ms",
+					Calls:    []CallConfig{{Target: "payments.charge"}},
+				}},
+			},
+			{
+				Name:                "payments",
+				BaggageAsAttributes: &surface,
+				Operations: []OperationConfig{{
+					Name:     "charge",
+					Duration: "10ms",
+					Baggage:  map[string]string{"tenant.id": "acme-payments"},
+					Calls:    []CallConfig{{Target: "ledger.record"}},
+				}},
+			},
+			{
+				Name:                "ledger",
+				BaggageAsAttributes: &surface,
+				Operations: []OperationConfig{{
+					Name:     "record",
+					Duration: "5ms",
+				}},
+			},
+		},
+		Traffic: TrafficConfig{Rate: "100/s"},
+	}
+}
+
+func TestValidateBaggage(t *testing.T) {
+	t.Parallel()
+
+	base := func(bag map[string]string) *Config {
+		return &Config{
+			Services: []ServiceConfig{{
+				Name:    "svc",
+				Baggage: bag,
+				Operations: []OperationConfig{{
+					Name:     "op",
+					Duration: "10ms",
+				}},
+			}},
+			Traffic: TrafficConfig{Rate: "10/s"},
+		}
+	}
+
+	t.Run("valid dotted key", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ValidateConfig(base(map[string]string{"user.id": "u-1"})))
+	})
+
+	t.Run("empty key rejected", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateConfig(base(map[string]string{"": "v"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "baggage key must not be empty")
+	})
+
+	t.Run("invalid token key rejected", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateConfig(base(map[string]string{"bad key": "v"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid baggage key")
+	})
+
+	t.Run("operation-level baggage validated", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Services: []ServiceConfig{{
+				Name: "svc",
+				Operations: []OperationConfig{{
+					Name:     "op",
+					Duration: "10ms",
+					Baggage:  map[string]string{"bad key": "v"},
+				}},
+			}},
+			Traffic: TrafficConfig{Rate: "10/s"},
+		}
+		err := ValidateConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid baggage key")
+	})
+}
+
+func TestBuildTopologyBaggageResolution(t *testing.T) {
+	t.Parallel()
+
+	topo, err := BuildTopology(baggageDemoConfig())
+	require.NoError(t, err)
+
+	charge := topo.Services["payments"].Operations["charge"]
+	// Service-level baggage is empty here, operation declares tenant.id only.
+	assert.Equal(t, map[string]string{"tenant.id": "acme-payments"}, charge.Baggage)
+	assert.True(t, charge.BaggageAsAttributes, "operation inherits service baggage_as_attributes default")
+
+	checkout := topo.Services["gateway"].Operations["checkout"]
+	assert.Equal(t, map[string]string{"tenant.id": "acme", "session.plan": "enterprise"}, checkout.Baggage)
+	assert.False(t, checkout.BaggageAsAttributes)
+}
+
+func TestBuildTopologyBaggageOperationOverridesServiceFlag(t *testing.T) {
+	t.Parallel()
+
+	svcOn, opOff := true, false
+	cfg := &Config{
+		Services: []ServiceConfig{{
+			Name:                "svc",
+			Baggage:             map[string]string{"a": "1"},
+			BaggageAsAttributes: &svcOn,
+			Operations: []OperationConfig{
+				{Name: "keep", Duration: "5ms"},
+				{Name: "opt-out", Duration: "5ms", BaggageAsAttributes: &opOff, Baggage: map[string]string{"b": "2"}},
+			},
+		}},
+		Traffic: TrafficConfig{Rate: "10/s"},
+	}
+	topo, err := BuildTopology(cfg)
+	require.NoError(t, err)
+
+	assert.True(t, topo.Services["svc"].Operations["keep"].BaggageAsAttributes)
+	assert.False(t, topo.Services["svc"].Operations["opt-out"].BaggageAsAttributes)
+	// Operation baggage overlays service baggage (operation wins on conflicts).
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, topo.Services["svc"].Operations["opt-out"].Baggage)
+}
+
+// TestEngineBaggagePropagation drives the batch walkTrace path and asserts that
+// baggage declared upstream is inherited and surfaced as attributes downstream,
+// including an operation-level override that propagates to descendants.
+func TestEngineBaggagePropagation(t *testing.T) {
+	t.Parallel()
+
+	engine, exporter, tp := newTestEngine(t, baggageDemoConfig())
+
+	root := engine.Topology.Roots[0]
+	require.Equal(t, "checkout", root.Name)
+
+	stats := &Stats{}
+	engine.walkTrace(context.Background(), root, nil, time.Now(), 0, nil, nil, stats, new(int), DefaultMaxSpansPerTrace, false, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	spans := exporter.GetSpans()
+
+	// gateway.checkout does not surface baggage (no baggage_as_attributes).
+	checkout, ok := findStub(spans, "checkout")
+	require.True(t, ok)
+	assert.Empty(t, baggageAttrs(checkout), "gateway span should not surface baggage attributes")
+
+	// payments.charge surfaces inherited session.plan plus its overridden tenant.id.
+	charge, ok := findStub(spans, "charge")
+	require.True(t, ok)
+	assert.Equal(t, map[string]string{
+		"tenant.id":    "acme-payments",
+		"session.plan": "enterprise",
+	}, baggageAttrs(charge))
+
+	// ledger.record inherits the override from charge, proving propagation to descendants.
+	record, ok := findStub(spans, "record")
+	require.True(t, ok)
+	assert.Equal(t, map[string]string{
+		"tenant.id":    "acme-payments",
+		"session.plan": "enterprise",
+	}, baggageAttrs(record))
+}
+
+// baggageCapture is a SpanProcessor that records the OTel baggage present on the
+// context at span start — the vantage point a real collector/processor has.
+type baggageCapture struct {
+	mu     sync.Mutex
+	byName map[string]map[string]string
+}
+
+func (b *baggageCapture) OnStart(parent context.Context, s sdktrace.ReadWriteSpan) {
+	m := map[string]string{}
+	for _, mem := range baggage.FromContext(parent).Members() {
+		m[mem.Key()] = mem.Value()
+	}
+	b.mu.Lock()
+	b.byName[s.Name()] = m
+	b.mu.Unlock()
+}
+
+func (b *baggageCapture) OnEnd(sdktrace.ReadOnlySpan)      {}
+func (b *baggageCapture) Shutdown(context.Context) error   { return nil }
+func (b *baggageCapture) ForceFlush(context.Context) error { return nil }
+
+// TestEngineBaggageOnContext verifies baggage propagates as real OTel baggage on
+// the context (not just as attributes), observable by a downstream processor.
+func TestEngineBaggageOnContext(t *testing.T) {
+	t.Parallel()
+
+	capture := &baggageCapture{byName: map[string]map[string]string{}}
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(capture))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	topo, err := BuildTopology(baggageDemoConfig())
+	require.NoError(t, err)
+	engine := &Engine{
+		Topology: topo,
+		Tracers:  func(name string) trace.Tracer { return tp.Tracer(name) },
+		Rng:      rand.New(rand.NewPCG(1, 2)), //nolint:gosec // deterministic test seed
+	}
+
+	engine.walkTrace(context.Background(), topo.Roots[0], nil, time.Now(), 0, nil, nil, &Stats{}, new(int), DefaultMaxSpansPerTrace, false, false)
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	// The gateway span starts with its declared baggage on the context.
+	assert.Equal(t, map[string]string{"tenant.id": "acme", "session.plan": "enterprise"}, capture.byName["checkout"])
+	// The ledger span sees the overridden tenant.id propagated down the context.
+	assert.Equal(t, map[string]string{"tenant.id": "acme-payments", "session.plan": "enterprise"}, capture.byName["record"])
+}
+
+// TestPlanBaggagePropagation drives the realtime plan path and asserts baggage is
+// resolved onto plans, propagated to child plans, and surfaced as attributes.
+func TestPlanBaggagePropagation(t *testing.T) {
+	t.Parallel()
+
+	engine, _, _ := newTestEngine(t, baggageDemoConfig())
+
+	var plans []SpanPlan
+	engine.planTrace(engine.Topology.Roots[0], nil, -1, time.Now(), 0, nil, nil, &Stats{}, &plans, new(int), DefaultMaxSpansPerTrace, false, false)
+
+	planByOp := map[string]SpanPlan{}
+	for _, p := range plans {
+		planByOp[p.Operation] = p
+	}
+
+	// Every plan carries the full baggage set visible while its span is active.
+	assert.Equal(t, map[string]string{"tenant.id": "acme", "session.plan": "enterprise"}, planByOp["checkout"].Baggage)
+	assert.Equal(t, map[string]string{"tenant.id": "acme-payments", "session.plan": "enterprise"}, planByOp["charge"].Baggage)
+	assert.Equal(t, map[string]string{"tenant.id": "acme-payments", "session.plan": "enterprise"}, planByOp["record"].Baggage)
+
+	// Surfaced attributes match the batch path.
+	assert.Equal(t, map[string]string{
+		"tenant.id":    "acme-payments",
+		"session.plan": "enterprise",
+	}, baggageAttrsFromPlan(planByOp["charge"]))
+	assert.Empty(t, baggageAttrsFromPlan(planByOp["checkout"]))
+}
+
+func baggageAttrsFromPlan(p SpanPlan) map[string]string {
+	out := map[string]string{}
+	for _, a := range p.Attrs {
+		if k, ok := strings.CutPrefix(string(a.Key), baggageAttributePrefix); ok {
+			out[k] = a.Value.AsString()
+		}
+	}
+	return out
+}

--- a/pkg/synth/config.go
+++ b/pkg/synth/config.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/baggage"
 	"gopkg.in/yaml.v3"
 )
 
@@ -105,11 +106,13 @@ type rawConfig struct {
 
 // rawServiceConfig is the YAML representation of a service before normalisation.
 type rawServiceConfig struct {
-	ResourceAttributes map[string]string             `yaml:"resource_attributes,omitempty"`
-	Attributes         map[string]string             `yaml:"attributes,omitempty"`
-	Metrics            []MetricConfig                `yaml:"metrics,omitempty"`
-	Logs               []LogConfig                   `yaml:"logs,omitempty"`
-	Operations         map[string]rawOperationConfig `yaml:"operations"`
+	ResourceAttributes  map[string]string             `yaml:"resource_attributes,omitempty"`
+	Attributes          map[string]string             `yaml:"attributes,omitempty"`
+	Baggage             map[string]string             `yaml:"baggage,omitempty"`
+	BaggageAsAttributes *bool                         `yaml:"baggage_as_attributes,omitempty"`
+	Metrics             []MetricConfig                `yaml:"metrics,omitempty"`
+	Logs                []LogConfig                   `yaml:"logs,omitempty"`
+	Operations          map[string]rawOperationConfig `yaml:"operations"`
 }
 
 // CallConfig describes a downstream call in the YAML DSL.
@@ -221,47 +224,53 @@ func (lc *LinkConfig) UnmarshalYAML(value *yaml.Node) error {
 
 // rawOperationConfig is the YAML representation of an operation before normalisation.
 type rawOperationConfig struct {
-	Domain         string                          `yaml:"domain,omitempty"`
-	Duration       string                          `yaml:"duration"`
-	ErrorRate      string                          `yaml:"error_rate,omitempty"`
-	Calls          []CallConfig                    `yaml:"calls,omitempty"`
-	CallStyle      string                          `yaml:"call_style,omitempty"`
-	Attributes     map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
-	Events         []EventConfig                   `yaml:"events,omitempty"`
-	Links          []LinkConfig                    `yaml:"links,omitempty"`
-	Metrics        []MetricConfig                  `yaml:"metrics,omitempty"`
-	Logs           []LogConfig                     `yaml:"logs,omitempty"`
-	QueueDepth     int                             `yaml:"queue_depth,omitempty"`
-	Backpressure   *BackpressureConfig             `yaml:"backpressure,omitempty"`
-	CircuitBreaker *CircuitBreakerConfig           `yaml:"circuit_breaker,omitempty"`
+	Domain              string                          `yaml:"domain,omitempty"`
+	Duration            string                          `yaml:"duration"`
+	ErrorRate           string                          `yaml:"error_rate,omitempty"`
+	Calls               []CallConfig                    `yaml:"calls,omitempty"`
+	CallStyle           string                          `yaml:"call_style,omitempty"`
+	Attributes          map[string]AttributeValueConfig `yaml:"attributes,omitempty"`
+	Baggage             map[string]string               `yaml:"baggage,omitempty"`
+	BaggageAsAttributes *bool                           `yaml:"baggage_as_attributes,omitempty"`
+	Events              []EventConfig                   `yaml:"events,omitempty"`
+	Links               []LinkConfig                    `yaml:"links,omitempty"`
+	Metrics             []MetricConfig                  `yaml:"metrics,omitempty"`
+	Logs                []LogConfig                     `yaml:"logs,omitempty"`
+	QueueDepth          int                             `yaml:"queue_depth,omitempty"`
+	Backpressure        *BackpressureConfig             `yaml:"backpressure,omitempty"`
+	CircuitBreaker      *CircuitBreakerConfig           `yaml:"circuit_breaker,omitempty"`
 }
 
 // ServiceConfig describes a service in the topology.
 type ServiceConfig struct {
-	Name               string
-	ResourceAttributes map[string]string
-	Attributes         map[string]string
-	Metrics            []MetricConfig
-	Logs               []LogConfig
-	Operations         []OperationConfig
+	Name                string
+	ResourceAttributes  map[string]string
+	Attributes          map[string]string
+	Baggage             map[string]string
+	BaggageAsAttributes *bool
+	Metrics             []MetricConfig
+	Logs                []LogConfig
+	Operations          []OperationConfig
 }
 
 // OperationConfig describes an operation within a service.
 type OperationConfig struct {
-	Name           string
-	Domain         string
-	Duration       string
-	ErrorRate      string
-	Calls          []CallConfig
-	CallStyle      string
-	Attributes     map[string]AttributeValueConfig
-	Events         []EventConfig
-	Links          []LinkConfig
-	Metrics        []MetricConfig
-	Logs           []LogConfig
-	QueueDepth     int
-	Backpressure   *BackpressureConfig
-	CircuitBreaker *CircuitBreakerConfig
+	Name                string
+	Domain              string
+	Duration            string
+	ErrorRate           string
+	Calls               []CallConfig
+	CallStyle           string
+	Attributes          map[string]AttributeValueConfig
+	Baggage             map[string]string
+	BaggageAsAttributes *bool
+	Events              []EventConfig
+	Links               []LinkConfig
+	Metrics             []MetricConfig
+	Logs                []LogConfig
+	QueueDepth          int
+	Backpressure        *BackpressureConfig
+	CircuitBreaker      *CircuitBreakerConfig
 }
 
 // TrafficConfig describes the traffic generation pattern.
@@ -429,11 +438,13 @@ func ParseConfig(data []byte) (*Config, error) {
 	for _, name := range serviceNames {
 		rawSvc := raw.Services[name]
 		svc := ServiceConfig{
-			Name:               name,
-			ResourceAttributes: rawSvc.ResourceAttributes,
-			Attributes:         rawSvc.Attributes,
-			Metrics:            rawSvc.Metrics,
-			Logs:               rawSvc.Logs,
+			Name:                name,
+			ResourceAttributes:  rawSvc.ResourceAttributes,
+			Attributes:          rawSvc.Attributes,
+			Baggage:             rawSvc.Baggage,
+			BaggageAsAttributes: rawSvc.BaggageAsAttributes,
+			Metrics:             rawSvc.Metrics,
+			Logs:                rawSvc.Logs,
 		}
 
 		opNames := make([]string, 0, len(rawSvc.Operations))
@@ -445,20 +456,22 @@ func ParseConfig(data []byte) (*Config, error) {
 		for _, opName := range opNames {
 			rawOp := rawSvc.Operations[opName]
 			svc.Operations = append(svc.Operations, OperationConfig{
-				Name:           opName,
-				Domain:         rawOp.Domain,
-				Duration:       rawOp.Duration,
-				ErrorRate:      rawOp.ErrorRate,
-				Calls:          rawOp.Calls,
-				CallStyle:      rawOp.CallStyle,
-				Attributes:     rawOp.Attributes,
-				Events:         rawOp.Events,
-				Links:          rawOp.Links,
-				Metrics:        rawOp.Metrics,
-				Logs:           rawOp.Logs,
-				QueueDepth:     rawOp.QueueDepth,
-				Backpressure:   rawOp.Backpressure,
-				CircuitBreaker: rawOp.CircuitBreaker,
+				Name:                opName,
+				Domain:              rawOp.Domain,
+				Duration:            rawOp.Duration,
+				ErrorRate:           rawOp.ErrorRate,
+				Calls:               rawOp.Calls,
+				CallStyle:           rawOp.CallStyle,
+				Attributes:          rawOp.Attributes,
+				Baggage:             rawOp.Baggage,
+				BaggageAsAttributes: rawOp.BaggageAsAttributes,
+				Events:              rawOp.Events,
+				Links:               rawOp.Links,
+				Metrics:             rawOp.Metrics,
+				Logs:                rawOp.Logs,
+				QueueDepth:          rawOp.QueueDepth,
+				Backpressure:        rawOp.Backpressure,
+				CircuitBreaker:      rawOp.CircuitBreaker,
 			})
 		}
 		cfg.Services = append(cfg.Services, svc)
@@ -522,6 +535,9 @@ func ValidateConfig(cfg *Config) error {
 			if reservedResourceAttribute[k] {
 				return fmt.Errorf("service %q: resource_attributes must not contain reserved key %q (set automatically)", svc.Name, k)
 			}
+		}
+		if err := validateBaggage(svc.Baggage, fmt.Sprintf("service %q", svc.Name)); err != nil {
+			return err
 		}
 		knownServices[svc.Name] = true
 		metricNames := make(map[string]bool)
@@ -594,6 +610,10 @@ func ValidateConfig(cfg *Config) error {
 				if _, err := NewAttributeGenerator(attrCfg); err != nil {
 					return fmt.Errorf("service %q operation %q: attribute %q: %w", svc.Name, op.Name, attrName, err)
 				}
+			}
+
+			if err := validateBaggage(op.Baggage, fmt.Sprintf("service %q operation %q", svc.Name, op.Name)); err != nil {
+				return err
 			}
 
 			for i, evt := range op.Events {
@@ -1051,6 +1071,27 @@ func validateLogConfig(lc LogConfig, prefix string) error {
 	for attrName, attrCfg := range lc.Attributes {
 		if _, err := NewAttributeGenerator(attrCfg); err != nil {
 			return fmt.Errorf("%s: attribute %q: %w", prefix, attrName, err)
+		}
+	}
+	return nil
+}
+
+// validateBaggage checks baggage keys and values for a service or operation.
+// Keys must be valid W3C baggage tokens (RFC 7230) so they survive propagation
+// across the simulated service boundary; values must be valid UTF-8. prefix
+// identifies the scope in error messages.
+func validateBaggage(bag map[string]string, prefix string) error {
+	for _, k := range sortedKeys(bag) {
+		if k == "" {
+			return fmt.Errorf("%s: baggage key must not be empty", prefix)
+		}
+		// NewMember enforces the W3C token grammar on the key; a plain
+		// alphanumeric placeholder value keeps the check key-focused.
+		if _, err := baggage.NewMember(k, "x"); err != nil {
+			return fmt.Errorf("%s: invalid baggage key %q (must be a valid W3C baggage token): %w", prefix, k, err)
+		}
+		if _, err := baggage.NewMemberRaw(k, bag[k]); err != nil {
+			return fmt.Errorf("%s: invalid baggage value for key %q: %w", prefix, k, err)
 		}
 	}
 	return nil

--- a/pkg/synth/emit.go
+++ b/pkg/synth/emit.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -69,6 +70,12 @@ func emitTrace(ctx context.Context, plans []SpanPlan, baseSimTime time.Time, bas
 				parentCtx = live[plan.ParentIndex].Ctx
 			} else {
 				parentCtx = ctx
+			}
+
+			// Place the span's baggage on the context so it propagates as real
+			// OTel baggage (planTrace already resolved the inherited + declared set).
+			if len(plan.Baggage) > 0 {
+				parentCtx = baggage.ContextWithBaggage(parentCtx, buildBaggage(plan.Baggage))
 			}
 
 			startOpts := []trace.SpanStartOption{

--- a/pkg/synth/engine.go
+++ b/pkg/synth/engine.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -452,6 +453,15 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 	// CLIENT otherwise.
 	kind := spanKindFor(e.Topology, op, parent, isAsync, isProducer)
 
+	// Baggage: overlay this operation's declared baggage onto whatever was
+	// inherited from the parent context, then propagate the combined set to
+	// descendant spans via the context. baggageAsAttributes surfaces it below.
+	inheritedBaggage := baggageToMap(baggage.FromContext(ctx))
+	mergedBaggage := overlayBaggageMap(inheritedBaggage, op.Baggage)
+	if len(op.Baggage) > 0 {
+		ctx = baggage.ContextWithBaggage(ctx, buildBaggage(mergedBaggage))
+	}
+
 	startAttrs := []attribute.KeyValue{
 		attribute.String("synth.service", op.Service.Name),
 		attribute.String("synth.operation", op.Name),
@@ -495,6 +505,9 @@ func (e *Engine) walkTrace(ctx context.Context, op, parent *Operation, startTime
 	}
 	for _, a := range opAttrs {
 		spanAttrs = append(spanAttrs, typedAttribute(a.Key, a.Gen.Generate(e.Rng)))
+	}
+	if op.BaggageAsAttributes {
+		spanAttrs = append(spanAttrs, baggageAttributesFromMap(mergedBaggage)...)
 	}
 	span.SetAttributes(spanAttrs...)
 

--- a/pkg/synth/plan.go
+++ b/pkg/synth/plan.go
@@ -34,6 +34,11 @@ type SpanPlan struct {
 	Rejected        bool
 	RejectionReason string
 	LinkRefs        []LinkRef
+	// Baggage is the full baggage set visible while this span is active
+	// (inherited from the parent plan plus this operation's declared baggage).
+	// Children read their parent's Baggage to inherit; emitTrace places it on
+	// the context so it propagates as real OTel baggage.
+	Baggage map[string]string
 }
 
 // planTrace recursively plans spans for an operation and its downstream calls.
@@ -89,6 +94,15 @@ func (e *Engine) planTrace(op, parent *Operation, parentIndex int, startTime tim
 
 	kind := spanKindFor(e.Topology, op, parent, isAsync, isProducer)
 
+	// Baggage: inherit from the parent plan (the plan phase has no context to
+	// carry OTel baggage), overlay this operation's declared baggage, and store
+	// the combined set so children inherit and emitTrace can propagate it.
+	var inheritedBaggage map[string]string
+	if parentIndex >= 0 {
+		inheritedBaggage = (*plans)[parentIndex].Baggage
+	}
+	mergedBaggage := overlayBaggageMap(inheritedBaggage, op.Baggage)
+
 	startAttrs := []attribute.KeyValue{
 		attribute.String("synth.service", op.Service.Name),
 		attribute.String("synth.operation", op.Name),
@@ -103,6 +117,9 @@ func (e *Engine) planTrace(op, parent *Operation, parentIndex int, startTime tim
 	}
 	for _, a := range opAttrs {
 		spanAttrs = append(spanAttrs, typedAttribute(a.Key, a.Gen.Generate(e.Rng)))
+	}
+	if op.BaggageAsAttributes {
+		spanAttrs = append(spanAttrs, baggageAttributesFromMap(mergedBaggage)...)
 	}
 
 	ownError := false
@@ -138,6 +155,7 @@ func (e *Engine) planTrace(op, parent *Operation, parentIndex int, startTime tim
 		Attrs:       spanAttrs,
 		Scenarios:   scenarioNames,
 		LinkRefs:    linkRefs,
+		Baggage:     mergedBaggage,
 	}
 	*plans = append(*plans, plan)
 

--- a/pkg/synth/topology.go
+++ b/pkg/synth/topology.go
@@ -47,6 +47,7 @@ type Service struct {
 	Operations         map[string]*Operation
 	ResourceAttributes map[string]string
 	Attributes         map[string]string
+	Baggage            map[string]string
 	Metrics            []MetricDefinition
 	Logs               []LogDefinition
 }
@@ -80,21 +81,28 @@ type Link struct {
 
 // Operation represents a resolved operation with pointers to downstream calls.
 type Operation struct {
-	Service        *Service
-	Name           string
-	Ref            string
-	Duration       Distribution
-	ErrorRate      float64
-	Calls          []Call
-	CallStyle      string
-	Attributes     Attributes
-	Events         []Event
-	Links          []Link
-	Metrics        []MetricDefinition
-	Logs           []LogDefinition
-	QueueDepth     int
-	Backpressure   *ResolvedBackpressure
-	CircuitBreaker *ResolvedCircuitBreaker
+	Service    *Service
+	Name       string
+	Ref        string
+	Duration   Distribution
+	ErrorRate  float64
+	Calls      []Call
+	CallStyle  string
+	Attributes Attributes
+	// Baggage is the operation's declared baggage: service-level entries merged
+	// with operation-level entries (operation wins). Set on the context when the
+	// span starts and propagated to descendant spans.
+	Baggage map[string]string
+	// BaggageAsAttributes surfaces the baggage visible while the span is active
+	// (inherited plus declared) as baggage.<key> span attributes.
+	BaggageAsAttributes bool
+	Events              []Event
+	Links               []Link
+	Metrics             []MetricDefinition
+	Logs                []LogDefinition
+	QueueDepth          int
+	Backpressure        *ResolvedBackpressure
+	CircuitBreaker      *ResolvedCircuitBreaker
 }
 
 // Call represents a resolved downstream call with optional modifiers.
@@ -136,6 +144,7 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 			Operations:         make(map[string]*Operation, len(svcCfg.Operations)),
 			ResourceAttributes: svcCfg.ResourceAttributes,
 			Attributes:         svcCfg.Attributes,
+			Baggage:            svcCfg.Baggage,
 		}
 		if len(svcCfg.Metrics) > 0 {
 			resolved, err := resolveMetrics(svcCfg.Metrics, svcCfg.Name, "")
@@ -185,15 +194,25 @@ func BuildTopology(cfg *Config, resolvers ...DomainResolver) (*Topology, error) 
 					attrs[name] = gen
 				}
 			}
+			// Effective baggage-as-attributes: operation overrides service default.
+			baggageAsAttrs := false
+			if svcCfg.BaggageAsAttributes != nil {
+				baggageAsAttrs = *svcCfg.BaggageAsAttributes
+			}
+			if opCfg.BaggageAsAttributes != nil {
+				baggageAsAttrs = *opCfg.BaggageAsAttributes
+			}
 			op := &Operation{
-				Service:    svc,
-				Name:       opCfg.Name,
-				Ref:        svcCfg.Name + "." + opCfg.Name,
-				Duration:   dist,
-				ErrorRate:  errorRate,
-				CallStyle:  opCfg.CallStyle,
-				Attributes: NewAttributes(attrs),
-				QueueDepth: opCfg.QueueDepth,
+				Service:             svc,
+				Name:                opCfg.Name,
+				Ref:                 svcCfg.Name + "." + opCfg.Name,
+				Duration:            dist,
+				ErrorRate:           errorRate,
+				CallStyle:           opCfg.CallStyle,
+				Attributes:          NewAttributes(attrs),
+				Baggage:             mergeDeclaredBaggage(svcCfg.Baggage, opCfg.Baggage),
+				BaggageAsAttributes: baggageAsAttrs,
+				QueueDepth:          opCfg.QueueDepth,
 			}
 			if len(opCfg.Metrics) > 0 {
 				resolved, mErr := resolveMetrics(opCfg.Metrics, svcCfg.Name, opCfg.Name)


### PR DESCRIPTION
Closes #212.

Adds OTel **baggage** to the topology model.

## What baggage is

Baggage is a set of key/value pairs that travels with the trace context across service boundaries (parent → children), distinct from span attributes which stay on a single span. Realistic synthetic traces — and anything testing baggage-aware collector processors or propagators — need it.

## Changes

- **DSL** — a `baggage:` map can be declared at the **service** and/or **operation** level. Operation entries overlay service entries (operation wins on key conflicts).
- **Propagation** — when a span starts, its declared baggage is set on the trace context and propagated to **every descendant span**, including across the simulated service boundary. Implemented in both emission paths:
  - batch (`walkTrace`) — inherits via `baggage.FromContext(ctx)`, overlays declared baggage, sets it back on the context passed to children.
  - realtime (`planTrace` / `emitTrace`) — the plan phase (which has no context) threads the merged set through each `SpanPlan`; `emitTrace` places it on the context as real OTel baggage.
- **Surfacing as attributes** — because motel emits directly to an OTLP endpoint in a single process, baggage is only observable to a downstream consumer when copied onto spans as attributes, exactly as collector baggage-copy processors do in production. A `baggage_as_attributes` flag (service or operation level, operation overriding service) surfaces the baggage visible on a span — inherited *and* declared — as `baggage.<key>` attributes.
- **Validation** — baggage keys are validated as W3C baggage tokens (RFC 7230) so they survive propagation; values must be valid UTF-8.

## Acceptance criteria

- [x] Topology can declare baggage and it propagates to descendant spans
- [x] Emitted spans carry baggage observable by a downstream OTLP consumer (via `baggage.<key>` attributes and as real OTel baggage on the context)
- [x] Unit coverage for propagation and attribute surfacing (batch + realtime paths, validation, topology resolution)
- [x] Docs (`cmd/motel/README.md`, CHANGELOG) + an example under `docs/examples/baggage.yaml`

## Testing

- `go test ./...` and `go test -race ./pkg/synth/` pass.
- `go vet` and `golangci-lint` clean on the new files (only pre-existing findings remain).
- Verified end-to-end: `motel validate`, `motel check`, and `motel run --stdout` (both batch and `--realtime`) on `docs/examples/baggage.yaml` — the gateway's baggage propagates through `payments.charge` and `ledger.record`, an operation-level override (`tenant.id: acme-payments`) reaches descendants, and only services with `baggage_as_attributes` surface the `baggage.*` attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vmw4k6WBig3B6cEgwfE94V)_