### PR TITLE
Add filtering and routing invariant checks for collector pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Filtering and routing invariants for collector pipeline testing.
+  `pkg/pipelinetest` gains `CheckFilterCorrectness` (a filter's output is
+  exactly the caller's keep/drop partition of the sent spans),
+  `CheckRoutingConsistency` (no trace split across backends),
+  `CheckRouteCompleteness` (no span falls through the routing rules), and
+  `ParseSpanKey`. Multi-backend pipelines are driven by the new `StartMulti`,
+  which exposes each sink to the config template as `{{index .SinkURLs N}}`
+  (`Start` and `{{.SinkURL}}` are unchanged). Property tests in
+  `pkg/synth/pipeline_filter_test.go` and `pkg/synth/pipeline_routing_test.go`
+  assert the invariants against a real collector — skipping per-component on
+  builds without `filter`/`routing` — and demonstrate the misconfigurations
+  they catch: per-span routing splitting traces, and a defaultless routing
+  table silently discarding unmatched spans. See
+  `docs/how-to/test-filtering-routing.md`. (#75)
 - `GenerateTraces` now forwards a `[]SpanObserver` (new `GenerateOptions.Observers`
   field) so embedders can receive motel's authoritative per-span `SpanInfo`
   (`ParentService`/`ParentOperation`, `IsError`, `Kind`, `Scenarios`, `Attrs`)

--- a/docs/how-to/test-filtering-routing.md
+++ b/docs/how-to/test-filtering-routing.md
@@ -1,0 +1,212 @@
+# Test Filtering and Routing
+
+This guide shows how to verify that filter and routing stages in an
+OpenTelemetry Collector pipeline do exactly what their rules say — no span
+silently dropped or leaked by a filter, no trace torn across backends, no
+telemetry falling through a routing table into the void. The checks run as Go
+property tests that drive motel-generated traces through a real collector
+binary, using the harness described in the
+[collector pipeline testing design](../research/collector-pipeline-testing.md).
+
+## The invariants
+
+Filter and routing bugs are combinatorial: they emerge from interactions
+between rules, attribute values, and trace shapes, so hand-picked test spans
+miss them. Three invariants pin the correct behaviour:
+
+- **Filter correctness.** The filter's output is exactly the spans its
+  predicate keeps — no false positives (a span dropped that shouldn't match)
+  and no false negatives (a matching span that leaks through).
+- **Routing consistency.** All spans of a trace arrive at the same backend.
+  Attribute-based routing must key on something constant across a trace (a
+  resource attribute), or each backend receives fragments no trace view or
+  tail-based tool can reassemble.
+- **Rule completeness.** Every span sent is delivered to some backend. A
+  routing table without a default silently discards whatever matches no rule.
+
+The invariants are exported from `pkg/pipelinetest` as
+`CheckFilterCorrectness`, `CheckRoutingConsistency`, and
+`CheckRouteCompleteness`, so any test — ours or yours — can assert them;
+`pkg/synth/pipeline_filter_test.go` and `pkg/synth/pipeline_routing_test.go`
+drive them against a real collector. For filter correctness the test computes
+the expected keep/drop partition itself: it knows every span it sent — with
+attributes — from the in-memory capture, so applying the filter's predicate
+client-side reduces the check to a set comparison. motel generates the traces,
+and [rapid](https://github.com/flyingmutant/rapid) shrinks any violation to the
+minimal topology that triggers it.
+
+## What you need
+
+- The motel repository (the checks are `go test` targets, not a CLI feature)
+- A collector build with the `filter` processor and `routing` connector, such
+  as `otelcol-contrib` (tests skip per-component when the binary lacks one —
+  the harness probes `components` output)
+
+## 1. Point the tests at a collector
+
+The harness resolves the collector binary from `MOTEL_COLLECTOR_BIN`, falling
+back to `otelcol` on `PATH`. Tests skip when neither is present.
+
+```sh
+export MOTEL_COLLECTOR_BIN=/path/to/otelcol-contrib
+```
+
+## 2. Run the invariant tests
+
+```sh
+go test ./pkg/synth/ -run 'TestFilter_|TestRouting_' -v
+```
+
+The suite contains:
+
+- **`TestFilter_ExactPartition`** — a fixed topology through a filter dropping
+  one service's spans; the output must be exactly the complement.
+- **`TestFilter_ErrorSpansProperty`** — filter correctness for 100
+  rapid-generated topologies under a status-based filter (drop error spans),
+  reusing one collector.
+- **`TestFilter_MidTreeDropBreaksLineage`** — the interaction bug the
+  structural invariants catch: a filter that is perfectly correct span by span
+  still orphans children when its predicate matches mid-tree spans.
+- **`TestRouting_WholeTracesPerBackend`** — two tenants' traffic through a
+  resource-attribute router: traces arrive whole, nothing falls through, each
+  backend receives exactly its tenant's spans.
+- **`TestRouting_ConsistencyProperty`** — the routing invariants for 100
+  rapid-generated topologies.
+- **`TestRouting_SplitByServiceDetected`** — routing on a per-span property
+  (the DIY pattern of parallel pipelines with complementary filters) tears
+  every multi-service trace apart; the consistency check must detect it.
+- **`TestRouting_FallthroughDetected`** — a routing table without
+  `default_pipelines` silently discards unmatched tenants; the completeness
+  check must detect it.
+
+## Example collector configs
+
+A correct filter stage — drop what the predicate matches, keep everything
+else (`pipelinetest.TracesConfig` wraps this into the shared
+receiver/exporter skeleton):
+
+```yaml
+processors:
+  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - status.code == STATUS_CODE_ERROR
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [filter]
+      exporters: [otlphttp]
+```
+
+A correct routing stage keys on a **resource** attribute, constant across each
+trace, with a default so nothing falls through. Multi-backend configs use
+`pipelinetest.StartMulti`, which exposes each sink positionally as
+`{{index .SinkURLs N}}`:
+
+```yaml
+connectors:
+  routing:
+    default_pipelines: [traces/primary]
+    table:
+      - context: resource
+        condition: attributes["tenant"] == "beta"
+        pipelines: [traces/secondary]
+
+service:
+  pipelines:
+    traces/in:
+      receivers: [otlp]
+      exporters: [routing]
+    traces/primary:
+      receivers: [routing]
+      exporters: [otlphttp/primary]
+    traces/secondary:
+      receivers: [routing]
+      exporters: [otlphttp/secondary]
+```
+
+Two misconfigurations the invariants exist to catch:
+
+- **Routing on a per-span property.** Parallel pipelines with complementary
+  filters (or a routing rule on a span attribute) send each service's spans to
+  a different backend — every cross-service trace is split. `CheckRoutingConsistency`
+  reports the first torn trace.
+- **A rule table with no default.** Omit `default_pipelines` and spans matching
+  no rule vanish without an error. `CheckRouteCompleteness` reports the first
+  span that fell through.
+
+## 3. Check your own filter or routing config
+
+The harness and checks compose directly — generate through an OTLP exporter at
+the collector, capture what was sent with a second in-memory exporter, and
+assert over the sinks (see
+[Test sampling trace integrity](test-sampling-integrity.md) for the full
+generation boilerplate):
+
+```go
+primary, secondary := pipelinetest.NewSink(), pipelinetest.NewSink()
+defer primary.Close()
+defer secondary.Close()
+
+collector, err := pipelinetest.StartMulti(myRoutingConfig, primary, secondary)
+if err != nil {
+	t.Fatal(err)
+}
+defer func() { _ = collector.Stop() }()
+
+// ... generate via synth.GenerateTraces, record identities in `sent`,
+// and build per-backend expectations from the captured spans ...
+
+backends := map[string][]*tracepb.Span{
+	"primary":   primary.WaitSettled(time.Second, 30*time.Second),
+	"secondary": secondary.WaitSettled(time.Second, 30*time.Second),
+}
+for _, check := range []error{
+	pipelinetest.CheckRoutingConsistency(backends),
+	pipelinetest.CheckRouteCompleteness(sent, backends),
+} {
+	if check != nil {
+		t.Fatal(check)
+	}
+}
+```
+
+For filter correctness, partition the captured spans with the same predicate
+your filter config encodes and compare:
+
+```go
+keep, drop := map[string]struct{}{}, map[string]struct{}{}
+for _, s := range captured.GetSpans() {
+	tid, sid := s.SpanContext.TraceID(), s.SpanContext.SpanID()
+	key := pipelinetest.SpanKey(tid[:], sid[:])
+	if s.Status.Code == codes.Error { // mirror the filter's OTTL condition
+		drop[key] = struct{}{}
+	} else {
+		keep[key] = struct{}{}
+	}
+}
+if err := pipelinetest.CheckFilterCorrectness(keep, drop, sink.WaitSettled(time.Second, 30*time.Second)); err != nil {
+	t.Fatal(err)
+}
+```
+
+One detail matters when adapting this: a filter or router with no default is
+lossy, so there is no exact span count to wait for — use `Sink.WaitSettled`
+(the bounded "eventually received" assertion), not `Sink.WaitFor`. When the
+expected per-backend counts *are* known (a lossless router), `WaitFor` the
+counts first and settle briefly afterwards so a misrouted straggler cannot
+arrive after the assertion.
+
+## Further reading
+
+- [Collector pipeline testing design](../research/collector-pipeline-testing.md)
+  -- the harness architecture these checks build on
+- [Test sampling trace integrity](test-sampling-integrity.md) -- the sampling
+  invariants over the same harness, with the full generation boilerplate
+- [Test OTTL transforms](test-ottl-transforms.md) -- manually exploring what an
+  OTTL statement matches, useful for authoring filter conditions
+- [Property testing in motel](../explanation/property-testing.md) -- rationale
+  and patterns for the rapid-based test suite

--- a/docs/research/collector-pipeline-testing.md
+++ b/docs/research/collector-pipeline-testing.md
@@ -186,9 +186,16 @@ tests and the harness can therefore live entirely outside `package synth`.
   "eventually received" assertion this needed is `Sink.WaitSettled` in the
   shared harness. See [Test sampling trace
   integrity](../how-to/test-sampling-integrity.md).
-- **Issue 75 (filtering and routing).** Needs a richer collector build (the
-  reference binary lacks a routing connector) and invariants over which spans
-  survive a filter and where routed spans land.
+- **Issue 75 (filtering and routing).** Implemented in
+  `pkg/synth/pipeline_filter_test.go` and `pkg/synth/pipeline_routing_test.go`:
+  filter correctness (the output is exactly the client-side partition of sent
+  spans by the filter's predicate), routing consistency (no trace split across
+  backends), and rule completeness (no span falls through the routing table),
+  plus violation tests showing each invariant catch its misconfiguration.
+  Multi-backend pipelines needed `StartMulti` in the shared harness, which
+  exposes several sinks to the config template as `{{index .SinkURLs N}}`;
+  tests skip per-component (`filter`, `routing`) on collector builds that lack
+  one. See [Test filtering and routing](../how-to/test-filtering-routing.md).
 - **Issue 76 (batching and ordering).** Invariants over batch boundaries and
   span ordering; the sink already records arrival order.
 - **Issue 77 (swarm over processor configs).** Generates collector configs as

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - docs/how-to/stress-test-collector.md
       - docs/how-to/test-tail-sampling.md
       - docs/how-to/test-sampling-integrity.md
+      - docs/how-to/test-filtering-routing.md
       - docs/how-to/test-ottl-transforms.md
       - docs/how-to/test-alert-thresholds.md
       - docs/how-to/test-backend-integration.md

--- a/pkg/pipelinetest/collector.go
+++ b/pkg/pipelinetest/collector.go
@@ -199,8 +199,10 @@ func Start(sink *Sink, config string) (*Collector, error) {
 // StartMulti is Start for pipelines with more than one destination, such as a
 // routing pipeline that fans traces out to several backends. Each sink is one
 // backend; the config template addresses them positionally as
-// {{index .SinkURLs 0}}, {{index .SinkURLs 1}}, and so on. {{.SinkURL}}
-// remains an alias for the first sink, so single-sink configs work unchanged.
+// {{index .SinkURLs 0}}, {{index .SinkURLs 1}}, and so on. The full set of
+// template fields is OTLPHTTPPort, HealthPort, SinkURLs, and SinkURL, where
+// {{.SinkURL}} remains an alias for the first sink, so single-sink configs
+// work unchanged.
 func StartMulti(config string, sinks ...*Sink) (*Collector, error) {
 	bin, ok := CollectorBinary()
 	if !ok {

--- a/pkg/pipelinetest/collector.go
+++ b/pkg/pipelinetest/collector.go
@@ -171,6 +171,7 @@ type configParams struct {
 	OTLPHTTPPort int
 	HealthPort   int
 	SinkURL      string
+	SinkURLs     []string
 }
 
 // Collector is a running OpenTelemetry Collector subprocess.
@@ -192,9 +193,21 @@ type Collector struct {
 // The caller owns the returned Collector and must call Stop. If no collector
 // binary is available, Start returns ErrNoCollector.
 func Start(sink *Sink, config string) (*Collector, error) {
+	return StartMulti(config, sink)
+}
+
+// StartMulti is Start for pipelines with more than one destination, such as a
+// routing pipeline that fans traces out to several backends. Each sink is one
+// backend; the config template addresses them positionally as
+// {{index .SinkURLs 0}}, {{index .SinkURLs 1}}, and so on. {{.SinkURL}}
+// remains an alias for the first sink, so single-sink configs work unchanged.
+func StartMulti(config string, sinks ...*Sink) (*Collector, error) {
 	bin, ok := CollectorBinary()
 	if !ok {
 		return nil, ErrNoCollector
+	}
+	if len(sinks) == 0 {
+		return nil, errors.New("no sinks provided")
 	}
 	if config == "" {
 		config = TracesConfig("")
@@ -209,10 +222,15 @@ func Start(sink *Sink, config string) (*Collector, error) {
 		return nil, fmt.Errorf("allocate health port: %w", err)
 	}
 
+	urls := make([]string, len(sinks))
+	for i, s := range sinks {
+		urls[i] = s.URL()
+	}
 	rendered, err := renderConfig(config, configParams{
 		OTLPHTTPPort: otlpPort,
 		HealthPort:   healthPort,
-		SinkURL:      sink.URL(),
+		SinkURL:      urls[0],
+		SinkURLs:     urls,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/pipelinetest/invariants.go
+++ b/pkg/pipelinetest/invariants.go
@@ -3,6 +3,7 @@ package pipelinetest
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
@@ -12,6 +13,22 @@ import (
 // Sink received, so invariant checks can compare the two sets.
 func SpanKey(traceID, spanID []byte) string {
 	return hex.EncodeToString(traceID) + ":" + hex.EncodeToString(spanID)
+}
+
+// ParseSpanKey decodes a SpanKey back into its raw trace and span ID bytes,
+// so identities that were reduced to keys can still be recorded via Sent.Add.
+func ParseSpanKey(key string) (traceID, spanID []byte, err error) {
+	tid, sid, ok := strings.Cut(key, ":")
+	if !ok {
+		return nil, nil, fmt.Errorf("span key %q has no separator", key)
+	}
+	if traceID, err = hex.DecodeString(tid); err != nil {
+		return nil, nil, fmt.Errorf("span key %q: %w", key, err)
+	}
+	if spanID, err = hex.DecodeString(sid); err != nil {
+		return nil, nil, fmt.Errorf("span key %q: %w", key, err)
+	}
+	return traceID, spanID, nil
 }
 
 // Sent records the span identities a test pushed into a pipeline, grouped so
@@ -127,6 +144,78 @@ func CheckConservation(sent *Sent, received []*tracepb.Span) error {
 	for key := range sent.keys {
 		if _, ok := got[key]; !ok {
 			return fmt.Errorf("span %s sent but not received", key)
+		}
+	}
+	return nil
+}
+
+// CheckFilterCorrectness verifies a filter's keep/drop decisions against the
+// caller's own partition of the sent spans: keep holds the identities the
+// filter must pass through, drop the identities it must remove. It reports a
+// false negative (a received span in drop), a false positive (a keep span
+// missing from received), or a fabrication (a received span in neither set).
+// This is the filter correctness invariant.
+//
+// The caller computes the partition by applying the filter's predicate to the
+// spans it sent — it knows every span's attributes client-side — so the check
+// stays a pure set comparison and works for any predicate.
+func CheckFilterCorrectness(keep, drop map[string]struct{}, received []*tracepb.Span) error {
+	got := ReceivedKeys(received)
+	for key := range got {
+		if _, ok := drop[key]; ok {
+			return fmt.Errorf("span %s was kept but matches the drop predicate", key)
+		}
+		if _, ok := keep[key]; !ok {
+			return fmt.Errorf("received span %s that was never sent", key)
+		}
+	}
+	for key := range keep {
+		if _, ok := got[key]; !ok {
+			return fmt.Errorf("span %s was dropped but does not match the drop predicate", key)
+		}
+	}
+	return nil
+}
+
+// CheckRoutingConsistency reports a trace split across backends: a trace ID
+// with spans at more than one destination. backends maps a backend name (used
+// only in the error message) to the spans that backend received. This is the
+// routing consistency invariant — attribute-based routing must not tear traces
+// apart, or each backend sees a fragment no tail-based tool can reassemble.
+func CheckRoutingConsistency(backends map[string][]*tracepb.Span) error {
+	seen := make(map[string]string) // trace ID -> backend that received it
+	for name, spans := range backends {
+		for _, s := range spans {
+			tid := hex.EncodeToString(s.GetTraceId())
+			if prev, ok := seen[tid]; ok && prev != name {
+				return fmt.Errorf("trace %s split across backends %q and %q", tid, prev, name)
+			}
+			seen[tid] = name
+		}
+	}
+	return nil
+}
+
+// CheckRouteCompleteness reports a span that fell through the routing rules:
+// a sent span that no backend received, silently discarded by a rule set that
+// does not cover it. It also reports a fabricated span (received by some
+// backend but never sent). This is the rule completeness invariant. A span
+// delivered to several backends is not a violation — fan-out duplication is a
+// routing policy choice, not a loss.
+func CheckRouteCompleteness(sent *Sent, backends map[string][]*tracepb.Span) error {
+	routed := make(map[string]struct{})
+	for name, spans := range backends {
+		for _, s := range spans {
+			key := SpanKey(s.GetTraceId(), s.GetSpanId())
+			if !sent.Has(key) {
+				return fmt.Errorf("backend %q received span %s that was never sent", name, key)
+			}
+			routed[key] = struct{}{}
+		}
+	}
+	for key := range sent.keys {
+		if _, ok := routed[key]; !ok {
+			return fmt.Errorf("span %s fell through the routing rules: sent but received by no backend", key)
 		}
 	}
 	return nil

--- a/pkg/pipelinetest/invariants.go
+++ b/pkg/pipelinetest/invariants.go
@@ -17,6 +17,9 @@ func SpanKey(traceID, spanID []byte) string {
 
 // ParseSpanKey decodes a SpanKey back into its raw trace and span ID bytes,
 // so identities that were reduced to keys can still be recorded via Sent.Add.
+// It enforces the OTLP ID sizes — a 16-byte trace ID and an 8-byte span ID —
+// so a malformed key fails here rather than surfacing later as an identity
+// that matches nothing.
 func ParseSpanKey(key string) (traceID, spanID []byte, err error) {
 	tid, sid, ok := strings.Cut(key, ":")
 	if !ok {
@@ -25,8 +28,14 @@ func ParseSpanKey(key string) (traceID, spanID []byte, err error) {
 	if traceID, err = hex.DecodeString(tid); err != nil {
 		return nil, nil, fmt.Errorf("span key %q: %w", key, err)
 	}
+	if len(traceID) != 16 {
+		return nil, nil, fmt.Errorf("span key %q: trace ID is %d bytes, want 16", key, len(traceID))
+	}
 	if spanID, err = hex.DecodeString(sid); err != nil {
 		return nil, nil, fmt.Errorf("span key %q: %w", key, err)
+	}
+	if len(spanID) != 8 {
+		return nil, nil, fmt.Errorf("span key %q: span ID is %d bytes, want 8", key, len(spanID))
 	}
 	return traceID, spanID, nil
 }

--- a/pkg/pipelinetest/invariants_test.go
+++ b/pkg/pipelinetest/invariants_test.go
@@ -90,7 +90,9 @@ func TestParseSpanKey(t *testing.T) {
 	if string(gotTid) != string(tid) || string(gotSid) != string(sid) {
 		t.Fatal("ParseSpanKey round-trip changed the IDs")
 	}
-	for _, bad := range []string{"nocolon", "zz:00", "00:zz"} {
+	short := SpanKey(spanID(1), spanID(1)) // 8-byte trace ID
+	long := SpanKey(tid, tid)              // 16-byte span ID
+	for _, bad := range []string{"nocolon", "zz:00", "00:zz", ":", SpanKey(nil, sid), SpanKey(tid, nil), short, long} {
 		if _, _, err := ParseSpanKey(bad); err == nil {
 			t.Fatalf("ParseSpanKey accepted malformed key %q", bad)
 		}

--- a/pkg/pipelinetest/invariants_test.go
+++ b/pkg/pipelinetest/invariants_test.go
@@ -81,6 +81,100 @@ func TestCheckNoFabrication(t *testing.T) {
 	}
 }
 
+func TestParseSpanKey(t *testing.T) {
+	tid, sid := traceID(7), spanID(9)
+	gotTid, gotSid, err := ParseSpanKey(SpanKey(tid, sid))
+	if err != nil {
+		t.Fatalf("ParseSpanKey round-trip failed: %v", err)
+	}
+	if string(gotTid) != string(tid) || string(gotSid) != string(sid) {
+		t.Fatal("ParseSpanKey round-trip changed the IDs")
+	}
+	for _, bad := range []string{"nocolon", "zz:00", "00:zz"} {
+		if _, _, err := ParseSpanKey(bad); err == nil {
+			t.Fatalf("ParseSpanKey accepted malformed key %q", bad)
+		}
+	}
+}
+
+func TestCheckFilterCorrectness(t *testing.T) {
+	tid := traceID(1)
+	keep := map[string]struct{}{SpanKey(tid, spanID(1)): {}}
+	drop := map[string]struct{}{SpanKey(tid, spanID(2)): {}}
+
+	if err := CheckFilterCorrectness(keep, drop, []*tracepb.Span{span(tid, 1, 0)}); err != nil {
+		t.Fatalf("CheckFilterCorrectness rejected a correct partition: %v", err)
+	}
+	if err := CheckFilterCorrectness(keep, drop, []*tracepb.Span{span(tid, 1, 0), span(tid, 2, 1)}); err == nil {
+		t.Fatal("CheckFilterCorrectness accepted a span that matches the drop predicate")
+	}
+	if err := CheckFilterCorrectness(keep, drop, nil); err == nil {
+		t.Fatal("CheckFilterCorrectness accepted the drop of a span it should keep")
+	}
+	if err := CheckFilterCorrectness(keep, drop, []*tracepb.Span{span(tid, 1, 0), span(tid, 3, 0)}); err == nil {
+		t.Fatal("CheckFilterCorrectness accepted a fabricated span")
+	}
+}
+
+func TestCheckRoutingConsistency(t *testing.T) {
+	tidA, tidB := traceID(1), traceID(2)
+
+	whole := map[string][]*tracepb.Span{
+		"primary":   {span(tidA, 1, 0), span(tidA, 2, 1)},
+		"secondary": {span(tidB, 1, 0)},
+	}
+	if err := CheckRoutingConsistency(whole); err != nil {
+		t.Fatalf("CheckRoutingConsistency rejected whole-trace routing: %v", err)
+	}
+
+	split := map[string][]*tracepb.Span{
+		"primary":   {span(tidA, 1, 0)},
+		"secondary": {span(tidA, 2, 1)},
+	}
+	if err := CheckRoutingConsistency(split); err == nil {
+		t.Fatal("CheckRoutingConsistency accepted a trace split across backends")
+	}
+}
+
+func TestCheckRouteCompleteness(t *testing.T) {
+	tid := traceID(1)
+	sent := NewSent()
+	sent.Add(tid, spanID(1))
+	sent.Add(tid, spanID(2))
+
+	complete := map[string][]*tracepb.Span{
+		"primary":   {span(tid, 1, 0)},
+		"secondary": {span(tid, 2, 1)},
+	}
+	if err := CheckRouteCompleteness(sent, complete); err != nil {
+		t.Fatalf("CheckRouteCompleteness rejected full coverage: %v", err)
+	}
+
+	// Fan-out duplication is a policy choice, not a loss.
+	duplicated := map[string][]*tracepb.Span{
+		"primary":   {span(tid, 1, 0), span(tid, 2, 1)},
+		"secondary": {span(tid, 2, 1)},
+	}
+	if err := CheckRouteCompleteness(sent, duplicated); err != nil {
+		t.Fatalf("CheckRouteCompleteness rejected fan-out duplication: %v", err)
+	}
+
+	fallthru := map[string][]*tracepb.Span{
+		"primary": {span(tid, 1, 0)},
+	}
+	if err := CheckRouteCompleteness(sent, fallthru); err == nil {
+		t.Fatal("CheckRouteCompleteness accepted a span that fell through the rules")
+	}
+
+	fabricated := map[string][]*tracepb.Span{
+		"primary":   {span(tid, 1, 0), span(tid, 2, 1)},
+		"secondary": {span(tid, 3, 0)},
+	}
+	if err := CheckRouteCompleteness(sent, fabricated); err == nil {
+		t.Fatal("CheckRouteCompleteness accepted a fabricated span")
+	}
+}
+
 func TestCheckConservation(t *testing.T) {
 	tid := traceID(1)
 	root := span(tid, 1, 0)

--- a/pkg/synth/pipeline_filter_test.go
+++ b/pkg/synth/pipeline_filter_test.go
@@ -1,0 +1,173 @@
+package synth
+
+import (
+	"testing"
+
+	"github.com/andrewh/motel/pkg/pipelinetest"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"pgregory.net/rapid"
+)
+
+// Filtering invariants (issue 75). A filter processor decides span by span
+// whether telemetry survives the pipeline; these tests assert its decisions
+// are exactly the configured predicate — no span it should drop leaks
+// through, no span it should keep disappears — using
+// pipelinetest.CheckFilterCorrectness. The test computes the expected
+// keep/drop partition client-side by applying the same predicate to the spans
+// it captured on the way out, so the check is a pure set comparison.
+//
+// Like the other pipeline tests, they drive a real collector subprocess and
+// skip when no binary is available. They additionally skip when the binary
+// lacks the filter processor (a contrib component absent from minimal builds).
+
+// leafFilterPipeline drops db spans — the leaves of passthroughTopology — so
+// removing them leaves the remaining lineage intact.
+var leafFilterPipeline = pipelinetest.TracesConfig(`  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - instrumentation_scope.name == "db"
+`, "filter")
+
+// midTreeFilterPipeline drops backend spans, which sit between gateway and db
+// in every trace, so every surviving db span is orphaned.
+var midTreeFilterPipeline = pipelinetest.TracesConfig(`  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - instrumentation_scope.name == "backend"
+`, "filter")
+
+// errorFilterPipeline drops error spans regardless of topology shape.
+var errorFilterPipeline = pipelinetest.TracesConfig(`  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - status.code == STATUS_CODE_ERROR
+`, "filter")
+
+// TestFilter_ExactPartition drives a fixed topology through a filter that
+// drops db spans and asserts the output is exactly the non-db spans: filter
+// correctness with no false positives or negatives.
+func TestFilter_ExactPartition(t *testing.T) {
+	requireFilter(t)
+	sink, collector := startPipeline(t, leafFilterPipeline)
+
+	topo := loadTopology(t, passthroughTopology)
+	stubs := generateAndCapture(t, topo, collector.OTLPEndpoint, 20, 3, nil)
+	keep, drop := partitionStubs(stubs, func(s tracetest.SpanStub) bool {
+		return s.InstrumentationScope.Name == "db"
+	})
+	if len(drop) == 0 {
+		t.Fatal("premise broken: topology generated no db spans")
+	}
+	spans := sink.WaitSettled(samplerSettleIdle, settleMax)
+
+	if err := pipelinetest.CheckFilterCorrectness(keep, drop, spans); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestFilter_ErrorSpansProperty asserts filter correctness for any generated
+// topology: whatever the trace shape and error mix, a status-based filter
+// keeps exactly the non-error spans. One collector is reused across all
+// draws, with the expected partition accumulating rather than resetting the
+// sink between draws (see TestPipeline_AllSpansRoundTripProperty for why a
+// reset races an in-flight export).
+func TestFilter_ErrorSpansProperty(t *testing.T) {
+	requireFilter(t)
+	sink, collector := startPipeline(t, errorFilterPipeline)
+
+	keep := make(map[string]struct{})
+	drop := make(map[string]struct{})
+
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := genSimpleConfig(t)
+		topo, err := BuildTopology(cfg)
+		if err != nil {
+			t.Fatalf("BuildTopology: %v", err)
+		}
+		if len(topo.Roots) == 0 {
+			t.Skip("no root operations")
+		}
+
+		seed := rapid.Uint64().Draw(t, "seed")
+		stubs := generateAndCapture(t, topo, collector.OTLPEndpoint, 5, seed, nil)
+		if len(stubs) == 0 {
+			t.Skip("no spans generated")
+		}
+		k, d := partitionStubs(stubs, func(s tracetest.SpanStub) bool {
+			return s.Status.Code == codes.Error
+		})
+		merge(keep, k)
+		merge(drop, d)
+		spans := sink.WaitSettled(propertySettleIdle, settleMax)
+
+		if err := pipelinetest.CheckFilterCorrectness(keep, drop, spans); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+// TestFilter_MidTreeDropBreaksLineage demonstrates the interaction bug the
+// structural invariants exist to catch: a filter that is perfectly correct
+// span by span still breaks traces when its predicate matches mid-tree spans.
+// Dropping backend spans orphans every db span, so filter correctness holds
+// while parent-child preservation fails — and a tail sampler or trace-level
+// tool downstream would see broken lineage.
+func TestFilter_MidTreeDropBreaksLineage(t *testing.T) {
+	requireFilter(t)
+	sink, collector := startPipeline(t, midTreeFilterPipeline)
+
+	topo := loadTopology(t, passthroughTopology)
+	stubs := generateAndCapture(t, topo, collector.OTLPEndpoint, 20, 3, nil)
+	keep, drop := partitionStubs(stubs, func(s tracetest.SpanStub) bool {
+		return s.InstrumentationScope.Name == "backend"
+	})
+	if len(drop) == 0 {
+		t.Fatal("premise broken: topology generated no backend spans")
+	}
+	spans := sink.WaitSettled(samplerSettleIdle, settleMax)
+
+	if err := pipelinetest.CheckFilterCorrectness(keep, drop, spans); err != nil {
+		t.Fatalf("filter applied its predicate incorrectly: %v", err)
+	}
+	if err := pipelinetest.CheckParentsKept(spans); err == nil {
+		t.Fatal("expected orphaned spans after dropping mid-tree spans, but lineage was intact")
+	}
+}
+
+// requireFilter skips the test when the collector build lacks the filter
+// processor.
+func requireFilter(t *testing.T) {
+	t.Helper()
+	if !pipelinetest.SupportsComponent("filter") {
+		t.Skip("no collector with the filter processor (set MOTEL_COLLECTOR_BIN to a build that includes it)")
+	}
+}
+
+// partitionStubs splits captured spans into keep/drop identity sets by the
+// drop predicate — the client-side mirror of a filter's configuration.
+func partitionStubs(stubs []tracetest.SpanStub, dropPred func(tracetest.SpanStub) bool) (keep, drop map[string]struct{}) {
+	keep = make(map[string]struct{})
+	drop = make(map[string]struct{})
+	for _, s := range stubs {
+		tid := s.SpanContext.TraceID()
+		sid := s.SpanContext.SpanID()
+		key := pipelinetest.SpanKey(tid[:], sid[:])
+		if dropPred(s) {
+			drop[key] = struct{}{}
+		} else {
+			keep[key] = struct{}{}
+		}
+	}
+	return keep, drop
+}
+
+// merge adds every key of src to dst.
+func merge(dst, src map[string]struct{}) {
+	for k := range src {
+		dst[k] = struct{}{}
+	}
+}

--- a/pkg/synth/pipeline_routing_test.go
+++ b/pkg/synth/pipeline_routing_test.go
@@ -1,0 +1,397 @@
+package synth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/andrewh/motel/pkg/pipelinetest"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"pgregory.net/rapid"
+)
+
+// Routing invariants (issue 75). A routing stage directs telemetry to one of
+// several backends based on attributes; these tests assert the two properties
+// a routing configuration must not violate, using the checks in
+// pkg/pipelinetest:
+//
+//   - Routing consistency: all spans of a trace arrive at the same backend —
+//     CheckRoutingConsistency.
+//   - Rule completeness: every sent span is delivered to some backend, none
+//     fall through the rules into silent discard — CheckRouteCompleteness.
+//
+// The correct configuration routes on a resource attribute ("tenant"), which
+// is constant across a trace, so traces move whole. The violation tests then
+// show each invariant catching a realistic misconfiguration: routing on a
+// per-span attribute (splits traces) and a rule table with no default
+// (drops unmatched spans).
+//
+// Like the other pipeline tests, they drive a real collector subprocess and
+// skip when no binary is available or it lacks the routing connector / filter
+// processor.
+
+// tenantRoutedPipeline routes resource attribute tenant=beta to the second
+// sink and everything else to the first, via the routing connector.
+const tenantRoutedPipeline = `receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 127.0.0.1:{{.OTLPHTTPPort}}
+connectors:
+  routing:
+    default_pipelines: [traces/primary]
+    table:
+      - context: resource
+        condition: attributes["tenant"] == "beta"
+        pipelines: [traces/secondary]
+exporters:
+  otlphttp/primary:
+    endpoint: {{index .SinkURLs 0}}
+    compression: none
+  otlphttp/secondary:
+    endpoint: {{index .SinkURLs 1}}
+    compression: none
+extensions:
+  health_check:
+    endpoint: 127.0.0.1:{{.HealthPort}}
+service:
+  extensions: [health_check]
+  pipelines:
+    traces/in:
+      receivers: [otlp]
+      exporters: [routing]
+    traces/primary:
+      receivers: [routing]
+      exporters: [otlphttp/primary]
+    traces/secondary:
+      receivers: [routing]
+      exporters: [otlphttp/secondary]
+  telemetry:
+    metrics:
+      level: none
+    logs:
+      level: warn
+`
+
+// noDefaultRoutedPipeline is tenantRoutedPipeline without default_pipelines:
+// spans that match no rule are silently discarded. This is the rule
+// completeness violation.
+const noDefaultRoutedPipeline = `receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 127.0.0.1:{{.OTLPHTTPPort}}
+connectors:
+  routing:
+    table:
+      - context: resource
+        condition: attributes["tenant"] == "beta"
+        pipelines: [traces/secondary]
+exporters:
+  otlphttp/primary:
+    endpoint: {{index .SinkURLs 0}}
+    compression: none
+  otlphttp/secondary:
+    endpoint: {{index .SinkURLs 1}}
+    compression: none
+extensions:
+  health_check:
+    endpoint: 127.0.0.1:{{.HealthPort}}
+service:
+  extensions: [health_check]
+  pipelines:
+    traces/in:
+      receivers: [otlp]
+      exporters: [routing]
+    traces/primary:
+      receivers: [routing]
+      exporters: [otlphttp/primary]
+    traces/secondary:
+      receivers: [routing]
+      exporters: [otlphttp/secondary]
+  telemetry:
+    metrics:
+      level: none
+    logs:
+      level: warn
+`
+
+// serviceSplitPipeline "routes" by a per-span property — the DIY routing
+// pattern of parallel pipelines with complementary filters. gateway spans go
+// to the first sink, everything else to the second, so every multi-service
+// trace is torn across backends. This is the routing consistency violation.
+const serviceSplitPipeline = `receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 127.0.0.1:{{.OTLPHTTPPort}}
+processors:
+  filter/only-gateway:
+    error_mode: ignore
+    traces:
+      span:
+        - instrumentation_scope.name != "gateway"
+  filter/all-but-gateway:
+    error_mode: ignore
+    traces:
+      span:
+        - instrumentation_scope.name == "gateway"
+exporters:
+  otlphttp/primary:
+    endpoint: {{index .SinkURLs 0}}
+    compression: none
+  otlphttp/secondary:
+    endpoint: {{index .SinkURLs 1}}
+    compression: none
+extensions:
+  health_check:
+    endpoint: 127.0.0.1:{{.HealthPort}}
+service:
+  extensions: [health_check]
+  pipelines:
+    traces/gateway:
+      receivers: [otlp]
+      processors: [filter/only-gateway]
+      exporters: [otlphttp/primary]
+    traces/rest:
+      receivers: [otlp]
+      processors: [filter/all-but-gateway]
+      exporters: [otlphttp/secondary]
+  telemetry:
+    metrics:
+      level: none
+    logs:
+      level: warn
+`
+
+// TestRouting_WholeTracesPerBackend drives two tenants' traffic through a
+// resource-attribute router and asserts the invariants plus exact
+// delivery: traces arrive whole, nothing falls through, and each backend
+// receives exactly its tenant's spans.
+func TestRouting_WholeTracesPerBackend(t *testing.T) {
+	requireRouting(t)
+	sinks, collector := startMultiPipeline(t, tenantRoutedPipeline, 2)
+
+	topo := loadTopology(t, passthroughTopology)
+	alpha := stubKeys(generateTenant(t, topo, collector.OTLPEndpoint, "alpha", 15, 3))
+	beta := stubKeys(generateTenant(t, topo, collector.OTLPEndpoint, "beta", 15, 4))
+
+	sent := pipelinetest.NewSent()
+	backends := settledBackends(sinks, len(alpha), len(beta))
+	for key := range alpha {
+		addKey(sent, key)
+	}
+	for key := range beta {
+		addKey(sent, key)
+	}
+
+	if err := pipelinetest.CheckRoutingConsistency(backends); err != nil {
+		t.Fatal(err)
+	}
+	if err := pipelinetest.CheckRouteCompleteness(sent, backends); err != nil {
+		t.Fatal(err)
+	}
+	// Exact delivery per backend: routing to a backend is a filter from that
+	// backend's point of view — keep my tenant's spans, drop the other's.
+	if err := pipelinetest.CheckFilterCorrectness(alpha, beta, backends["primary"]); err != nil {
+		t.Fatalf("primary backend: %v", err)
+	}
+	if err := pipelinetest.CheckFilterCorrectness(beta, alpha, backends["secondary"]); err != nil {
+		t.Fatalf("secondary backend: %v", err)
+	}
+}
+
+// TestRouting_ConsistencyProperty asserts the routing invariants for any
+// generated topology: whatever the trace shape, resource-attribute routing
+// must deliver every trace whole to exactly one backend. Each draw sends one
+// tenant's traffic; sent identities accumulate across draws as in the other
+// pipeline properties.
+func TestRouting_ConsistencyProperty(t *testing.T) {
+	requireRouting(t)
+	sinks, collector := startMultiPipeline(t, tenantRoutedPipeline, 2)
+
+	sent := pipelinetest.NewSent()
+	expected := map[string]map[string]struct{}{
+		"alpha": make(map[string]struct{}),
+		"beta":  make(map[string]struct{}),
+	}
+
+	rapid.Check(t, func(t *rapid.T) {
+		cfg := genSimpleConfig(t)
+		topo, err := BuildTopology(cfg)
+		if err != nil {
+			t.Fatalf("BuildTopology: %v", err)
+		}
+		if len(topo.Roots) == 0 {
+			t.Skip("no root operations")
+		}
+
+		tenant := rapid.SampledFrom([]string{"alpha", "beta"}).Draw(t, "tenant")
+		seed := rapid.Uint64().Draw(t, "seed")
+		keys := stubKeys(generateTenant(t, topo, collector.OTLPEndpoint, tenant, 5, seed))
+		if len(keys) == 0 {
+			t.Skip("no spans generated")
+		}
+		merge(expected[tenant], keys)
+		for key := range keys {
+			addKey(sent, key)
+		}
+		backends := settledBackends(sinks, len(expected["alpha"]), len(expected["beta"]))
+
+		if err := pipelinetest.CheckRoutingConsistency(backends); err != nil {
+			t.Fatal(err)
+		}
+		if err := pipelinetest.CheckRouteCompleteness(sent, backends); err != nil {
+			t.Fatal(err)
+		}
+		if err := pipelinetest.CheckFilterCorrectness(expected["alpha"], expected["beta"], backends["primary"]); err != nil {
+			t.Fatalf("primary backend: %v", err)
+		}
+		if err := pipelinetest.CheckFilterCorrectness(expected["beta"], expected["alpha"], backends["secondary"]); err != nil {
+			t.Fatalf("secondary backend: %v", err)
+		}
+	})
+}
+
+// TestRouting_SplitByServiceDetected demonstrates the routing consistency
+// invariant catching the misconfiguration it exists for: routing on a
+// per-span property tears every multi-service trace across backends, even
+// though no span is lost.
+func TestRouting_SplitByServiceDetected(t *testing.T) {
+	requireFilter(t)
+	sinks, collector := startMultiPipeline(t, serviceSplitPipeline, 2)
+
+	topo := loadTopology(t, passthroughTopology)
+	stubs := generateTenant(t, topo, collector.OTLPEndpoint, "alpha", 15, 3)
+	gateway, rest := partitionStubs(stubs, func(s tracetest.SpanStub) bool {
+		return s.InstrumentationScope.Name != "gateway"
+	})
+
+	sent := pipelinetest.NewSent()
+	for key := range gateway {
+		addKey(sent, key)
+	}
+	for key := range rest {
+		addKey(sent, key)
+	}
+	backends := settledBackends(sinks, len(gateway), len(rest))
+
+	if err := pipelinetest.CheckRouteCompleteness(sent, backends); err != nil {
+		t.Fatalf("per-span routing lost spans, expected only a split: %v", err)
+	}
+	if err := pipelinetest.CheckRoutingConsistency(backends); err == nil {
+		t.Fatal("expected per-span routing to split traces across backends, but every trace arrived whole")
+	}
+}
+
+// TestRouting_FallthroughDetected demonstrates the rule completeness
+// invariant catching a rule table with no default: traffic matching no rule
+// is silently discarded, while matched traffic still arrives whole.
+func TestRouting_FallthroughDetected(t *testing.T) {
+	requireRouting(t)
+	sinks, collector := startMultiPipeline(t, noDefaultRoutedPipeline, 2)
+
+	topo := loadTopology(t, passthroughTopology)
+	alpha := stubKeys(generateTenant(t, topo, collector.OTLPEndpoint, "alpha", 10, 3))
+	beta := stubKeys(generateTenant(t, topo, collector.OTLPEndpoint, "beta", 10, 4))
+
+	sent := pipelinetest.NewSent()
+	for key := range alpha {
+		addKey(sent, key)
+	}
+	for key := range beta {
+		addKey(sent, key)
+	}
+	backends := settledBackends(sinks, 0, len(beta))
+
+	if err := pipelinetest.CheckRoutingConsistency(backends); err != nil {
+		t.Fatal(err)
+	}
+	if err := pipelinetest.CheckFilterCorrectness(beta, alpha, backends["secondary"]); err != nil {
+		t.Fatalf("secondary backend: %v", err)
+	}
+	if err := pipelinetest.CheckRouteCompleteness(sent, backends); err == nil {
+		t.Fatal("expected unmatched tenant's spans to fall through the rules, but every span was delivered")
+	}
+}
+
+// requireRouting skips the test when the collector build lacks the routing
+// connector.
+func requireRouting(t *testing.T) {
+	t.Helper()
+	if !pipelinetest.SupportsComponent("routing") {
+		t.Skip("no collector with the routing connector (set MOTEL_COLLECTOR_BIN to a build that includes it)")
+	}
+}
+
+// startMultiPipeline starts n sinks and a collector fanning out to them,
+// registering cleanup. It skips the test when no collector binary is
+// available.
+func startMultiPipeline(t testing.TB, config string, n int) ([]*pipelinetest.Sink, *pipelinetest.Collector) {
+	t.Helper()
+	if _, ok := pipelinetest.CollectorBinary(); !ok {
+		t.Skipf("no collector binary (set %s or install otelcol)", pipelinetest.BinaryEnv)
+	}
+
+	sinks := make([]*pipelinetest.Sink, n)
+	for i := range sinks {
+		sinks[i] = pipelinetest.NewSink()
+		t.Cleanup(sinks[i].Close)
+	}
+
+	collector, err := pipelinetest.StartMulti(config, sinks...)
+	if errors.Is(err, pipelinetest.ErrNoCollector) {
+		t.Skip("collector binary disappeared")
+	}
+	if err != nil {
+		t.Fatalf("start collector: %v", err)
+	}
+	t.Cleanup(func() { _ = collector.Stop() })
+
+	return sinks, collector
+}
+
+// generateTenant emits n traces from topo whose resource carries the tenant
+// attribute the routing pipelines decide on, returning the captured stubs.
+func generateTenant(t testingT, topo *Topology, endpoint, tenant string, n int, seed uint64) []tracetest.SpanStub {
+	t.Helper()
+	res := resource.NewSchemaless(attribute.String("tenant", tenant))
+	return generateAndCapture(t, topo, endpoint, n, seed, nil, sdktrace.WithResource(res))
+}
+
+// settledBackends waits for each sink to hold its expected span count (zero
+// means no exact count is known), lets both settle so a misrouted straggler
+// cannot slip in after the assertion, and returns the received spans keyed by
+// backend name.
+func settledBackends(sinks []*pipelinetest.Sink, wantPrimary, wantSecondary int) map[string][]*tracepb.Span {
+	sinks[0].WaitFor(wantPrimary, settleMax)
+	sinks[1].WaitFor(wantSecondary, settleMax)
+	return map[string][]*tracepb.Span{
+		"primary":   sinks[0].WaitSettled(propertySettleIdle, settleMax),
+		"secondary": sinks[1].WaitSettled(propertySettleIdle, settleMax),
+	}
+}
+
+// stubKeys reduces captured stubs to their identity set.
+func stubKeys(stubs []tracetest.SpanStub) map[string]struct{} {
+	keys := make(map[string]struct{}, len(stubs))
+	for _, s := range stubs {
+		tid := s.SpanContext.TraceID()
+		sid := s.SpanContext.SpanID()
+		keys[pipelinetest.SpanKey(tid[:], sid[:])] = struct{}{}
+	}
+	return keys
+}
+
+// addKey records a SpanKey-encoded identity into sent. Sent.Add takes raw ID
+// bytes, so decode the hex key back into its parts.
+func addKey(sent *pipelinetest.Sent, key string) {
+	tid, sid, err := pipelinetest.ParseSpanKey(key)
+	if err != nil {
+		panic(err)
+	}
+	sent.Add(tid, sid)
+}

--- a/pkg/synth/pipeline_test.go
+++ b/pkg/synth/pipeline_test.go
@@ -180,8 +180,10 @@ func addSent(sent *pipelinetest.Sent, spans []tracetest.SpanStub) {
 // The spans come from a second in-memory exporter attached to the same
 // TracerProvider, so the test knows exactly what it pushed, including parent
 // relationships. A non-nil idGen overrides the SDK's random trace/span ID
-// generator, letting tests replay the exact same span identities.
-func generateAndCapture(t testingT, topo *Topology, endpoint string, n int, seed uint64, idGen sdktrace.IDGenerator) []tracetest.SpanStub {
+// generator, letting tests replay the exact same span identities. Extra
+// TracerProvider options (for example a resource carrying routing attributes)
+// are appended as given.
+func generateAndCapture(t testingT, topo *Topology, endpoint string, n int, seed uint64, idGen sdktrace.IDGenerator, tpOpts ...sdktrace.TracerProviderOption) []tracetest.SpanStub {
 	t.Helper()
 
 	ctx := context.Background()
@@ -200,6 +202,7 @@ func generateAndCapture(t testingT, topo *Topology, endpoint string, n int, seed
 	if idGen != nil {
 		opts = append(opts, sdktrace.WithIDGenerator(idGen))
 	}
+	opts = append(opts, tpOpts...)
 	tp := sdktrace.NewTracerProvider(opts...)
 	defer func() { _ = tp.Shutdown(ctx) }()
 


### PR DESCRIPTION
## Summary

Fixes #75.

This PR implements three invariants for testing filter and routing stages in OpenTelemetry Collector pipelines, addressing issue 75. The changes add property-based tests that drive real collector binaries with motel-generated traces to verify correct filtering and routing behavior.

## Key Changes

- **New invariant checks in `pkg/pipelinetest`:**
  - `CheckFilterCorrectness`: Verifies a filter's output matches the expected keep/drop partition with no false positives, false negatives, or fabrications
  - `CheckRoutingConsistency`: Ensures all spans of a trace arrive at the same backend (no trace splitting)
  - `CheckRouteCompleteness`: Confirms every sent span is delivered to some backend (no silent discards)
  - `ParseSpanKey`: Decodes span keys back to raw ID bytes for recording sent identities

- **Multi-backend pipeline support:**
  - New `StartMulti` function in `pkg/pipelinetest` for pipelines with multiple destinations
  - Config templates can address sinks positionally via `{{index .SinkURLs N}}`
  - `Start` now delegates to `StartMulti` for backward compatibility

- **Comprehensive test suites:**
  - `pkg/synth/pipeline_filter_test.go`: Tests filter correctness with fixed and property-based topologies, including detection of mid-tree drop lineage breaks
  - `pkg/synth/pipeline_routing_test.go`: Tests routing consistency and completeness with resource-attribute routing, plus detection of misconfiguration patterns (per-span routing splits, missing defaults)

- **Documentation:**
  - New guide `docs/how-to/test-filtering-routing.md` explaining the invariants, test patterns, and example configurations
  - Updated research documentation to reflect implementation of issue 75

## Implementation Details

- Tests use `rapid` for property-based generation of trace topologies and attributes
- Filter correctness is verified by client-side partition computation (the test applies the same predicate to captured spans)
- Routing tests demonstrate both correct configurations and realistic misconfigurations that the invariants catch
- Tests skip gracefully when collector binary is unavailable or lacks required components (filter processor, routing connector)
- Multi-sink coordination uses `WaitFor` for known counts and `WaitSettled` for lossy configurations

https://claude.ai/code/session_01XnDyhpm8xSkr26ugPg4276