### PR TITLE
feat: forward SpanObserver hook through GenerateTraces (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `GenerateTraces` now forwards a `[]SpanObserver` (new `GenerateOptions.Observers`
+  field) so embedders can receive motel's authoritative per-span `SpanInfo`
+  (`ParentService`/`ParentOperation`, `IsError`, `Kind`, `Scenarios`, `Attrs`)
+  alongside OTLP emission, matching the observer hooks already exposed by `Run`
+  and replay. A nil or empty slice preserves the exporter-only behavior. (#240)
 - OTel baggage in topology definitions. A `baggage:` map can be declared at the
   service and/or operation level (operation entries overlay service entries).
   When a span starts, its declared baggage is set on the trace context and

--- a/pkg/synth/generate.go
+++ b/pkg/synth/generate.go
@@ -25,6 +25,12 @@ type GenerateOptions struct {
 	// MaxSpansPerTrace bounds the spans emitted per trace.
 	// Zero applies DefaultMaxSpansPerTrace.
 	MaxSpansPerTrace int
+
+	// Observers are notified with a SpanInfo for each generated span, the
+	// same metadata Run and replay produce. This is a parallel observation
+	// channel alongside the TracerProvider: OTLP emission is unaffected, and
+	// a nil or empty slice preserves the exporter-only behavior exactly.
+	Observers []SpanObserver
 }
 
 // TracerProviderSource adapts a trace.TracerProvider into a TracerSource that
@@ -48,6 +54,10 @@ func TracerProviderSource(tp trace.TracerProvider) TracerSource {
 // simulation state; each starts from a root chosen by the trace's own
 // seed-derived RNG. Generation stops early when ctx is cancelled, returning
 // the statistics accumulated so far alongside the context's error.
+//
+// If opts.Observers is non-empty, each observer's Observe is called with a
+// SpanInfo for every generated span — the same metadata Run and replay
+// produce — alongside the OTLP emission through tracers.
 func GenerateTraces(ctx context.Context, topo *Topology, tracers TracerSource, opts GenerateOptions) (*Stats, error) {
 	if tracers == nil {
 		return nil, fmt.Errorf("no tracer source provided")
@@ -71,6 +81,7 @@ func GenerateTraces(ctx context.Context, topo *Topology, tracers TracerSource, o
 	engine := &Engine{
 		Topology:     topo,
 		Tracers:      tracers,
+		Observers:    opts.Observers,
 		linkRegistry: newSpanContextRegistry(topo),
 	}
 

--- a/pkg/synth/generate_test.go
+++ b/pkg/synth/generate_test.go
@@ -97,7 +97,7 @@ func TestGenerateTraces_NotifiesObservers(t *testing.T) {
 
 	records := obs.get()
 	// The chain emits exactly three spans per trace, one Observe call each.
-	if len(records) != int(stats.Spans) {
+	if int64(len(records)) != stats.Spans {
 		t.Fatalf("expected one SpanInfo per span (%d), got %d", stats.Spans, len(records))
 	}
 	if len(records) != 3*n {

--- a/pkg/synth/generate_test.go
+++ b/pkg/synth/generate_test.go
@@ -83,6 +83,57 @@ func TestGenerateTraces_EmitsExpectedSpans(t *testing.T) {
 	}
 }
 
+func TestGenerateTraces_NotifiesObservers(t *testing.T) {
+	topo := generateTestChain()
+	_, tp := newCapturingProvider(t)
+
+	obs := &recordingObserver{}
+	const n = 3
+	stats, err := GenerateTraces(context.Background(), topo, TracerProviderSource(tp),
+		GenerateOptions{Traces: n, Seed: 42, Observers: []SpanObserver{obs}})
+	if err != nil {
+		t.Fatalf("GenerateTraces: %v", err)
+	}
+
+	records := obs.get()
+	// The chain emits exactly three spans per trace, one Observe call each.
+	if len(records) != int(stats.Spans) {
+		t.Fatalf("expected one SpanInfo per span (%d), got %d", stats.Spans, len(records))
+	}
+	if len(records) != 3*n {
+		t.Fatalf("expected %d SpanInfo records, got %d", 3*n, len(records))
+	}
+
+	// Verify parent attribution for the cross-service call backend.read,
+	// whose parent is gateway.handle.
+	var read SpanInfo
+	found := false
+	for _, r := range records {
+		if r.Service == "backend" && r.Operation == "read" {
+			read = r
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("no SpanInfo recorded for backend.read")
+	}
+	if read.ParentService != "gateway" || read.ParentOperation != "handle" {
+		t.Fatalf("backend.read parent = %q/%q, want gateway/handle",
+			read.ParentService, read.ParentOperation)
+	}
+
+	// Root spans (gateway.handle) carry no parent attribution.
+	for _, r := range records {
+		if r.Service == "gateway" && r.Operation == "handle" {
+			if r.ParentService != "" || r.ParentOperation != "" {
+				t.Fatalf("root gateway.handle has parent %q/%q, want empty",
+					r.ParentService, r.ParentOperation)
+			}
+		}
+	}
+}
+
 func TestGenerateTraces_ReproducibleWithSeed(t *testing.T) {
 	run := func() (*Stats, []tracetest.SpanStub) {
 		topo := generateTestChain()


### PR DESCRIPTION
## Summary

`GenerateTraces` was the one emission entry point with no `[]SpanObserver` hook. Every other path (`emitTrace`, `ReplayRecordingFrom`, `Engine.Observers`) exposes motel's per-span metadata that way, so embedders wanting authoritative `SpanInfo` from `GenerateTraces` had to **reconstruct** it from OTel `ReadOnlySpan`s — a silent coupling to motel's span-naming and status conventions.

This adds an observer channel parallel to the existing `TracerProvider`/OTLP path. Fixes #240.

## Changes

- Add `GenerateOptions.Observers []SpanObserver`.
- Wire it to the `Engine.Observers` field that `walkTrace` already honours before the generation loop.
- Update the `GenerateTraces` doc comment.
- Add a CHANGELOG entry under Unreleased → Added.

No change to the emission core: `walkTrace` already builds the full `SpanInfo` (parent service/op, `IsError`, `Kind`, `Scenarios`, `Attrs`, span context) whenever observers are present. `GenerateTraces` previously constructed its `Engine` without setting `Observers`, so that block was skipped — wiring the field through is the whole change. `TracerProviderSource` stays the primary/OTLP path; a nil or empty slice preserves today's exporter-only behavior exactly.

## Tests

- New `TestGenerateTraces_NotifiesObservers`: asserts one `SpanInfo` per generated span and correct `ParentService`/`ParentOperation` for the cross-service `backend.read` call (parent `gateway.handle`), plus empty parent attribution on root spans.
- Existing observer-less `GenerateTraces` tests remain green, confirming current callers are unaffected.
- `go test ./...` passes.

## Acceptance criteria

- [x] `GenerateTraces` accepts `[]SpanObserver` and invokes `Observe` per generated span, with the same `SpanInfo` that `Run`/replay produce.
- [x] Existing callers (no observers) unaffected — verified by current tests.
- [x] Unit coverage asserting the passed observer receives one `SpanInfo` per span, with correct parent attribution for a cross-service call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkpjwCpESs4enw8pSUXXNg)_